### PR TITLE
fix: Many improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ matrix:
         - yarn lint
     - env: NAME="test"
       script:
-        - yarn test
+        - yarn test && yarn e2e

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,5 @@ matrix:
         - yarn lint
     - env: NAME="test"
       script:
-        - yarn test && yarn e2e
+        - yarn test
+        - yarn e2e

--- a/example/main.js
+++ b/example/main.js
@@ -1,11 +1,16 @@
+const { app, BrowserWindow, ipcMain } = require('electron');
+const path = require('path');
+const url = require('url');
+
+// If we're running e2e tests, use the supplied temp userData directory
+if (process.env['E2E_USERDATA_DIRECTORY']) {
+  app.setPath('userData', process.env['E2E_USERDATA_DIRECTORY']);
+}
+
 // Activate the Sentry Electron SDK as early as possible in every process.
 // To support errors in renderer processes on Linux and Windows, make sure
 // to include this line in those files as well.
 require('./sentry');
-
-const { app, BrowserWindow, ipcMain } = require('electron');
-const path = require('path');
-const url = require('url');
 
 app.on('ready', () => {
   const window = new BrowserWindow({

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "tslint --config ./tslint.json src/**/*",
     "format": "prettier --config /.prettierrc.json src/**/* --write",
     "pretest": "run-s clean build build:test",
-    "test": "xvfb-maybe mocha --timeout 30000 ./dist/test"
+    "test": "xvfb-maybe electron-mocha --timeout 30000 ./dist/test"
   },
   "dependencies": {
     "@sentry/browser": "0.4.0-beta.2",
@@ -37,6 +37,7 @@
     "chai-as-promised": "^7.1.1",
     "electron": "^1.7.9",
     "electron-chromedriver": "^1.8.0",
+    "electron-mocha": "^5.0.0",
     "mocha": "^5.0.1",
     "npm-run-all": "^4.1.2",
     "prettier": "^1.10.2",

--- a/package.json
+++ b/package.json
@@ -9,14 +9,13 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "build:test": "tsc -p tsconfig.test.json",
     "clean": "rimraf dist",
     "preexample": "if [ ! -d \"dist\" ]; then npm run build; fi;",
     "example": "electron example",
     "lint": "tslint --config ./tslint.json src/**/*",
     "format": "prettier --config /.prettierrc.json src/**/* --write",
-    "pretest": "run-s clean build build:test",
-    "test": "xvfb-maybe electron-mocha --timeout 30000 ./dist/test"
+    "test": "cross-env TS_NODE_PROJECT=./tsconfig.test.json xvfb-maybe electron-mocha --require ts-node/register --timeout 3000 ./test/unit/**/*.ts",
+    "e2e": "cross-env TS_NODE_PROJECT=./tsconfig.test.json xvfb-maybe mocha --require ts-node/register --timeout 30000 ./test/e2e/**/*.ts"
   },
   "dependencies": {
     "@sentry/browser": "0.4.0-beta.2",
@@ -35,14 +34,15 @@
     "@types/webdriverio": "^4.8.8",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
+    "cross-env": "^5.1.3",
     "electron": "^1.7.9",
-    "electron-chromedriver": "^1.8.0",
     "electron-mocha": "^5.0.0",
     "mocha": "^5.0.1",
     "npm-run-all": "^4.1.2",
     "prettier": "^1.10.2",
     "rimraf": "^2.6.2",
     "spectron": "^3.8.0",
+    "ts-node": "^5.0.0",
     "tslint": "^5.9.1",
     "tslint-config-prettier": "^1.8.0",
     "tslint-eslint-rules": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "example": "electron example",
     "lint": "tslint --config ./tslint.json src/**/*",
     "format": "prettier --config /.prettierrc.json src/**/* --write",
+    "pretest": "run-s clean build",
     "test": "cross-env TS_NODE_PROJECT=./tsconfig.test.json xvfb-maybe electron-mocha --require ts-node/register --timeout 3000 ./test/unit/**/*.ts",
+    "pree2e": "run-s clean build",
     "e2e": "cross-env TS_NODE_PROJECT=./tsconfig.test.json xvfb-maybe mocha --require ts-node/register --timeout 30000 ./test/e2e/**/*.ts"
   },
   "dependencies": {

--- a/src/lib/electron.ts
+++ b/src/lib/electron.ts
@@ -64,8 +64,8 @@ const APP_BASE_PATH = (app || remote.app).getAppPath().replace(/\\/g, '/');
  */
 export interface SentryElectronOptions
   extends Options,
-    SentryBrowserOptions,
-    SentryNodeOptions {
+  SentryBrowserOptions,
+  SentryNodeOptions {
   /**
    * Enables crash reporting for native crashes of this process (via Minidumps).
    * Defaults to `true`.
@@ -109,6 +109,15 @@ export interface SentryElectronOptions
  * @see Sentry.Client
  */
 export class SentryElectron implements Adapter {
+
+  /**
+   * Normalizes URLs in exceptions and stacktraces so Sentry can fingerprint
+   * across platforms
+   *
+   * @param {string} url The URL to be normalized
+   * @param {string} [base=APP_BASE_PATH] (optional) The application base path
+   * @returns
+   */
   private static normalizeUrl(url: string, base: string = APP_BASE_PATH) {
     return decodeURI(url)
       .replace(/\\/g, '/')
@@ -132,7 +141,7 @@ export class SentryElectron implements Adapter {
   constructor(
     private client: Client,
     public options: SentryElectronOptions = {},
-  ) {}
+  ) { }
 
   /**
    * Initializes the SDK.

--- a/src/lib/electron.ts
+++ b/src/lib/electron.ts
@@ -552,7 +552,7 @@ export class SentryElectron implements Adapter {
   }
 
   private normalizeUrl(url: string) {
-    const normUrl = url.replace(/\\/g, '/');
+    const normUrl = decodeURI(url).replace(/\\/g, '/');
 
     return normUrl.includes(APP_BASE_PATH)
       ? 'app://' + normUrl

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/core';
 import { expect, should, use } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
-import { APPDATA_DIRECTORY, initialiseSpectron } from './spectron-helper';
+import { initialiseSpectron } from './spectron-helper';
 
 should();
 const app = initialiseSpectron();
@@ -9,23 +9,16 @@ const app = initialiseSpectron();
 use(chaiAsPromised);
 
 describe('Test', () => {
-  before(() => {
-    return app.start().then(() => app.client.waitUntilWindowLoaded());
+  beforeEach(async () => {
+    await app.start();
+    await app.client.waitUntilWindowLoaded();
   });
 
-  after(() => {
+  afterEach(async () => {
     if (app && app.isRunning()) {
       return app.stop();
     }
     return false;
-  });
-
-  beforeEach(async () => {
-    if (process.env[APPDATA_DIRECTORY]) {
-      app.electron.app.setPath('userData', process.env[
-        APPDATA_DIRECTORY
-      ] as string);
-    }
   });
 
   it('Open app', () => {
@@ -34,6 +27,7 @@ describe('Test', () => {
 
   it('Throw renderer error', done => {
     app.client
+      .waitForExist('#error-render')
       .element('#error-render')
       .click()
       .then(() => {

--- a/test/e2e/spectron-helper.ts
+++ b/test/e2e/spectron-helper.ts
@@ -3,8 +3,6 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { Application } from 'spectron';
 
-export const APPDATA_DIRECTORY = 'E2E_APPDATA_DIRECTORY';
-
 export function initialiseSpectron() {
   let electronPath = join(
     __dirname,

--- a/test/tslint.json
+++ b/test/tslint.json
@@ -1,0 +1,10 @@
+{
+  "rules": {
+    "no-implicit-dependencies": [
+      false
+    ]
+  },
+  "extends": [
+    "../tslint.json"
+  ]
+}

--- a/test/unit/url-normalize.test.ts
+++ b/test/unit/url-normalize.test.ts
@@ -1,6 +1,6 @@
 import { expect, should, use } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
-import { SentryElectron } from '../src/lib/electron';
+import { SentryElectron } from '../../src/lib/electron';
 
 should();
 use(chaiAsPromised);
@@ -10,7 +10,7 @@ const normalizeUrl = (SentryElectron as any).normalizeUrl as (url: string, base:
 
 describe('Normalize URLs', () => {
   it('Example app on Windows', () => {
-    const base = 'C:/Users/Username/sentry-electron/example';
+    const base = 'c:/Users/Username/sentry-electron/example';
 
     expect(normalizeUrl('C:\\Users\\Username\\sentry-electron\\example\\renderer.js', base))
       .to.equal('app://renderer.js');

--- a/test/url-normalize.test.ts
+++ b/test/url-normalize.test.ts
@@ -1,0 +1,37 @@
+import { expect, should, use } from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import { SentryElectron } from '../src/lib/electron';
+
+should();
+use(chaiAsPromised);
+
+// It's not public
+const normalizeUrl = (SentryElectron as any).normalizeUrl as (url: string, base: string) => string;
+
+describe('Normalize URLs', () => {
+  it('Example app on Windows', () => {
+    const base = 'C:/Users/Username/sentry-electron/example';
+
+    expect(normalizeUrl('C:\\Users\\Username\\sentry-electron\\example\\renderer.js', base))
+      .to.equal('app://renderer.js');
+
+    expect(normalizeUrl('C:\\Users\\Username\\sentry-electron\\example\\sub-directory\\renderer.js', base))
+      .to.equal('app://sub-directory/renderer.js');
+
+    expect(normalizeUrl('file:///C:/Users/Username/sentry-electron/example/index.html', base))
+      .to.equal('app://index.html');
+  });
+
+  it('Asar packaged app in Windows Program Files', () => {
+    const base = 'C:/Program Files/My App/resources/app.asar';
+
+    expect(normalizeUrl('/C:/Program%20Files/My%20App/resources/app.asar/dist/bundle-app.js', base))
+      .to.equal('app://dist/bundle-app.js');
+
+    expect(normalizeUrl('file:///C:/Program%20Files/My%20App/resources/app.asar/index.html', base))
+      .to.equal('app://index.html');
+
+    expect(normalizeUrl('file:///C:/Program%20Files/My%20App/resources/app.asar/a/index.html', base))
+      .to.equal('app://a/index.html');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -141,6 +141,10 @@ array-reduce@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/array-reduce/-/array-reduce-0.0.0.tgz#173899d3ffd1c7d9383e4479525dbe278cab5f2b"
 
+arrify@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
+
 asn1@~0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
@@ -403,6 +407,13 @@ crc@^3.4.4:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/crc/-/crc-3.5.0.tgz#98b8ba7d489665ba3979f59b21381374101a1964"
 
+cross-env@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.1.3.tgz#f8ae18faac87692b0a8b4d2f7000d4ec3a85dfd7"
+  dependencies:
+    cross-spawn "^5.1.0"
+    is-windows "^1.0.0"
+
 cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -501,7 +512,7 @@ diff@3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.1.tgz#aa8567a6eed03c531fc89d3f711cd0e5259dec75"
 
-diff@^3.2.0:
+diff@^3.1.0, diff@^3.2.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
 
@@ -526,7 +537,7 @@ ejs@~2.5.6:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.7.tgz#cc872c168880ae3c7189762fd5ffc00896c9518a"
 
-electron-chromedriver@^1.8.0, electron-chromedriver@~1.8.0:
+electron-chromedriver@~1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/electron-chromedriver/-/electron-chromedriver-1.8.0.tgz#901714133cf6f6093d365e1f44a52d99624d8241"
   dependencies:
@@ -987,6 +998,10 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
+is-windows@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
@@ -1108,6 +1123,10 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+make-error@^1.1.1:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.4.tgz#19978ed575f9e9545d2ff8c13e33b5d18a67d535"
+
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
@@ -1181,7 +1200,7 @@ mkdirp@0.5.0:
   dependencies:
     minimist "0.0.8"
 
-mkdirp@0.5.1, mkdirp@~0.5.1:
+mkdirp@0.5.1, mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -1683,6 +1702,12 @@ source-map-resolve@^0.3.0:
     source-map-url "~0.3.0"
     urix "~0.1.0"
 
+source-map-support@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.3.tgz#2b3d5fff298cfa4d1afd7d4352d569e9a0158e76"
+  dependencies:
+    source-map "^0.6.0"
+
 source-map-url@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.3.0.tgz#7ecaf13b57bcd09da8a40c5d269db33799d4aaf9"
@@ -1692,6 +1717,10 @@ source-map@^0.1.38:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
   dependencies:
     amdefine ">=0.0.4"
+
+source-map@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 spdx-correct@~1.0.0:
   version "1.0.2"
@@ -1915,6 +1944,19 @@ trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
 
+ts-node@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-5.0.0.tgz#9aa573889ad7949411f972981c209e064705e36f"
+  dependencies:
+    arrify "^1.0.0"
+    chalk "^2.3.0"
+    diff "^3.1.0"
+    make-error "^1.1.1"
+    minimist "^1.2.0"
+    mkdirp "^0.5.1"
+    source-map-support "^0.5.3"
+    yn "^2.0.0"
+
 tslib@1.9.0, tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
@@ -2132,6 +2174,10 @@ yauzl@2.4.1:
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.4.1.tgz#9528f442dab1b2284e58b4379bb194e22e0c4005"
   dependencies:
     fd-slicer "~1.0.1"
+
+yn@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"
 
 zip-stream@^1.2.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -351,13 +351,13 @@ commander@2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
+commander@^2.11.0, commander@^2.9.0:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.14.1.tgz#2235123e37af8ca3c65df45b026dbd357b01b9aa"
+
 commander@^2.12.1:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
-
-commander@^2.9.0:
-  version "2.14.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.14.1.tgz#2235123e37af8ca3c65df45b026dbd357b01b9aa"
 
 compress-commons@^1.2.0:
   version "1.2.2"
@@ -561,6 +561,22 @@ electron-download@^4.1.0:
     semver "^5.3.0"
     sumchecker "^2.0.1"
 
+electron-mocha@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/electron-mocha/-/electron-mocha-5.0.0.tgz#415b86166a6bf80125fc4106ecc2545669c284ac"
+  dependencies:
+    commander "^2.11.0"
+    electron-window "^0.8.0"
+    fs-extra "^4.0.2"
+    mocha "^4.0.1"
+    which "^1.3.0"
+
+electron-window@^0.8.0:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/electron-window/-/electron-window-0.8.1.tgz#16ca187eb4870b0679274fc8299c5960e6ab2c5e"
+  dependencies:
+    is-electron-renderer "^2.0.0"
+
 electron@^1.7.9:
   version "1.7.11"
   resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.11.tgz#993b6aa79e0e79a7cfcc369f4c813fbd9a0b08d9"
@@ -735,6 +751,14 @@ fs-extra@^2.0.0:
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^2.1.0"
+
+fs-extra@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -921,6 +945,10 @@ is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
 
+is-electron-renderer@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-electron-renderer/-/is-electron-renderer-2.0.1.tgz#a469d056f975697c58c98c6023eb0aa79af895a2"
+
 is-finite@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
@@ -1009,6 +1037,12 @@ json-stringify-safe@~5.0.1:
 jsonfile@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -1152,6 +1186,21 @@ mkdirp@0.5.1, mkdirp@~0.5.1:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+mocha@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-4.1.0.tgz#7d86cfbcf35cb829e2754c32e17355ec05338794"
+  dependencies:
+    browser-stdout "1.3.0"
+    commander "2.11.0"
+    debug "3.1.0"
+    diff "3.3.1"
+    escape-string-regexp "1.0.5"
+    glob "7.1.2"
+    growl "1.10.3"
+    he "1.1.1"
+    mkdirp "0.5.1"
+    supports-color "4.4.0"
 
 mocha@^5.0.1:
   version "5.0.1"
@@ -1949,6 +1998,10 @@ typescript@^2.7.2:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
 
+universalify@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
+
 urix@^0.1.0, urix@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
@@ -2039,7 +2092,7 @@ wgxpath@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wgxpath/-/wgxpath-1.0.0.tgz#eef8a4b9d558cc495ad3a9a2b751597ecd9af690"
 
-which@^1.2.4, which@^1.2.9:
+which@^1.2.4, which@^1.2.9, which@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:


### PR DESCRIPTION
Changes
- Split tests into `unit` and `e2e`
- Run unit tests in `electron-mocha` and e2e in `mocha`
- Use `ts-node/register` so TypeScript tests don't require pre-compilation step
- Simplify `normalizeUrl` and add some initial tests (Fixes #21)