### PR TITLE
feat: Identify process in JavaScript and native crashes

### DIFF
--- a/src/lib/electron.ts
+++ b/src/lib/electron.ts
@@ -167,6 +167,7 @@ export class SentryElectron implements Adapter {
 
       app.on('web-contents-created', (e, contents) => {
         // setImmediate is required for contents.id to be correct
+        // https://github.com/electron/electron/issues/12036
         setImmediate(() => {
           this.breadcrumbsFromEvents(`WebContents[${contents.id}]`, contents, [
             'dom-ready',

--- a/src/lib/electron.ts
+++ b/src/lib/electron.ts
@@ -358,7 +358,7 @@ export class SentryElectron implements Adapter {
   }
 
   /** Loads new native crashes from disk and sends them to Sentry. */
-  private async sendNativeCrashes(processId: string = 'browser'): Promise<void> {
+  private async sendNativeCrashes(processType: string = 'browser'): Promise<void> {
     // Whenever we are called, assume that the crashes we are going to load down
     // below have occurred recently. This means, we can use the same event data
     // for all minidumps that we load now. There are two conditions:
@@ -375,7 +375,7 @@ export class SentryElectron implements Adapter {
     const event = {
       user: context.user,
       tags: context.tags,
-      extra: { crashed_process: processId, ...context.extra },
+      extra: { crashed_process: processType, ...context.extra },
       release: this.options.release,
       environment: this.options.environment,
       sdk: { name: SDK_NAME, version: SDK_VERSION },

--- a/src/lib/electron.ts
+++ b/src/lib/electron.ts
@@ -235,7 +235,7 @@ export class SentryElectron implements Adapter {
   public async send(event: SentryEvent): Promise<void> {
     if (this.isRenderProcess()) {
       const id = remote.getCurrentWebContents().id;
-      event.tags = { ...event.tags, process: `renderer[${id}]` };
+      event.extra = { ...event.extra, crashed_process: `renderer[${id}]` };
       ipcRenderer.send(IPC_EVENT, event);
       return;
     }
@@ -244,8 +244,8 @@ export class SentryElectron implements Adapter {
     const mergedEvent = {
       ...event,
       user: { ...context.user, ...event.user },
-      tags: { process: 'browser', ...context.tags, ...event.tags },
-      extra: { ...context.extra, ...event.extra },
+      tags: { ...context.tags, ...event.tags },
+      extra: { crashed_process: 'browser', ...context.extra, ...event.extra },
       sdk: { name: SDK_NAME, version: SDK_VERSION },
       breadcrumbs: this.breadcrumbs.get(),
     };
@@ -373,8 +373,8 @@ export class SentryElectron implements Adapter {
     const context = this.getEnrichedContext();
     const event = {
       user: context.user,
-      tags: { process: processId, ...context.tags },
-      extra: context.extra,
+      tags: context.tags,
+      extra: { crashed_process: processId, ...context.extra },
       release: this.options.release,
       environment: this.options.environment,
       sdk: { name: SDK_NAME, version: SDK_VERSION },


### PR DESCRIPTION
Fixes #13 and also tracks multiple renderer processes.

`extra.crashed_process` = `browser` | `renderer[${webContents.id}]`