### PR TITLE
feat: Add nodeIntegration disabled test

### DIFF
--- a/test/e2e/context.ts
+++ b/test/e2e/context.ts
@@ -48,7 +48,7 @@ export class TestContext {
   ) {}
 
   /** Starts the app. */
-  public async start(sentryConfig: string, fixture?: string): Promise<void> {
+  public async start(sentryConfig?: string, fixture?: string): Promise<void> {
     // Start the test server if required
     if (this.testServer) {
       this.testServer.start();
@@ -61,7 +61,7 @@ export class TestContext {
       this.tempDir = await getTempDir();
     }
 
-    const env: { [key: string]: string } = {
+    const env: { [key: string]: string | undefined } = {
       ...process.env,
       DSN:
         'http://37f8a2ee37c0409d8970bc7559c7c7e4:4cfde0ca506c4ea39b4e25b61a1ff1c3@localhost:8000/277345',

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -1,5 +1,6 @@
 import { expect, should, use } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
+import { join } from 'path';
 import { TestContext } from './context';
 import { getLastFrame } from './utils';
 
@@ -159,5 +160,15 @@ describe('Basic Tests', () => {
     expect(context.testServer.events.length).to.equal(1);
     expect(event.dump_file).to.equal(undefined);
     expect(breadcrumbs.length, 'filtered breadcrumbs').to.equal(1);
+  });
+
+  it('Loaded via preload script with nodeIntegration disabled', async () => {
+    context = new TestContext(join(__dirname, 'preload-app'));
+    await context.start();
+    await context.waitForEvents(1);
+    const event = context.testServer.events[0];
+
+    expect(context.testServer.events.length).to.equal(1);
+    expect(event.dump_file).to.equal(undefined);
   });
 });

--- a/test/e2e/preload-app/index.html
+++ b/test/e2e/preload-app/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <title>Crash Fixture!</title>
+</head>
+
+<body>
+
+</body>
+
+<script>
+  setTimeout(() => {
+    throw new Error('Not much')
+  }, 2000)
+</script>
+
+</html>

--- a/test/e2e/preload-app/main.js
+++ b/test/e2e/preload-app/main.js
@@ -1,0 +1,33 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+const url = require('url');
+
+// If we're running e2e tests, use the supplied temp userData directory
+if (process.env['E2E_USERDATA_DIRECTORY']) {
+  app.setPath('userData', process.env['E2E_USERDATA_DIRECTORY']);
+}
+
+const sentryPath = path.join(__dirname, '../test-app/fixtures/sentry-basic')
+
+require(sentryPath);
+
+app.on('ready', () => {
+  const window = new BrowserWindow({
+    width: 800,
+    height: 600,
+    titleBarStyle: 'hidden',
+    webPreferences: {
+      preload: sentryPath,
+      nodeIntegration: false
+    }
+  });
+
+  window.loadURL(
+    url.format({
+      pathname: path.join(__dirname, 'index.html'),
+      protocol: 'file:',
+      slashes: true,
+    }),
+  );
+});
+

--- a/test/e2e/preload-app/package.json
+++ b/test/e2e/preload-app/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "test-app",
+  "version": "1.0.0",
+  "main": "main.js"
+}


### PR DESCRIPTION
Adds a test which tests a renderer with `nodeIntegration` disabled and `SentryClient` created via preload script