### PR TITLE
ref: Update to latest core

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <br />
 </p>
 
-# Official Sentry SDK for Electron
+# Official Sentry SDK for Electron (Beta)
 
 [![Travis](https://img.shields.io/travis/getsentry/sentry-electron.svg?maxAge=2592000)](https://travis-ci.org/getsentry/sentry-electron)
 [![AppVeyor](https://img.shields.io/appveyor/ci/sentry/sentry-electron.svg)](https://ci.appveyor.com/project/sentry/sentry-electron)
@@ -15,6 +15,13 @@
 [![deps](https://david-dm.org/getsentry/sentry-electron/status.svg)](https://david-dm.org/getsentry/sentry-electron?view=list)
 [![deps dev](https://david-dm.org/getsentry/sentry-electron/dev-status.svg)](https://david-dm.org/getsentry/sentry-electron?type=dev&view=list)
 [![deps peer](https://david-dm.org/getsentry/sentry-electron/peer-status.svg)](https://david-dm.org/getsentry/sentry-electron?type=peer&view=list)
+
+**NOTE**: This package is still in beta. It is part of an early access preview
+for the
+[next generation](https://github.com/getsentry/raven-js/tree/next#readme) of
+Sentry JavaScript SDKs. While we try to keep breaking changes to a minimum,
+interfaces might change between minor releases before the first stable `1.x`
+release.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -25,43 +25,43 @@ release.
 
 ## Usage
 
-To use this SDK, call `SentryClient.create(options)` as early as possible in the
-entry modules in the main process as well as all renderer processes or further
-sub processees you spawn. This will initialize the SDK and hook into the
+To use this SDK, call `create(options)` as early as possible in the entry
+modules in the main process as well as all renderer processes or further sub
+processees you spawn. This will initialize the SDK and hook into the
 environment. Note that you can turn off almost all side effects using the
 respective options.
 
 ```javascript
-import { SentryClient } from '@sentry/electron';
+import { create } from '@sentry/electron';
 
-SentryClient.create({
+create({
   dsn: '__DSN__',
   // ...
 });
 ```
 
-To set context information or send manual events, use the provided methods on
-`SentryClient`. Note that these functions will not perform any action before you
-have called `SentryClient.create()`:
+To set context information or send manual events, use the exported functions of
+`@sentry/electron`. Note that these functions will not perform any action before
+you have called `create()`:
 
 ```javascript
+import * as Sentry from '@sentry/electron';
+
 // Set user information, as well as tags and further extras
-SentryClient.setContext({
-  extra: { battery: 0.7 },
-  tags: { user_mode: 'admin' },
-  user: { id: '4711' },
-});
+Sentry.setExtraContext({ battery: 0.7 });
+Sentry.setTagsContext({ user_mode: 'admin' });
+Sentry.setUserContext({ id: '4711' });
 
 // Add a breadcrumb for future events
-SentryClient.addBreadcrumb({
+Sentry.addBreadcrumb({
   message: 'My Breadcrumb',
   // ...
 });
 
 // Capture exceptions, messages or manual events
-SentryClient.captureMessage('Hello, world!');
-SentryClient.captureException(new Error('Good bye'));
-SentryClient.captureEvent({
+Sentry.captureMessage('Hello, world!');
+Sentry.captureException(new Error('Good bye'));
+Sentry.captureEvent({
   message: 'Manual',
   stacktrace: [
     // ...
@@ -84,26 +84,4 @@ const client = new ElectronFrontend({
 
 client.install();
 // ...
-```
-
-Note that `install()` returns a `Promise` that resolves when the installation
-has finished. It is not necessary to wait for the installation before adding
-breadcrumbs, defining context or sending events. However, the return value
-indicates whether the installation was successful and the environment could be
-instrumented:
-
-```javascript
-import { ElectronFrontend } from '@sentry/electron';
-
-const client = new ElectronFrontend({
-  dsn: '__DSN__',
-  // ...
-});
-
-const success = await client.install();
-if (success) {
-  // Will catch global exceptions, record breadcrumbs for DOM events, etc...
-} else {
-  // Limited instrumentation, but sending events will still work
-}
 ```

--- a/example/sentry.js
+++ b/example/sentry.js
@@ -1,10 +1,10 @@
-const { SentryClient } = require('..');
+const { create } = require('..');
 
 // TODO: Replace with your project's DSN
 const MY_DSN =
   'https://37f8a2ee37c0409d8970bc7559c7c7e4:4cfde0ca506c4ea39b4e25b61a1ff1c3@sentry.io/277345';
 
-SentryClient.create({
+create({
   dsn: MY_DSN,
   // TODO: Add more options
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1077 @@
+{
+  "name": "@sentry/electron",
+  "version": "0.4.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@sentry/browser": {
+      "version": "0.4.1",
+      "requires": {
+        "@sentry/core": "0.4.1",
+        "@sentry/utils": "0.4.1",
+        "raven-js": "3.23.1"
+      },
+      "dependencies": {
+        "@sentry/core": {
+          "version": "0.4.1",
+          "bundled": true
+        },
+        "@sentry/utils": {
+          "version": "0.4.1",
+          "bundled": true
+        },
+        "raven-js": {
+          "version": "3.23.1",
+          "bundled": true
+        },
+        "sinon": {
+          "bundled": true,
+          "requires": {
+            "supports-color": "5.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.1.0",
+          "bundled": true
+        }
+      }
+    },
+    "@sentry/cli": {
+      "version": "1.30.3",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-1.30.3.tgz",
+      "integrity": "sha1-AtD3eBwe5eG+WkMSoyX76LGzcjE=",
+      "dev": true,
+      "requires": {
+        "https-proxy-agent": "2.2.0",
+        "node-fetch": "1.7.3",
+        "progress": "2.0.0",
+        "proxy-from-env": "1.0.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "dev": true,
+          "requires": {
+            "encoding": "0.1.12",
+            "is-stream": "1.1.0"
+          }
+        }
+      }
+    },
+    "@sentry/core": {
+      "version": "0.4.1"
+    },
+    "@sentry/node": {
+      "version": "0.4.1",
+      "requires": {
+        "@sentry/core": "0.4.1",
+        "@sentry/utils": "0.4.1",
+        "raven": "2.4.2"
+      },
+      "dependencies": {
+        "@sentry/core": {
+          "version": "0.4.1",
+          "bundled": true
+        },
+        "@sentry/utils": {
+          "version": "0.4.1",
+          "bundled": true
+        },
+        "charenc": {
+          "version": "0.0.2",
+          "bundled": true
+        },
+        "cookie": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "crypt": {
+          "version": "0.0.2",
+          "bundled": true
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "md5": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "charenc": "0.0.2",
+            "crypt": "0.0.2",
+            "is-buffer": "1.1.6"
+          }
+        },
+        "raven": {
+          "version": "2.4.2",
+          "bundled": true,
+          "requires": {
+            "cookie": "0.3.1",
+            "md5": "2.2.1",
+            "stack-trace": "0.0.9",
+            "timed-out": "4.0.1",
+            "uuid": "3.0.0"
+          }
+        },
+        "stack-trace": {
+          "version": "0.0.9",
+          "bundled": true
+        },
+        "timed-out": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.0.0",
+          "bundled": true
+        }
+      }
+    },
+    "@sentry/typescript": {
+      "version": "0.4.1",
+      "dev": true,
+      "requires": {
+        "tslint-config-prettier": "1.10.0"
+      },
+      "dependencies": {
+        "tslint-config-prettier": {
+          "version": "1.10.0",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
+    "@sentry/utils": {
+      "version": "0.4.1"
+    },
+    "@sentry/wizard": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@sentry/wizard/-/wizard-0.9.1.tgz",
+      "integrity": "sha1-8EdnLwMYTy+yAiR3XO/r0fF2eVs=",
+      "dev": true,
+      "requires": {
+        "@sentry/cli": "1.30.3",
+        "chalk": "2.3.2",
+        "glob": "7.1.2",
+        "inquirer": "5.1.0",
+        "lodash": "4.17.5",
+        "open": "0.0.5",
+        "r2": "2.0.0",
+        "read-env": "1.1.1",
+        "xcode": "1.0.0",
+        "yargs": "11.0.0"
+      }
+    },
+    "agent-base": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
+      "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
+      "dev": true,
+      "requires": {
+        "es6-promisify": "5.0.0"
+      }
+    },
+    "ansi-escapes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "1.9.1"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base64-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz",
+      "integrity": "sha1-1kAMrBxMZgl22Q0HoENR2JOV9eg=",
+      "dev": true
+    },
+    "big-integer": {
+      "version": "1.6.26",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.26.tgz",
+      "integrity": "sha1-OvFnL6Ytry1eyvrPblqg0l4Cwcg=",
+      "dev": true
+    },
+    "bplist-creator": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.7.tgz",
+      "integrity": "sha1-N98VNgkoJLh8QvlXsBNEEXNyrkU=",
+      "dev": true,
+      "requires": {
+        "stream-buffers": "2.2.0"
+      }
+    },
+    "bplist-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
+      "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
+      "dev": true,
+      "requires": {
+        "big-integer": "1.6.26"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "camelcase": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+      "dev": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+      "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.3.0"
+      }
+    },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "cliui": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
+      "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+      "dev": true,
+      "requires": {
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "wrap-ansi": "2.1.0"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.2",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
+      }
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.19"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
+      "dev": true
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "4.2.4"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "execa": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
+      }
+    },
+    "external-editor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+      "dev": true,
+      "requires": {
+        "chardet": "0.4.2",
+        "iconv-lite": "0.4.19",
+        "tmp": "0.0.33"
+      }
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5"
+      }
+    },
+    "find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "dev": true,
+      "requires": {
+        "locate-path": "2.0.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "https-proxy-agent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.0.tgz",
+      "integrity": "sha512-uUWcfXHvy/dwfM9bqa6AozvAjS32dZSTUYd/4SEpYKRg6LEcPLshksnQYRudM9AyNvUARMfAg5TLjUDyX/K4vA==",
+      "dev": true,
+      "requires": {
+        "agent-base": "4.2.0",
+        "debug": "3.1.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.1.0.tgz",
+      "integrity": "sha512-kn7N70US1MSZHZHSGJLiZ7iCwwncc7b0gc68YtlX29OjI3Mp0tSVV+snVXpZ1G+ONS3Ac9zd1m6hve2ibLDYfA==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "3.0.0",
+        "chalk": "2.3.2",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.1.0",
+        "figures": "2.0.0",
+        "lodash": "4.17.5",
+        "mute-stream": "0.0.7",
+        "run-async": "2.3.0",
+        "rxjs": "5.5.7",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
+      }
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
+      "requires": {
+        "invert-kv": "1.0.0"
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
+      "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
+    },
+    "mem": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "1.2.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "2.0.1"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "1.2.0"
+      }
+    },
+    "open": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
+      "integrity": "sha1-QsPhjslUZra/DcQvOilFw/DK2Pw=",
+      "dev": true
+    },
+    "os-locale": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+      "dev": true,
+      "requires": {
+        "execa": "0.7.0",
+        "lcid": "1.0.0",
+        "mem": "1.1.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "dev": true,
+      "requires": {
+        "p-try": "1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "1.2.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "pegjs": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
+      "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0=",
+      "dev": true
+    },
+    "plist": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-2.0.1.tgz",
+      "integrity": "sha1-CjLKlIGxw2TpLhjcVch23p0B2os=",
+      "dev": true,
+      "requires": {
+        "base64-js": "1.1.2",
+        "xmlbuilder": "8.2.2",
+        "xmldom": "0.1.27"
+      }
+    },
+    "progress": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "dev": true
+    },
+    "proxy-from-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "r2": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/r2/-/r2-2.0.0.tgz",
+      "integrity": "sha512-qZ3W0BiiNCZ4EnixbsD1k2KgFk6mM97wRxDWMMtQwqUEmivju9kOyYsoO0hvhnof/niJ1/gIldSB3h2K86bZiQ==",
+      "dev": true,
+      "requires": {
+        "caseless": "0.12.0",
+        "node-fetch": "2.1.1",
+        "typedarray-to-buffer": "3.1.5"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.1.tgz",
+          "integrity": "sha1-NpynC4L1DIZJYQSmx3bSdPTkotQ=",
+          "dev": true
+        }
+      }
+    },
+    "read-env": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/read-env/-/read-env-1.1.1.tgz",
+      "integrity": "sha512-yzGQb8P7N8zf513nRu+kMiQPJlmADWqS7Qn2pd6aAvRcrMCxuFvRX1KL8KU0ckdWVqoTX7Qpj10U+Dx7cVL/LA==",
+      "dev": true,
+      "requires": {
+        "camelcase": "4.1.0"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "2.1.0"
+      }
+    },
+    "rxjs": {
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.7.tgz",
+      "integrity": "sha512-Hxo2ac8gRQjwjtKgukMIwBRbq5+KAeEV5hXM4obYBOAghev41bDQWgFH4svYiU9UnQ5kNww2LgfyBdevCd2HXA==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "1.0.1"
+      }
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "simple-plist": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-0.2.1.tgz",
+      "integrity": "sha1-cXZts1IyaSjPOoByQrp2IyJjZyM=",
+      "dev": true,
+      "requires": {
+        "bplist-creator": "0.0.7",
+        "bplist-parser": "0.1.1",
+        "plist": "2.0.1"
+      }
+    },
+    "stream-buffers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
+      "integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "3.0.0"
+      }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+      "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+      "dev": true,
+      "requires": {
+        "has-flag": "3.0.0"
+      }
+    },
+    "symbol-observable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "1.0.2"
+      }
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "requires": {
+        "is-typedarray": "1.0.0"
+      }
+    },
+    "uuid": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+      "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+      "dev": true
+    },
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        }
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xcode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/xcode/-/xcode-1.0.0.tgz",
+      "integrity": "sha1-4fWxRDJF3tOMGAeW3xoQ/e2ghOw=",
+      "dev": true,
+      "requires": {
+        "pegjs": "0.10.0",
+        "simple-plist": "0.2.1",
+        "uuid": "3.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+      "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
+      "dev": true
+    },
+    "xmldom": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
+      "dev": true
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
+      "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
+      "dev": true,
+      "requires": {
+        "cliui": "4.0.0",
+        "decamelize": "1.2.0",
+        "find-up": "2.1.0",
+        "get-caller-file": "1.0.2",
+        "os-locale": "2.1.0",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "9.0.2"
+      }
+    },
+    "yargs-parser": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+      "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+      "dev": true,
+      "requires": {
+        "camelcase": "4.1.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -30,17 +30,17 @@
       "cross-env TS_NODE_PROJECT=tsconfig.json xvfb-maybe mocha --require ts-node/register --timeout 30000 ./test/e2e/**/*.ts"
   },
   "dependencies": {
-    "@sentry/browser": "0.4.2",
-    "@sentry/core": "0.4.2",
-    "@sentry/node": "0.4.2",
-    "@sentry/shim": "^0.5.0-beta.0",
-    "@sentry/utils": "0.4.2",
+    "@sentry/browser": "^0.5.0-beta.1",
+    "@sentry/core": "^0.5.0-beta.1",
+    "@sentry/node": "^0.5.0-beta.1",
+    "@sentry/shim": "^0.5.0-beta.1",
+    "@sentry/utils": "^0.5.0-beta.1",
     "form-data": "^2.3.2",
     "node-fetch": "^2.1.1",
     "util.promisify": "^1.0.0"
   },
   "devDependencies": {
-    "@sentry/typescript": "0.4.2",
+    "@sentry/typescript": "^0.5.0-beta.1",
     "@types/body-parser": "^1.16.8",
     "@types/chai": "^4.1.2",
     "@types/chai-as-promised": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -30,17 +30,17 @@
     "e2e": "cross-env TS_NODE_PROJECT=tsconfig.json xvfb-maybe mocha --require ts-node/register --timeout 30000 ./test/e2e/**/*.ts"
   },
   "dependencies": {
-    "@sentry/browser": "0.5.0-beta.3",
-    "@sentry/core": "0.5.0-beta.3",
-    "@sentry/node": "0.5.0-beta.3",
-    "@sentry/shim": "0.5.0-beta.3",
-    "@sentry/utils": "0.5.0-beta.3",
+    "@sentry/browser": "0.5.0-beta.4",
+    "@sentry/core": "0.5.0-beta.4",
+    "@sentry/node": "0.5.0-beta.4",
+    "@sentry/shim": "0.5.0-beta.4",
+    "@sentry/utils": "0.5.0-beta.4",
     "form-data": "^2.3.2",
     "node-fetch": "^2.1.1",
     "util.promisify": "^1.0.0"
   },
   "devDependencies": {
-    "@sentry/typescript": "0.5.0-beta.3",
+    "@sentry/typescript": "0.5.0-beta.4",
     "@types/body-parser": "^1.16.8",
     "@types/chai": "^4.1.2",
     "@types/chai-as-promised": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "./dist/index.js",
   "repository": "https://github.com/getsentry/sentry-electron.git",
   "author": "Sentry",
-  "contributors": ["Tim Fish"],
+  "contributors": [
+    "Tim Fish"
+  ],
   "license": "MIT",
   "types": "./dist/index.d.ts",
   "publishConfig": {
@@ -23,24 +25,22 @@
     "fix:prettier": "prettier --write \"{src,test}/**/*.ts\"",
     "fix:tslint": "tslint --fix -t stylish -p .",
     "pretest": "run-s clean build",
-    "test":
-      "cross-env TS_NODE_PROJECT=tsconfig.json xvfb-maybe electron-mocha --require ts-node/register --timeout 3000 ./test/unit/**/*.ts",
+    "test": "cross-env TS_NODE_PROJECT=tsconfig.json xvfb-maybe electron-mocha --require ts-node/register --timeout 3000 ./test/unit/**/*.ts",
     "pree2e": "run-s clean build",
-    "e2e":
-      "cross-env TS_NODE_PROJECT=tsconfig.json xvfb-maybe mocha --require ts-node/register --timeout 30000 ./test/e2e/**/*.ts"
+    "e2e": "cross-env TS_NODE_PROJECT=tsconfig.json xvfb-maybe mocha --require ts-node/register --timeout 30000 ./test/e2e/**/*.ts"
   },
   "dependencies": {
-    "@sentry/browser": "^0.5.0-beta.1",
-    "@sentry/core": "^0.5.0-beta.1",
-    "@sentry/node": "^0.5.0-beta.1",
-    "@sentry/shim": "^0.5.0-beta.1",
-    "@sentry/utils": "^0.5.0-beta.1",
+    "@sentry/browser": "0.5.0-beta.2",
+    "@sentry/core": "0.5.0-beta.2",
+    "@sentry/node": "0.5.0-beta.2",
+    "@sentry/shim": "0.5.0-beta.2",
+    "@sentry/utils": "0.5.0-beta.2",
     "form-data": "^2.3.2",
     "node-fetch": "^2.1.1",
     "util.promisify": "^1.0.0"
   },
   "devDependencies": {
-    "@sentry/typescript": "^0.5.0-beta.1",
+    "@sentry/typescript": "0.5.0-beta.2",
     "@types/body-parser": "^1.16.8",
     "@types/chai": "^4.1.2",
     "@types/chai-as-promised": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
   "main": "./dist/index.js",
   "repository": "https://github.com/getsentry/sentry-electron.git",
   "author": "Sentry",
-  "contributors": [
-    "Tim Fish"
-  ],
+  "contributors": ["Tim Fish"],
   "license": "MIT",
   "types": "./dist/index.d.ts",
   "publishConfig": {
@@ -25,14 +23,17 @@
     "fix:prettier": "prettier --write \"{src,test}/**/*.ts\"",
     "fix:tslint": "tslint --fix -t stylish -p .",
     "pretest": "run-s clean build",
-    "test": "cross-env TS_NODE_PROJECT=tsconfig.json xvfb-maybe electron-mocha --require ts-node/register --timeout 3000 ./test/unit/**/*.ts",
+    "test":
+      "cross-env TS_NODE_PROJECT=tsconfig.json xvfb-maybe electron-mocha --require ts-node/register --timeout 3000 ./test/unit/**/*.ts",
     "pree2e": "run-s clean build",
-    "e2e": "cross-env TS_NODE_PROJECT=tsconfig.json xvfb-maybe mocha --require ts-node/register --timeout 30000 ./test/e2e/**/*.ts"
+    "e2e":
+      "cross-env TS_NODE_PROJECT=tsconfig.json xvfb-maybe mocha --require ts-node/register --timeout 30000 ./test/e2e/**/*.ts"
   },
   "dependencies": {
     "@sentry/browser": "0.4.2",
     "@sentry/core": "0.4.2",
     "@sentry/node": "0.4.2",
+    "@sentry/shim": "^0.5.0-beta.0",
     "@sentry/utils": "0.4.2",
     "form-data": "^2.3.2",
     "node-fetch": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -30,17 +30,17 @@
     "e2e": "cross-env TS_NODE_PROJECT=tsconfig.json xvfb-maybe mocha --require ts-node/register --timeout 30000 ./test/e2e/**/*.ts"
   },
   "dependencies": {
-    "@sentry/browser": "0.5.0-beta.2",
-    "@sentry/core": "0.5.0-beta.2",
-    "@sentry/node": "0.5.0-beta.2",
-    "@sentry/shim": "0.5.0-beta.2",
-    "@sentry/utils": "0.5.0-beta.2",
+    "@sentry/browser": "0.5.0-beta.3",
+    "@sentry/core": "0.5.0-beta.3",
+    "@sentry/node": "0.5.0-beta.3",
+    "@sentry/shim": "0.5.0-beta.3",
+    "@sentry/utils": "0.5.0-beta.3",
     "form-data": "^2.3.2",
     "node-fetch": "^2.1.1",
     "util.promisify": "^1.0.0"
   },
   "devDependencies": {
-    "@sentry/typescript": "0.5.0-beta.2",
+    "@sentry/typescript": "0.5.0-beta.3",
     "@types/body-parser": "^1.16.8",
     "@types/chai": "^4.1.2",
     "@types/chai-as-promised": "^7.1.0",

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -63,8 +63,8 @@ interface CrashReporterExt {
  */
 export interface ElectronOptions extends Options, BrowserOptions, NodeOptions {
   /**
-   * Enables crash reporting for JavaScript errors in this process.
-   * Defaults to `true`.
+   * Enables crash reporting for JavaScript errors in this process. Defaults to
+   * `true`.
    */
   enableJavaScript?: boolean;
 
@@ -168,11 +168,15 @@ export class ElectronBackend implements Backend {
   }
 
   /**
-   * TODO
+   * Uploads the given minidump and attaches event information.
+   *
+   * @param path A relative or absolute path to the minidump file.
+   * @param event Optional event information to add to the minidump request.
+   * @returns A promise that resolves to the status code of the request.
    */
   public async uploadMinidump(
     path: string,
-    event: SentryEvent,
+    event: SentryEvent = {},
   ): Promise<number> {
     if (this.uploader) {
       await this.uploader.uploadMinidump({ path, event });
@@ -180,7 +184,7 @@ export class ElectronBackend implements Backend {
     return 200;
   }
 
-  /** TODO */
+  /** Returns the full list of breadcrumbs (or empty). */
   public loadBreadcrumbs(): Breadcrumb[] {
     return this.breadcrumbs ? this.breadcrumbs.get() : [];
   }
@@ -205,7 +209,7 @@ export class ElectronBackend implements Backend {
     return true;
   }
 
-  /** TODO */
+  /** Returns the latest context (or empty). */
   public loadContext(): Context {
     return this.context ? this.context.get() : {};
   }
@@ -330,8 +334,8 @@ export class ElectronBackend implements Backend {
       // Flush already cached minidumps from the queue.
       forget(this.uploader.flushQueue());
 
-      // Start to submit recent minidump crashes. This will load breadcrumbs
-      // and context information that was cached on disk prior to the crash.
+      // Start to submit recent minidump crashes. This will load breadcrumbs and
+      // context information that was cached on disk prior to the crash.
       forget(
         this.sendNativeCrashes({
           crashed_process: 'browser',
@@ -390,7 +394,7 @@ export class ElectronBackend implements Backend {
     return true;
   }
 
-  /** TODO */
+  /** Installs IPC handlers to receive events and metadata from renderers. */
   private installIPC(): void {
     ipcMain.on(IPC_CRUMB, (_: any, crumb: Breadcrumb) => {
       addBreadcrumb(crumb);
@@ -423,7 +427,7 @@ export class ElectronBackend implements Backend {
     });
   }
 
-  /** TODO */
+  /** Installs auto-breadcrumb handlers for certain Electron events. */
   private installAutoBreadcrumbs(): void {
     this.instrumentBreadcrumbs('app', app);
 

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -195,12 +195,14 @@ export class ElectronBackend implements Backend {
       );
     }
 
+    // We replicate the behavior of the frontend
     const { maxBreadcrumbs = 100 } = this.frontend.getOptions();
     this.breadcrumbs.update(breadcrumbs =>
       [...breadcrumbs, breadcrumb].slice(-maxBreadcrumbs),
     );
 
-    return false;
+    // Still, the frontend should merge breadcrumbs into events, for now
+    return true;
   }
 
   /** TODO */
@@ -218,6 +220,7 @@ export class ElectronBackend implements Backend {
       );
     }
 
+    // We replicate the behavior of the frontend
     this.context.update(context => {
       if (nextContext.extra) {
         context.extra = { ...context.extra, ...nextContext.extra };
@@ -232,7 +235,8 @@ export class ElectronBackend implements Backend {
       return context;
     });
 
-    return false;
+    // Still, the frontend should merge context into events, for now
+    return true;
   }
 
   /** Loads new native crashes from disk and sends them to Sentry. */

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -16,7 +16,6 @@ import {
   addBreadcrumb,
   Breadcrumb,
   captureEvent,
-  captureException,
   Context,
   SentryEvent,
   setExtraContext,
@@ -361,17 +360,6 @@ export class ElectronBackend implements Backend {
 
   /** Activates the Node SDK for the main process. */
   private async installMainHandler(): Promise<boolean> {
-    if (!this.frontend.getOptions().onFatalError) {
-      this.frontend.getOptions().onFatalError = (error: Error) => {
-        console.error('*********************************');
-        console.error('* SentryElectron unhandledError *');
-        console.error('*********************************');
-        console.error(error);
-        console.error('---------------------------------');
-        captureException(error);
-      };
-    }
-
     // Browser is the Electron main process (Node)
     const node = new NodeBackend(this.frontend);
     if (!node.install()) {

--- a/src/frontend.ts
+++ b/src/frontend.ts
@@ -49,13 +49,16 @@ export class ElectronFrontend extends FrontendBase<
   }
 
   /**
-   * TODO
-   * @param path
+   * Uploads a native crash dump (Minidump) to Sentry.
+   *
+   * @param path The relative or absolute path to the minidump.
+   * @param event Optional event payload to attach to the minidump.
+   * @param scope The SDK scope used to upload.
    */
   public async captureMinidump(
     path: string,
     event: SentryEvent = {},
-    scope: Scope = this.getInitialScope(),
+    scope: Scope = this.getInternalScope(),
   ): Promise<void> {
     const prepared = await this.prepareEvent(event, scope);
     await this.getBackend().uploadMinidump(path, prepared);

--- a/src/frontend.ts
+++ b/src/frontend.ts
@@ -7,7 +7,7 @@ import {
   SdkInfo,
   SentryEvent,
 } from '@sentry/core';
-import { callOnClient } from '@sentry/shim';
+import { _callOnClient } from '@sentry/shim';
 // tslint:disable-next-line:no-implicit-dependencies
 import { ipcRenderer } from 'electron';
 import { ElectronBackend, ElectronOptions } from './backend';
@@ -112,7 +112,7 @@ export class ElectronFrontend extends FrontendBase<
  * @param event
  */
 export function captureMinidump(path: string, event: SentryEvent = {}): void {
-  callOnClient('captureMinidump', path, event);
+  _callOnClient('captureMinidump', path, event);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,13 @@
-export * from './backend';
-export * from './frontend';
+export { ElectronBackend, ElectronOptions } from './backend';
+export { ElectronFrontend } from './frontend';
+export { captureMinidump, create, getCurrentFrontend } from './sdk';
+
+export {
+  addBreadcrumb,
+  captureMessage,
+  captureException,
+  captureEvent,
+  setUserContext,
+  setTagsContext,
+  setExtraContext,
+} from '@sentry/shim';

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -1,4 +1,4 @@
-import { SentryEvent, SentryException, Stacktrace } from '@sentry/core';
+import { SentryEvent, SentryException, Stacktrace } from '@sentry/shim';
 import { clone } from '@sentry/utils';
 import { getApp } from './utils';
 

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,0 +1,64 @@
+import { createAndBind } from '@sentry/core';
+import { _callOnClient, getCurrentClient, SentryEvent } from '@sentry/shim';
+import { ElectronOptions } from './backend';
+import { ElectronFrontend } from './frontend';
+
+/**
+ * The Sentry Electron SDK Client.
+ *
+ * To use this SDK, call the {@link Sdk.create} function as early as possible
+ * in the entry modules. This applies to the main process as well as all
+ * renderer processes or further sub processes you spawn. To set context
+ * information or send manual events, use the provided methods.
+ *
+ * @example
+ * const { SentryClient } = require('@sentry/electron');
+ *
+ * SentryClient.create({
+ *   dsn: '__DSN__',
+ *   // ...
+ * });
+ *
+ * @example
+ * SentryClient.setContext({
+ *   extra: { battery: 0.7 },
+ *   tags: { user_mode: 'admin' },
+ *   user: { id: '4711' },
+ * });
+ *
+ * @example
+ * SentryClient.addBreadcrumb({
+ *   message: 'My Breadcrumb',
+ *   // ...
+ * });
+ *
+ * @example
+ * SentryClient.captureMessage('Hello, world!');
+ * SentryClient.captureException(new Error('Good bye'));
+ * SentryClient.captureEvent({
+ *   message: 'Manual',
+ *   stacktrace: [
+ *     // ...
+ *   ],
+ * });
+ *
+ * @see ElectronOptions for documentation on configuration options.
+ */
+export function create(options: ElectronOptions): void {
+  createAndBind(ElectronFrontend, options);
+}
+
+/** Returns the current ElectronFrontend, if any. */
+export function getCurrentFrontend(): ElectronFrontend {
+  return getCurrentClient() as ElectronFrontend;
+}
+
+/**
+ * TODO
+ *
+ * @param path
+ * @param event
+ */
+export function captureMinidump(path: string, event: SentryEvent = {}): void {
+  _callOnClient('captureMinidump', path, event);
+}

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -6,36 +6,39 @@ import { ElectronFrontend } from './frontend';
 /**
  * The Sentry Electron SDK Client.
  *
- * To use this SDK, call the {@link Sdk.create} function as early as possible
- * in the entry modules. This applies to the main process as well as all
- * renderer processes or further sub processes you spawn. To set context
- * information or send manual events, use the provided methods.
+ * To use this SDK, call the {@link create} function as early as possible in the
+ * entry modules. This applies to the main process as well as all renderer
+ * processes or further sub processes you spawn. To set context information or
+ * send manual events, use the provided methods.
  *
  * @example
- * const { SentryClient } = require('@sentry/electron');
+ * const { create } = require('@sentry/electron');
  *
- * SentryClient.create({
+ * create({
  *   dsn: '__DSN__',
  *   // ...
  * });
  *
  * @example
- * SentryClient.setContext({
+ * import { setContext } from '@sentry/electron';
+ * setContext({
  *   extra: { battery: 0.7 },
  *   tags: { user_mode: 'admin' },
  *   user: { id: '4711' },
  * });
  *
  * @example
- * SentryClient.addBreadcrumb({
+ * import { addBreadcrumb } from '@sentry/electron';
+ * addBreadcrumb({
  *   message: 'My Breadcrumb',
  *   // ...
  * });
  *
  * @example
- * SentryClient.captureMessage('Hello, world!');
- * SentryClient.captureException(new Error('Good bye'));
- * SentryClient.captureEvent({
+ * import * as Sentry from '@sentry/electron';
+ * Sentry.captureMessage('Hello, world!');
+ * Sentry.captureException(new Error('Good bye'));
+ * Sentry.captureEvent({
  *   message: 'Manual',
  *   stacktrace: [
  *     // ...
@@ -54,10 +57,10 @@ export function getCurrentFrontend(): ElectronFrontend {
 }
 
 /**
- * TODO
+ * Uploads a native crash dump (Minidump) to Sentry.
  *
- * @param path
- * @param event
+ * @param path The relative or absolute path to the minidump.
+ * @param event Optional event payload to attach to the minidump.
  */
 export function captureMinidump(path: string, event: SentryEvent = {}): void {
   _callOnClient('captureMinidump', path, event);

--- a/src/uploader.ts
+++ b/src/uploader.ts
@@ -30,7 +30,8 @@ const MAX_REQUESTS_COUNT = 10;
 type CrashReporterType = 'crashpad' | 'breakpad';
 
 /**
- * TODO
+ * Payload for a minidump request comprising a persistent file system path and
+ * event metadata.
  */
 export interface MinidumpRequest {
   /** Path to the minidump file. */
@@ -52,7 +53,10 @@ export class MinidumpUploader {
   /** List of minidumps that have been found already. */
   private readonly knownPaths: string[];
 
-  /** Store to persist queued Minidumps beyond application crashes or lost internet connection. */
+  /**
+   * Store to persist queued Minidumps beyond application crashes or lost
+   * internet connection.
+   */
   private readonly queue: Store<MinidumpRequest[]> = new Store(
     this.cacheDirectory,
     'queue',
@@ -164,8 +168,8 @@ export class MinidumpUploader {
 
   /** Scans the Crashpad directory structure for minidump files. */
   private async scanCrashpadFolder(): Promise<string[]> {
-    // Crashpad moves minidump files directly into the completed/ folder. We
-    // can load them from there, upload to the server, and then delete it.
+    // Crashpad moves minidump files directly into the completed/ folder. We can
+    // load them from there, upload to the server, and then delete it.
     const dumpDirectory = join(this.crashesDirectory, 'completed');
     const files = await readdir(dumpDirectory);
     return files
@@ -175,8 +179,8 @@ export class MinidumpUploader {
 
   /** Scans the Breakpad directory structure for minidump files. */
   private async scanBreakpadFolder(): Promise<string[]> {
-    // Breakpad stores all minidump files along with a metadata file directly
-    // in the crashes directory.
+    // Breakpad stores all minidump files along with a metadata file directly in
+    // the crashes directory.
     const files = await readdir(this.crashesDirectory);
 
     // Remove all metadata files (asynchronously) and forget about them.

--- a/src/uploader.ts
+++ b/src/uploader.ts
@@ -6,7 +6,8 @@ import { platform } from 'os';
 import { basename, join } from 'path';
 import { promisify } from 'util';
 
-import { DSN, SentryEvent } from '@sentry/core';
+import { DSN } from '@sentry/core';
+import { SentryEvent } from '@sentry/shim';
 import { filterAsync, mkdirp, Store } from '@sentry/utils';
 import * as FormData from 'form-data';
 import fetch from 'node-fetch';

--- a/test/e2e/context.ts
+++ b/test/e2e/context.ts
@@ -64,7 +64,7 @@ export class TestContext {
     const env: { [key: string]: string | undefined } = {
       ...process.env,
       DSN:
-        'http://37f8a2ee37c0409d8970bc7559c7c7e4:4cfde0ca506c4ea39b4e25b61a1ff1c3@localhost:8000/277345',
+        'http://37f8a2ee37c0409d8970bc7559c7c7e4:4cfde0ca506c4ea39b4e25b61a1ff1c3@localhost:8123/277345',
       E2E_TEST_SENTRY: sentryConfig,
       E2E_USERDATA_DIRECTORY: this.tempDir.path,
     };
@@ -74,7 +74,9 @@ export class TestContext {
     }
 
     const childProcess = spawn(this.electronPath, [this.appPath], { env });
-
+    childProcess.stdout.on('data', data => {
+      process.stdout.write(data.toString());
+    });
     this.mainProcess = new ProcessStatus(childProcess.pid);
 
     await this.waitForTrue(

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -110,7 +110,7 @@ describe('Basic Tests', () => {
     expect(breadcrumbs.length).to.greaterThan(5);
   });
 
-  it.only('Native crash in renderer process', async () => {
+  it('Native crash in renderer process', async () => {
     await context.start('sentry-basic', 'native-renderer');
     // It can take rather a long time to get the event on Mac
     await context.waitForEvents(1, 20000);

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -59,12 +59,12 @@ describe('Basic Tests', () => {
     const breadcrumbs = event.data.breadcrumbs || [];
     const lastFrame = getLastFrame(event.data);
 
-    const mainRunning = context.mainProcess
-      ? await context.mainProcess.isRunning()
-      : false;
-
-    // The default is not to terminate the main process on js error
-    expect(mainRunning).to.equal(true);
+    // wait for the main process to exit (default behavior)
+    await context.waitForTrue(
+      async () =>
+        context.mainProcess ? !await context.mainProcess.isRunning() : false,
+      'Timeout: Waiting for app to die',
+    );
 
     expect(context.testServer.events.length).to.equal(1);
     expect(lastFrame.filename).to.equal('app:///fixtures/javascript-main.js');
@@ -89,7 +89,7 @@ describe('Basic Tests', () => {
     expect(breadcrumbs.length).to.greaterThan(5);
   });
 
-  it('onFatalError can be overridden to exit app', async () => {
+  it('onFatalError can be overridden', async () => {
     await context.start('sentry-onfatal-exit', 'javascript-main');
     await context.waitForEvents(1);
     const event = context.testServer.events[0];

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -110,7 +110,7 @@ describe('Basic Tests', () => {
     expect(breadcrumbs.length).to.greaterThan(5);
   });
 
-  it('Native crash in renderer process', async () => {
+  it.only('Native crash in renderer process', async () => {
     await context.start('sentry-basic', 'native-renderer');
     // It can take rather a long time to get the event on Mac
     await context.waitForEvents(1, 20000);

--- a/test/e2e/server.ts
+++ b/test/e2e/server.ts
@@ -3,7 +3,7 @@
 import { readFileSync } from 'fs';
 import * as http from 'http';
 
-import { SentryEvent } from '@sentry/core';
+import { SentryEvent } from '@sentry/shim';
 import * as bodyParser from 'body-parser';
 import * as express from 'express';
 import * as finalhandler from 'finalhandler';

--- a/test/e2e/server.ts
+++ b/test/e2e/server.ts
@@ -92,6 +92,7 @@ export class TestServer {
       app(req as any, res as any, finalhandler(req, res));
     });
 
+    // Changed to port to 8123 because sentry uses 8000 if run locally
     this.server.listen(8123);
   }
 

--- a/test/e2e/server.ts
+++ b/test/e2e/server.ts
@@ -92,7 +92,7 @@ export class TestServer {
       app(req as any, res as any, finalhandler(req, res));
     });
 
-    this.server.listen(8000);
+    this.server.listen(8123);
   }
 
   /** Stops accepting requests and closes the server. */

--- a/test/e2e/test-app/fixtures/native-main.js
+++ b/test/e2e/test-app/fixtures/native-main.js
@@ -1,4 +1,5 @@
-
-if(process.type === 'browser'){
-  process.crash();
+if (process.type === 'browser') {
+  setTimeout(() => {
+    process.crash();
+  }, 100);
 }

--- a/test/e2e/test-app/fixtures/native-renderer.js
+++ b/test/e2e/test-app/fixtures/native-renderer.js
@@ -1,4 +1,5 @@
-
-if(process.type === 'renderer'){
-  process.crash();
+if (process.type === 'renderer') {
+  setTimeout(() => {
+    process.crash();
+  }, 100);
 }

--- a/test/e2e/test-app/fixtures/sentry-basic.js
+++ b/test/e2e/test-app/fixtures/sentry-basic.js
@@ -1,5 +1,5 @@
-const { SentryClient } = require('../../../../');
+const { create } = require('../../../../');
 
-SentryClient.create({
+create({
   dsn: process.env.DSN,
 });

--- a/test/e2e/test-app/fixtures/sentry-onfatal-exit.js
+++ b/test/e2e/test-app/fixtures/sentry-onfatal-exit.js
@@ -1,12 +1,11 @@
-const { SentryClient } = require('../../../../');
+const { create, captureException } = require('../../../../');
 const { app } = require('electron');
 
-SentryClient.create({
+create({
   dsn: process.env.DSN,
-  onFatalError: (error) => {
-    SentryClient.captureException(error)
-      .then(() => {
-        app.exit();
-      });
-  }
+  onFatalError: error => {
+    captureException(error).then(() => {
+      app.exit();
+    });
+  },
 });

--- a/test/e2e/test-app/fixtures/sentry-onfatal-exit.js
+++ b/test/e2e/test-app/fixtures/sentry-onfatal-exit.js
@@ -1,11 +1,9 @@
-const { create, captureException } = require('../../../../');
+const { create, captureMessage } = require('../../../../');
 const { app } = require('electron');
 
 create({
   dsn: process.env.DSN,
   onFatalError: error => {
-    captureException(error).then(() => {
-      app.exit();
-    });
+    app.exit();
   },
 });

--- a/test/e2e/utils.ts
+++ b/test/e2e/utils.ts
@@ -1,4 +1,4 @@
-import { SentryEvent, StackFrame } from '@sentry/core';
+import { SentryEvent, StackFrame } from '@sentry/shim';
 
 /** Get stack frames from SentryEvent */
 function getFrames(event: SentryEvent): StackFrame[] {

--- a/test/tslint.json
+++ b/test/tslint.json
@@ -1,7 +1,10 @@
 {
   "rules": {
     "await-promise": [true, "Client"],
-    "no-implicit-dependencies": [true, "dev"]
+    "completed-docs": false,
+    "no-non-null-assertion": false,
+    "no-implicit-dependencies": [true, "dev"],
+    "no-unused-expression": false
   },
   "extends": ["../tslint.json"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,41 +2,41 @@
 # yarn lockfile v1
 
 
-"@sentry/browser@0.5.0-beta.2":
-  version "0.5.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-0.5.0-beta.2.tgz#45d39160be18b7eadf8af629f1656b0b69037783"
+"@sentry/browser@0.5.0-beta.3":
+  version "0.5.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-0.5.0-beta.3.tgz#6a1d15e35000af084e6ecb80356371d7751dc019"
   dependencies:
-    "@sentry/core" "0.5.0-beta.2"
-    "@sentry/shim" "0.5.0-beta.2"
-    raven-js "^3.23.3"
+    "@sentry/core" "0.5.0-beta.3"
+    "@sentry/shim" "0.5.0-beta.3"
+    raven-js "^3.24.0"
 
-"@sentry/core@0.5.0-beta.2":
-  version "0.5.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-0.5.0-beta.2.tgz#c3860242bfb0bdba37c7e66c06a9973a2ca2deec"
+"@sentry/core@0.5.0-beta.3":
+  version "0.5.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-0.5.0-beta.3.tgz#7834e6d026f67934dd26d74c55e1b030c4edec2b"
   dependencies:
-    "@sentry/shim" "0.5.0-beta.2"
+    "@sentry/shim" "0.5.0-beta.3"
 
-"@sentry/node@0.5.0-beta.2":
-  version "0.5.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-0.5.0-beta.2.tgz#8f046d15edf5fcfe08ece139b3a3a8ebfa163d1c"
+"@sentry/node@0.5.0-beta.3":
+  version "0.5.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-0.5.0-beta.3.tgz#9df2c131f170b913f6dde3ed9d3392d65e553b75"
   dependencies:
-    "@sentry/core" "0.5.0-beta.2"
-    "@sentry/shim" "0.5.0-beta.2"
+    "@sentry/core" "0.5.0-beta.3"
+    "@sentry/shim" "0.5.0-beta.3"
     raven "^2.4.2"
 
-"@sentry/shim@0.5.0-beta.2":
-  version "0.5.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@sentry/shim/-/shim-0.5.0-beta.2.tgz#ee4b83f01cde82ef1a9a9a02685aaeceeb694ab3"
+"@sentry/shim@0.5.0-beta.3":
+  version "0.5.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@sentry/shim/-/shim-0.5.0-beta.3.tgz#e1cdab05287078c9f45129483e49ab3cb535e929"
 
-"@sentry/typescript@0.5.0-beta.2":
-  version "0.5.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@sentry/typescript/-/typescript-0.5.0-beta.2.tgz#7f6ee5094872c0bad6df29c42e9f31130d2d33fe"
+"@sentry/typescript@0.5.0-beta.3":
+  version "0.5.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@sentry/typescript/-/typescript-0.5.0-beta.3.tgz#a90bcd88057b49223cfcce551c86c02afe6b706c"
   dependencies:
-    tslint-config-prettier "^1.9.0"
+    tslint-config-prettier "^1.10.0"
 
-"@sentry/utils@0.5.0-beta.2":
-  version "0.5.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-0.5.0-beta.2.tgz#e8368ec9e762842d1a7108a65fba480c82b864b4"
+"@sentry/utils@0.5.0-beta.3":
+  version "0.5.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-0.5.0-beta.3.tgz#14f22a3181115352f15a3149a3df89381aa23d20"
 
 "@types/body-parser@*", "@types/body-parser@^1.16.8":
   version "1.16.8"
@@ -1480,7 +1480,7 @@ range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
-raven-js@^3.23.3:
+raven-js@^3.24.0:
   version "3.24.0"
   resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.24.0.tgz#59464d8bc4b3812ae87a282e9bb98ecad5b4b047"
 
@@ -1906,7 +1906,7 @@ tslib@1.9.0, tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
 
-tslint-config-prettier@^1.9.0:
+tslint-config-prettier@^1.10.0, tslint-config-prettier@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.10.0.tgz#5063c413d43de4f6988c73727f65ecfc239054ec"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,43 +2,41 @@
 # yarn lockfile v1
 
 
-"@sentry/browser@^0.5.0-beta.1":
-  version "0.5.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-0.5.0-beta.1.tgz#ca27cc3c2f8aa911917a50fc1c03c206a027d897"
+"@sentry/browser@0.5.0-beta.2":
+  version "0.5.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-0.5.0-beta.2.tgz#45d39160be18b7eadf8af629f1656b0b69037783"
   dependencies:
-    "@sentry/core" "0.5.0-beta.1"
-    "@sentry/shim" "0.5.0-beta.1"
+    "@sentry/core" "0.5.0-beta.2"
+    "@sentry/shim" "0.5.0-beta.2"
     raven-js "^3.23.3"
 
-"@sentry/core@0.5.0-beta.1", "@sentry/core@^0.5.0-beta.1":
-  version "0.5.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-0.5.0-beta.1.tgz#d3a0a0cc94dd386c998d2545fe30e9fb7445843f"
+"@sentry/core@0.5.0-beta.2":
+  version "0.5.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-0.5.0-beta.2.tgz#c3860242bfb0bdba37c7e66c06a9973a2ca2deec"
   dependencies:
-    "@sentry/shim" "0.5.0-beta.1"
-    "@sentry/utils" "0.5.0-beta.1"
+    "@sentry/shim" "0.5.0-beta.2"
 
-"@sentry/node@^0.5.0-beta.1":
-  version "0.5.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-0.5.0-beta.1.tgz#def989f595f14730d06a552249f5b74329a15ae5"
+"@sentry/node@0.5.0-beta.2":
+  version "0.5.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-0.5.0-beta.2.tgz#8f046d15edf5fcfe08ece139b3a3a8ebfa163d1c"
   dependencies:
-    "@sentry/core" "0.5.0-beta.1"
-    "@sentry/shim" "0.5.0-beta.1"
-    "@sentry/utils" "0.5.0-beta.1"
+    "@sentry/core" "0.5.0-beta.2"
+    "@sentry/shim" "0.5.0-beta.2"
     raven "^2.4.2"
 
-"@sentry/shim@0.5.0-beta.1", "@sentry/shim@^0.5.0-beta.1":
-  version "0.5.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@sentry/shim/-/shim-0.5.0-beta.1.tgz#b770fad1b95ebe0c15bbc9e8d45899b47ba3cd29"
+"@sentry/shim@0.5.0-beta.2":
+  version "0.5.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@sentry/shim/-/shim-0.5.0-beta.2.tgz#ee4b83f01cde82ef1a9a9a02685aaeceeb694ab3"
 
-"@sentry/typescript@^0.5.0-beta.1":
-  version "0.5.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@sentry/typescript/-/typescript-0.5.0-beta.1.tgz#ae142925af003f82aeced7dc15ed67687fa7bab0"
+"@sentry/typescript@0.5.0-beta.2":
+  version "0.5.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@sentry/typescript/-/typescript-0.5.0-beta.2.tgz#7f6ee5094872c0bad6df29c42e9f31130d2d33fe"
   dependencies:
     tslint-config-prettier "^1.9.0"
 
-"@sentry/utils@0.5.0-beta.1", "@sentry/utils@^0.5.0-beta.1":
-  version "0.5.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-0.5.0-beta.1.tgz#6c52313a4e64c70e937ace31152703f5125e1d1d"
+"@sentry/utils@0.5.0-beta.2":
+  version "0.5.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-0.5.0-beta.2.tgz#e8368ec9e762842d1a7108a65fba480c82b864b4"
 
 "@types/body-parser@*", "@types/body-parser@^1.16.8":
   version "1.16.8"
@@ -109,12 +107,12 @@
     "@types/node" "*"
 
 "@types/node@*":
-  version "9.4.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.4.7.tgz#57d81cd98719df2c9de118f2d5f3b1120dcd7275"
+  version "9.6.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.1.tgz#e2d374ef15b315b48e7efc308fa1a7cd51faa06c"
 
 "@types/node@^8.0.24":
-  version "8.9.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.9.5.tgz#162b864bc70be077e6db212b322754917929e976"
+  version "8.10.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.1.tgz#aac98b810c50568054486f2bb8c486d824713be8"
 
 "@types/serve-static@*":
   version "1.13.1"
@@ -275,6 +273,12 @@ bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
 
+caller-id@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/caller-id/-/caller-id-0.1.0.tgz#59bdac0893d12c3871408279231f97458364f07b"
+  dependencies:
+    stack-trace "~0.0.7"
+
 camelcase-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
@@ -362,8 +366,8 @@ commander@2.11.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
 commander@^2.12.1, commander@^2.14.1:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.0.tgz#ad2a23a1c3b036e392469b8012cec6b33b4c1322"
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -569,8 +573,8 @@ error-ex@^1.2.0, error-ex@^1.3.1:
     is-arrayish "^0.2.1"
 
 es-abstract@^1.4.3, es-abstract@^1.5.1:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.10.0.tgz#1ecb36c197842a00d8ee4c2dfd8646bb97d60864"
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.11.0.tgz#cce87d518f0496893b1a30cd8461835535480681"
   dependencies:
     es-to-primitive "^1.1.1"
     function-bind "^1.1.1"
@@ -616,7 +620,7 @@ etag@~1.8.1:
 
 event-stream@~3.3.0:
   version "3.3.4"
-  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
+  resolved "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
   dependencies:
     duplexer "~0.1.1"
     from "~0"
@@ -874,7 +878,7 @@ hosted-git-info@^2.1.4:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.6.0.tgz#23235b29ab230c576aab0d4f13fc046b0b038222"
 
-http-errors@1.6.2, http-errors@~1.6.2:
+http-errors@1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.2.tgz#0a002cc85707192a7e7946ceedc11155f60ec736"
   dependencies:
@@ -882,6 +886,15 @@ http-errors@1.6.2, http-errors@~1.6.2:
     inherits "2.0.3"
     setprototypeof "1.0.3"
     statuses ">= 1.3.1 < 2"
+
+http-errors@~1.6.2:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.3"
+    setprototypeof "1.1.0"
+    statuses ">= 1.4.0 < 2"
 
 http-router@^0.5.0:
   version "0.5.0"
@@ -1191,8 +1204,8 @@ mkdirp@0.5.1, mkdirp@^0.5.1:
     minimist "0.0.8"
 
 mocha@^5.0.1, mocha@^5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.0.4.tgz#6b7aa328472da1088e69d47e75925fd3a3bb63c6"
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.0.5.tgz#e228e3386b9387a4710007a641f127b00be44b52"
   dependencies:
     browser-stdout "1.3.1"
     commander "2.11.0"
@@ -1204,6 +1217,12 @@ mocha@^5.0.1, mocha@^5.0.4:
     he "1.1.1"
     mkdirp "0.5.1"
     supports-color "4.4.0"
+
+mock-require@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/mock-require/-/mock-require-2.0.2.tgz#1eaa71aad23013773d127dc7e91a3fbb4837d60d"
+  dependencies:
+    caller-id "^0.1.0"
 
 ms@2.0.0:
   version "2.0.0"
@@ -1220,8 +1239,8 @@ negotiator@0.6.1:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
 node-fetch@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.1.tgz#369ca70b82f50c86496104a6c776d274f4e4a2d4"
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
 
 node-fingerprint@0.0.2:
   version "0.0.2"
@@ -1578,8 +1597,8 @@ request@^2.45.0:
     uuid "^3.1.0"
 
 resolve@^1.3.2:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.6.0.tgz#0fbd21278b27b4004481c395349e7aba60a9ff5c"
   dependencies:
     path-parse "^1.0.5"
 
@@ -1668,8 +1687,8 @@ sntp@2.x.x:
     hoek "4.x.x"
 
 source-map-support@^0.5.3:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.3.tgz#2b3d5fff298cfa4d1afd7d4352d569e9a0158e76"
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.4.tgz#54456efa89caa9270af7cd624cc2f123e51fbae8"
   dependencies:
     source-map "^0.6.0"
 
@@ -1731,7 +1750,15 @@ stack-trace@0.0.9:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.9.tgz#a8f6eaeca90674c333e7c43953f275b451510695"
 
-"statuses@>= 1.3.1 < 2", statuses@~1.4.0:
+stack-trace@~0.0.7:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+
+"statuses@>= 1.3.1 < 2", "statuses@>= 1.4.0 < 2":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
+
+statuses@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
 
@@ -1892,8 +1919,10 @@ tslint-eslint-rules@^5.1.0:
     tsutils "2.8.0"
 
 tslint-language-service@^0.9.8:
-  version "0.9.8"
-  resolved "https://registry.yarnpkg.com/tslint-language-service/-/tslint-language-service-0.9.8.tgz#22a6f2f926b7c0a4cafed3ae1f65021e8008dc96"
+  version "0.9.9"
+  resolved "https://registry.yarnpkg.com/tslint-language-service/-/tslint-language-service-0.9.9.tgz#f546dc38483979e6fb3cfa59584ad8525b3ad4da"
+  dependencies:
+    mock-require "^2.0.2"
 
 tslint@^5.9.1:
   version "5.9.1"
@@ -1919,8 +1948,8 @@ tsutils@2.8.0:
     tslib "^1.7.1"
 
 tsutils@^2.12.1:
-  version "2.22.2"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.22.2.tgz#0b9f3d87aa3eb95bd32d26ce2b88aa329a657951"
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.25.0.tgz#14d616ef59224a3c9fb7eb483e1c182b6665ae5e"
   dependencies:
     tslib "^1.8.1"
 
@@ -1950,8 +1979,8 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
 typescript@^2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.1.tgz#6160e4f8f195d5ba81d4876f9c0cc1fbc0820624"
 
 universalify@^0.1.0:
   version "0.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,39 +2,43 @@
 # yarn lockfile v1
 
 
-"@sentry/browser@0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-0.4.2.tgz#bd91752558d2e92adbd1f4b1dcd78efd92c7d2ed"
+"@sentry/browser@^0.5.0-beta.1":
+  version "0.5.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-0.5.0-beta.1.tgz#ca27cc3c2f8aa911917a50fc1c03c206a027d897"
   dependencies:
-    "@sentry/core" "0.4.2"
-    "@sentry/utils" "0.4.2"
-    raven-js "^3.23.1"
+    "@sentry/core" "0.5.0-beta.1"
+    "@sentry/shim" "0.5.0-beta.1"
+    raven-js "^3.23.3"
 
-"@sentry/core@0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-0.4.2.tgz#3922c61b42519d9b67cd49da39f214a1d92b7f84"
-
-"@sentry/node@0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-0.4.2.tgz#3fcc890cdff157fbb488a130ba83b7f68b57aacd"
+"@sentry/core@0.5.0-beta.1", "@sentry/core@^0.5.0-beta.1":
+  version "0.5.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-0.5.0-beta.1.tgz#d3a0a0cc94dd386c998d2545fe30e9fb7445843f"
   dependencies:
-    "@sentry/core" "0.4.2"
-    "@sentry/utils" "0.4.2"
+    "@sentry/shim" "0.5.0-beta.1"
+    "@sentry/utils" "0.5.0-beta.1"
+
+"@sentry/node@^0.5.0-beta.1":
+  version "0.5.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-0.5.0-beta.1.tgz#def989f595f14730d06a552249f5b74329a15ae5"
+  dependencies:
+    "@sentry/core" "0.5.0-beta.1"
+    "@sentry/shim" "0.5.0-beta.1"
+    "@sentry/utils" "0.5.0-beta.1"
     raven "^2.4.2"
 
-"@sentry/shim@^0.5.0-beta.0":
-  version "0.5.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@sentry/shim/-/shim-0.5.0-beta.0.tgz#201dcb3a8a01b86bdd24627dc7bc5a9bfe067f38"
+"@sentry/shim@0.5.0-beta.1", "@sentry/shim@^0.5.0-beta.1":
+  version "0.5.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@sentry/shim/-/shim-0.5.0-beta.1.tgz#b770fad1b95ebe0c15bbc9e8d45899b47ba3cd29"
 
-"@sentry/typescript@0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@sentry/typescript/-/typescript-0.4.2.tgz#bde6a0e29f7382b23f6fc11da67b2a7eded9d03d"
+"@sentry/typescript@^0.5.0-beta.1":
+  version "0.5.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@sentry/typescript/-/typescript-0.5.0-beta.1.tgz#ae142925af003f82aeced7dc15ed67687fa7bab0"
   dependencies:
     tslint-config-prettier "^1.9.0"
 
-"@sentry/utils@0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-0.4.2.tgz#1a951ceee448f0fd2dc146798ee9b93f39c058cf"
+"@sentry/utils@0.5.0-beta.1", "@sentry/utils@^0.5.0-beta.1":
+  version "0.5.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-0.5.0-beta.1.tgz#6c52313a4e64c70e937ace31152703f5125e1d1d"
 
 "@types/body-parser@*", "@types/body-parser@^1.16.8":
   version "1.16.8"
@@ -1457,9 +1461,9 @@ range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
-raven-js@^3.23.1:
-  version "3.23.1"
-  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.23.1.tgz#34a5d7b5b3dd626a3d59e7a264e1d19a4c799cdb"
+raven-js@^3.23.3:
+  version "3.24.0"
+  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.24.0.tgz#59464d8bc4b3812ae87a282e9bb98ecad5b4b047"
 
 raven@^2.4.2:
   version "2.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,6 +22,10 @@
     "@sentry/utils" "0.4.2"
     raven "^2.4.2"
 
+"@sentry/shim@^0.5.0-beta.0":
+  version "0.5.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@sentry/shim/-/shim-0.5.0-beta.0.tgz#201dcb3a8a01b86bdd24627dc7bc5a9bfe067f38"
+
 "@sentry/typescript@0.4.2":
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/@sentry/typescript/-/typescript-0.4.2.tgz#bde6a0e29f7382b23f6fc11da67b2a7eded9d03d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,41 +2,41 @@
 # yarn lockfile v1
 
 
-"@sentry/browser@0.5.0-beta.3":
-  version "0.5.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-0.5.0-beta.3.tgz#6a1d15e35000af084e6ecb80356371d7751dc019"
+"@sentry/browser@0.5.0-beta.4":
+  version "0.5.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-0.5.0-beta.4.tgz#dc757df00598eefdc3dd3c7c62656064a22ac86e"
   dependencies:
-    "@sentry/core" "0.5.0-beta.3"
-    "@sentry/shim" "0.5.0-beta.3"
+    "@sentry/core" "0.5.0-beta.4"
+    "@sentry/shim" "0.5.0-beta.4"
     raven-js "^3.24.0"
 
-"@sentry/core@0.5.0-beta.3":
-  version "0.5.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-0.5.0-beta.3.tgz#7834e6d026f67934dd26d74c55e1b030c4edec2b"
+"@sentry/core@0.5.0-beta.4":
+  version "0.5.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-0.5.0-beta.4.tgz#b1387d896efa620471f9d918f09cae5a68061b29"
   dependencies:
-    "@sentry/shim" "0.5.0-beta.3"
+    "@sentry/shim" "0.5.0-beta.4"
 
-"@sentry/node@0.5.0-beta.3":
-  version "0.5.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-0.5.0-beta.3.tgz#9df2c131f170b913f6dde3ed9d3392d65e553b75"
+"@sentry/node@0.5.0-beta.4":
+  version "0.5.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-0.5.0-beta.4.tgz#6e957b7357b9aeea2118650bfd2002f2e99c82ae"
   dependencies:
-    "@sentry/core" "0.5.0-beta.3"
-    "@sentry/shim" "0.5.0-beta.3"
+    "@sentry/core" "0.5.0-beta.4"
+    "@sentry/shim" "0.5.0-beta.4"
     raven "^2.4.2"
 
-"@sentry/shim@0.5.0-beta.3":
-  version "0.5.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@sentry/shim/-/shim-0.5.0-beta.3.tgz#e1cdab05287078c9f45129483e49ab3cb535e929"
+"@sentry/shim@0.5.0-beta.4":
+  version "0.5.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@sentry/shim/-/shim-0.5.0-beta.4.tgz#b6c4742b4cd44ceb3fc414af926da09f30c84b1a"
 
-"@sentry/typescript@0.5.0-beta.3":
-  version "0.5.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@sentry/typescript/-/typescript-0.5.0-beta.3.tgz#a90bcd88057b49223cfcce551c86c02afe6b706c"
+"@sentry/typescript@0.5.0-beta.4":
+  version "0.5.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@sentry/typescript/-/typescript-0.5.0-beta.4.tgz#675d27e18579351114633d5712c41b63e846f27d"
   dependencies:
     tslint-config-prettier "^1.10.0"
 
-"@sentry/utils@0.5.0-beta.3":
-  version "0.5.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-0.5.0-beta.3.tgz#14f22a3181115352f15a3149a3df89381aa23d20"
+"@sentry/utils@0.5.0-beta.4":
+  version "0.5.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-0.5.0-beta.4.tgz#2adeaf8e6d9c896e63419f04c65d8b412837d179"
 
 "@types/body-parser@*", "@types/body-parser@^1.16.8":
   version "1.16.8"


### PR DESCRIPTION
For now, in order for this to work, I recommend checking out the latest commit of 
https://github.com/getsentry/raven-js/tree/4.0.0-wip locally and run 
`yarn link` in every sub package.
Also, don't forget to run `yarn build` in raven-js to have the latest builds transpiled.
Then run this in `sentry-electron``yarn link @sentry/core @sentry/browser @sentry/node @sentry/utils @sentry/typescript @sentry/shim`

Then everything should work, the new style of calling things for users goes through the shim.
Shim > Frontend > Backend

- [ ] Check context/breadcrumbs persistence
- [ ] Test irl
- [ ] Update Wizard https://github.com/getsentry/sentry-wizard/blob/891c5d5b58e0ad0c9ef9745288f9aae35b18d17f/lib/Steps/Integrations/Electron.ts#L58-L62