### PR TITLE
build: Run build as preexample step

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist",
+    "preexample": "if [ ! -d \"dist\" ]; then npm run build; fi;",
     "example": "electron example",
     "lint": "tslint --config ./tslint.json src/**/*",
     "format": "prettier --config /.prettierrc.json src/**/* --write"


### PR DESCRIPTION
Just so no one else gets hideous `Error: Cannot find module '..'` error anymore.