### PR TITLE
Fix: Change Electron integration functionality 

### DIFF
--- a/src/main/backend.ts
+++ b/src/main/backend.ts
@@ -2,8 +2,6 @@ import {
   app,
   crashReporter,
   ipcMain,
-  powerMonitor,
-  screen,
   // tslint:disable-next-line:no-implicit-dependencies
 } from 'electron';
 import { join } from 'path';
@@ -26,7 +24,8 @@ import { Store } from '@sentry/utils/store';
 
 import { CommonBackend, ElectronOptions, IPC_CRUMB, IPC_EVENT, IPC_PING, IPC_SCOPE } from '../common';
 import { captureMinidump } from '../sdk';
-import { normalizeUrl } from './normalize';
+import { addEventDefaults } from './context';
+import { normalizeEvent, normalizeUrl } from './normalize';
 import { MinidumpUploader } from './uploader';
 
 /** Patch to access internal CrashReporter functionality. */
@@ -105,6 +104,8 @@ export class MainBackend extends BaseBackend<ElectronOptions> implements CommonB
           scope.addBreadcrumb(crumb);
         });
       }
+
+      scope.addEventProcessor(async (event: SentryEvent) => normalizeEvent(await addEventDefaults(event)));
     });
 
     if (this.isNativeEnabled()) {
@@ -112,7 +113,6 @@ export class MainBackend extends BaseBackend<ElectronOptions> implements CommonB
     }
 
     this.installIPC();
-    this.installAutoBreadcrumbs();
 
     return success;
   }
@@ -277,53 +277,6 @@ export class MainBackend extends BaseBackend<ElectronOptions> implements CommonB
         }
       });
     });
-  }
-
-  /**
-   * Installs auto-breadcrumb handlers for certain Electron events.
-   * TODO: Consider moving to integration
-   */
-  private installAutoBreadcrumbs(): void {
-    this.instrumentBreadcrumbs('app', app);
-
-    app.once('ready', () => {
-      // We can't access these until 'ready'
-      this.instrumentBreadcrumbs('Screen', screen);
-      this.instrumentBreadcrumbs('PowerMonitor', powerMonitor);
-    });
-
-    app.on('web-contents-created', (_, contents) => {
-      // SetImmediate is required for contents.id to be correct
-      // https://github.com/electron/electron/issues/12036
-      setImmediate(() => {
-        this.instrumentBreadcrumbs(`WebContents[${contents.id}]`, contents, ['dom-ready', 'load-url', 'destroyed']);
-      });
-    });
-  }
-
-  /**
-   * Hooks into the Electron EventEmitter to capture breadcrumbs for the
-   * specified events.
-   * TODO: Consider moving to integration
-   */
-  private instrumentBreadcrumbs(category: string, emitter: Electron.EventEmitter, events: string[] = []): void {
-    type Emit = (event: string, ...args: any[]) => boolean;
-    const emit = emitter.emit.bind(emitter) as Emit;
-
-    emitter.emit = (event, ...args) => {
-      if (events.length === 0 || events.indexOf(event) > -1) {
-        const breadcrumb = {
-          category: 'electron',
-          message: `${category}.${event}`,
-          timestamp: new Date().getTime() / 1000,
-          type: 'ui',
-        };
-
-        addBreadcrumb(breadcrumb);
-      }
-
-      return emit(event, ...args);
-    };
   }
 
   /** Loads new native crashes from disk and sends them to Sentry. */

--- a/src/main/backend.ts
+++ b/src/main/backend.ts
@@ -24,8 +24,7 @@ import { Store } from '@sentry/utils/store';
 
 import { CommonBackend, ElectronOptions, IPC_CRUMB, IPC_EVENT, IPC_PING, IPC_SCOPE } from '../common';
 import { captureMinidump } from '../sdk';
-import { addEventDefaults } from './context';
-import { normalizeEvent, normalizeUrl } from './normalize';
+import { normalizeUrl } from './normalize';
 import { MinidumpUploader } from './uploader';
 
 /** Patch to access internal CrashReporter functionality. */
@@ -104,8 +103,6 @@ export class MainBackend extends BaseBackend<ElectronOptions> implements CommonB
           scope.addBreadcrumb(crumb);
         });
       }
