### PR TITLE
Fixed Deep Dive URLs to point to the new locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ Sentry.captureEvent({
 
 ## Deep Dive
 
-* [Configuration](https://docs.sentry.io/clients/electron/config/)
-* [JavaScript Usage](https://docs.sentry.io/clients/electron/javascript/)
-* [Native Usage](https://docs.sentry.io/clients/electron/native/)
-* [Source Maps](https://docs.sentry.io/clients/electron/sourcemaps/)
+* [Configuration](https://docs.sentry.io/platforms/javascript/electron/#configuring-the-client)
+* [JavaScript Usage](https://docs.sentry.io/platforms/javascript/electron/)
+* [Native Usage](https://docs.sentry.io/platforms/javascript/electron/native/)
+* [Source Maps](https://docs.sentry.io/platforms/javascript/electron/sourcemaps/)
 
 ## Resources
 


### PR DESCRIPTION
The README Deep Dive section URLs are all 404 now. This PR fixes those links to point to the new URLs.