### PR TITLE
fix: Limit maxBreadcrumbs to [0;100] and default to 30

### DIFF
--- a/src/backend.ts
+++ b/src/backend.ts
@@ -199,9 +199,11 @@ export class ElectronBackend implements Backend {
     }
 
     // We replicate the behavior of the frontend
-    const { maxBreadcrumbs = 100 } = this.frontend.getOptions();
+    const { maxBreadcrumbs = 30 } = this.frontend.getOptions();
     this.breadcrumbs.update(breadcrumbs =>
-      [...breadcrumbs, breadcrumb].slice(-maxBreadcrumbs),
+      [...breadcrumbs, breadcrumb].slice(
+        -Math.max(0, Math.min(maxBreadcrumbs, 100)),
+      ),
     );
 
     // Still, the frontend should merge breadcrumbs into events, for now


### PR DESCRIPTION
The default for `maxBreadcrumbs` was incorrectly set to `100`. However, documentation says `30`, with a maximum possible value of `100`. This PR fixes this and adds an additional check for negative numbers.