-
-      scope.addEventProcessor(async (event: SentryEvent) => normalizeEvent(await addEventDefaults(event)));
     });
 
     if (this.isNativeEnabled()) {

--- a/src/main/client.ts
+++ b/src/main/client.ts
@@ -3,6 +3,8 @@ import { Breadcrumb, SentryBreadcrumbHint, SentryEvent, SentryEventHint, SentryR
 import { CommonClient, ElectronOptions } from '../common';
 import { SDK_NAME } from '../sdk';
 import { MainBackend } from './backend';
+import { normalizeEvent } from './normalize';
+import { addEventDefaults } from './context';
 
 /** SDK version used in every event. */
 // tslint:disable-next-line
@@ -35,7 +37,7 @@ export class MainClient extends BaseClient<MainBackend, ElectronOptions> impleme
       version: SDK_VERSION,
     };
 
-    return super.prepareEvent(event, scope, hint);
+    return super.prepareEvent(normalizeEvent(await addEventDefaults(event)), scope, hint);
   }
 
   /**

--- a/src/main/client.ts
+++ b/src/main/client.ts
@@ -3,8 +3,8 @@ import { Breadcrumb, SentryBreadcrumbHint, SentryEvent, SentryEventHint, SentryR
 import { CommonClient, ElectronOptions } from '../common';
 import { SDK_NAME } from '../sdk';
 import { MainBackend } from './backend';
-import { normalizeEvent } from './normalize';
 import { addEventDefaults } from './context';
+import { normalizeEvent } from './normalize';
 
 /** SDK version used in every event. */
 // tslint:disable-next-line

--- a/src/main/integrations/electron.ts
+++ b/src/main/integrations/electron.ts
@@ -1,7 +1,11 @@
 import { getCurrentHub } from '@sentry/node';
-import { Integration, SentryEvent } from '@sentry/types';
-import { addEventDefaults } from '../context';
-import { normalizeEvent } from '../normalize';
+import { Integration } from '@sentry/types';
+import {
+  app,
+  powerMonitor,
+  screen,
+  // tslint:disable-next-line:no-implicit-dependencies
+} from 'electron';
 
 /** Electron integration that cleans up the event. */
 export class Electron implements Integration {
@@ -14,8 +18,45 @@ export class Electron implements Integration {
    * @inheritDoc
    */
   public install(): void {
-    getCurrentHub().configureScope(scope => {
-      scope.addEventProcessor(async (event: SentryEvent) => normalizeEvent(await addEventDefaults(event)));
+    this.instrumentBreadcrumbs('app', app);
+
+    app.once('ready', () => {
+      // We can't access these until 'ready'
+      this.instrumentBreadcrumbs('Screen', screen);
+      this.instrumentBreadcrumbs('PowerMonitor', powerMonitor);
     });
+
+    app.on('web-contents-created', (_, contents) => {
+      // SetImmediate is required for contents.id to be correct
+      // https://github.com/electron/electron/issues/12036
+      setImmediate(() => {
+        this.instrumentBreadcrumbs(`WebContents[${contents.id}]`, contents, ['dom-ready', 'load-url', 'destroyed']);
+      });
+    });
+  }
+
+  /**
+   * Hooks into the Electron EventEmitter to capture breadcrumbs for the
+   * specified events.
+   * TODO: Consider moving to integration
+   */
+  private instrumentBreadcrumbs(category: string, emitter: Electron.EventEmitter, events: string[] = []): void {
+    type Emit = (event: string, ...args: any[]) => boolean;
+    const emit = emitter.emit.bind(emitter) as Emit;
+
+    emitter.emit = (event, ...args) => {
+      if (events.length === 0 || events.indexOf(event) > -1) {
+        const breadcrumb = {
+          category: 'electron',
+          message: `${category}.${event}`,
+          timestamp: new Date().getTime() / 1000,
+          type: 'ui',
+        };
+
+        getCurrentHub().addBreadcrumb(breadcrumb);
+      }
+
+      return emit(event, ...args);
+    };
   }
 }

--- a/src/main/integrations/electron.ts
+++ b/src/main/integrations/electron.ts
@@ -38,7 +38,6 @@ export class Electron implements Integration {
   /**
    * Hooks into the Electron EventEmitter to capture breadcrumbs for the
    * specified events.
-   * TODO: Consider moving to integration
    */
   private instrumentBreadcrumbs(category: string, emitter: Electron.EventEmitter, events: string[] = []): void {
     type Emit = (event: string, ...args: any[]) => boolean;

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -10,7 +10,7 @@ const SENTRY_KEY = '37f8a2ee37c0409d8970bc7559c7c7e4';
 should();
 use(chaiAsPromised);
 
-const tests = getTests('1.7.14', '1.8.6', '2.0.5', '3.0.0');
+const tests = getTests('1.7.16', '1.8.8', '2.0.10', '3.0.2');
 
 tests.forEach(([version, arch]) => {
   describe(`Test Electron ${version} ${arch}`, () => {


### PR DESCRIPTION
- Moves event normalisation out from the Electron integration
- Moves instrumented electron breadcrumbs into the Electron integration

This way, if a user sets `defaultIntegrations: false`, path normalisation will still work but the Electron breadcrumbs will no longer be written.