### PR TITLE
fix: Check linux distribution files in correct order

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,6 +4,7 @@
   "exclude": ["node_modules"],
   "compilerOptions": {
     "baseUrl": ".",
+    "lib": ["es7", "dom"],
     "outDir": "dist",
     "rootDir": "src",
     "target": "es6"


### PR DESCRIPTION
The linux distributions need to be checked in a certain order, obviously.