### PR TITLE
Fix: onFatalError test

### DIFF
--- a/test/e2e/context.ts
+++ b/test/e2e/context.ts
@@ -74,9 +74,6 @@ export class TestContext {
     }
 
     const childProcess = spawn(this.electronPath, [this.appPath], { env });
-    childProcess.stdout.on('data', data => {
-      process.stdout.write(data.toString());
-    });
     this.mainProcess = new ProcessStatus(childProcess.pid);
 
     await this.waitForTrue(

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -90,24 +90,24 @@ describe('Basic Tests', () => {
   });
 
   it('onFatalError can be overridden', async () => {
-    await context.start('sentry-onfatal-exit', 'javascript-main');
+    await context.start('sentry-onfatal-dont-exit', 'javascript-main');
     await context.waitForEvents(1);
     const event = context.testServer.events[0];
     const breadcrumbs = event.data.breadcrumbs || [];
     const lastFrame = getLastFrame(event.data);
-
-    // wait for the main process to die
-    await context.waitForTrue(
-      async () =>
-        context.mainProcess ? !await context.mainProcess.isRunning() : false,
-      'Timeout: Waiting for app to die',
-    );
 
     expect(context.testServer.events.length).to.equal(1);
     expect(lastFrame.filename).to.equal('app:///fixtures/javascript-main.js');
     expect(event.dump_file).to.equal(undefined);
     expect(event.sentry_key).to.equal(SENTRY_KEY);
     expect(breadcrumbs.length).to.greaterThan(5);
+
+    // Ensure the main process is still alive
+    await context.waitForTrue(
+      async () =>
+        context.mainProcess ? context.mainProcess.isRunning() : false,
+      'Timeout: Ensure app is still alive',
+    );
   });
 
   it('Native crash in renderer process', async () => {

--- a/test/e2e/preload-app/main.js
+++ b/test/e2e/preload-app/main.js
@@ -16,6 +16,7 @@ app.on('ready', () => {
     width: 800,
     height: 600,
     titleBarStyle: 'hidden',
+    show: false,
     webPreferences: {
       preload: sentryPath,
       nodeIntegration: false

--- a/test/e2e/test-app/fixtures/sentry-onfatal-dont-exit.js
+++ b/test/e2e/test-app/fixtures/sentry-onfatal-dont-exit.js
@@ -4,6 +4,6 @@ const { app } = require('electron');
 init({
   dsn: process.env.DSN,
   onFatalError: error => {
-    app.exit();
+
   },
 });

--- a/test/e2e/test-app/main.js
+++ b/test/e2e/test-app/main.js
@@ -14,6 +14,7 @@ app.on('ready', () => {
     width: 800,
     height: 600,
     titleBarStyle: 'hidden',
+    show: false
   });
 
   window.loadURL(


### PR DESCRIPTION
`onFatalError` default behaviour has been changed so that the default is to kill the process. This fixes the test to ensure it can be overridden to disable this.

Also fixes:
- Electron stdout outputted inline with test results
- Electron windows hidden while running e2e tests