### PR TITLE
feat: Add option for onFatalError

### DIFF
--- a/src/lib/electron.ts
+++ b/src/lib/electron.ts
@@ -64,8 +64,8 @@ const APP_BASE_PATH = (app || remote.app).getAppPath().replace(/\\/g, '/');
  */
 export interface SentryElectronOptions
   extends Options,
-  SentryBrowserOptions,
-  SentryNodeOptions {
+    SentryBrowserOptions,
+    SentryNodeOptions {
   /**
    * Enables crash reporting for native crashes of this process (via Minidumps).
    * Defaults to `true`.
@@ -77,6 +77,11 @@ export interface SentryElectronOptions
    * Defaults to `true`.
    */
   enableJavaScript?: boolean;
+
+  /**
+   * This will be called in case of a non recoverable fatal error.
+   */
+  onFatalError?: (error: Error) => void;
 }
 
 /**
@@ -109,7 +114,6 @@ export interface SentryElectronOptions
  * @see Sentry.Client
  */
 export class SentryElectron implements Adapter {
-
   /**
    * Normalizes URLs in exceptions and stacktraces so Sentry can fingerprint
    * across platforms
@@ -121,7 +125,7 @@ export class SentryElectron implements Adapter {
   private static normalizeUrl(url: string, base: string = APP_BASE_PATH) {
     return decodeURI(url)
       .replace(/\\/g, '/')
-      .replace(new RegExp(`(file:\/\/)?\/*${base}\/*`, "ig"), 'app://');
+      .replace(new RegExp(`(file:\/\/)?\/*${base}\/*`, 'ig'), 'app://');
   }
 
   /** The inner SDK used to record JavaScript events. */
@@ -141,7 +145,7 @@ export class SentryElectron implements Adapter {
   constructor(
     private client: Client,
     public options: SentryElectronOptions = {},
-  ) { }
+  ) {}
 
   /**
    * Initializes the SDK.
@@ -258,7 +262,7 @@ export class SentryElectron implements Adapter {
       const contents = remote.getCurrentWebContents();
       event.extra = {
         ...event.extra,
-        crashed_process: `renderer[${contents.id}]`
+        crashed_process: `renderer[${contents.id}]`,
       };
 
       ipcRenderer.send(IPC_EVENT, event);
@@ -387,7 +391,9 @@ export class SentryElectron implements Adapter {
   }
 
   /** Loads new native crashes from disk and sends them to Sentry. */
-  private async sendNativeCrashes(extra: object = { crashed_process: 'browser' }): Promise<void> {
+  private async sendNativeCrashes(
+    extra: object = { crashed_process: 'browser' },
+  ): Promise<void> {
     // Whenever we are called, assume that the crashes we are going to load down
     // below have occurred recently. This means, we can use the same event data
     // for all minidumps that we load now. There are two conditions:
@@ -445,10 +451,12 @@ export class SentryElectron implements Adapter {
       // Every time a subprocess or renderer crashes, start sending minidumps
       // right away.
       app.on('web-contents-created', (event, contents) => {
-        contents.on('crashed', () => this.sendNativeCrashes({
-          crashed_process: `renderer[${contents.id}]`,
-          crashed_url: contents.getURL()
-        }));
+        contents.on('crashed', () =>
+          this.sendNativeCrashes({
+            crashed_process: `renderer[${contents.id}]`,
+            crashed_url: contents.getURL(),
+          }),
+        );
       });
     }
 
@@ -466,6 +474,11 @@ export class SentryElectron implements Adapter {
     const node = new SentryNode(this.client, options);
     if (!await node.install()) {
       return false;
+    }
+
+    const Raven = node.getRaven();
+    if (this.options.onFatalError) {
+      Raven.onFatalError = this.options.onFatalError;
     }
 
     this.inner = node;
@@ -551,11 +564,13 @@ export class SentryElectron implements Adapter {
     }
 
     const stacktrace =
-      event.stacktrace
+      event.stacktrace ||
       // node.js exceptions
-      || (event.exception && event.exception[0] && event.exception[0].stacktrace)
+      (event.exception &&
+        event.exception[0] &&
+        event.exception[0].stacktrace) ||
       // Browser exceptions
-      || (event.exception && event.exception.values[0].stacktrace);
+      (event.exception && event.exception.values[0].stacktrace);
 
     if (stacktrace) {
       stacktrace.frames.forEach((frame: any) => {


### PR DESCRIPTION
This exposes `onFatalError` in the electron options.
With that you should be able to overwrite the default behaviour of 
```
console.error(err && err.stack ? err.stack : err);
global.process.exit(1);
```