### PR TITLE
fix: Custom release string not sent with minidump

### DIFF
--- a/src/main/client.ts
+++ b/src/main/client.ts
@@ -37,7 +37,8 @@ export class MainClient extends BaseClient<MainBackend, ElectronOptions> impleme
       version: SDK_VERSION,
     };
 
-    return super.prepareEvent(normalizeEvent(await addEventDefaults(event)), scope, hint);
+    const prepared = await super.prepareEvent(event, scope, hint);
+    return prepared ? normalizeEvent(await addEventDefaults(prepared)) : null;
   }
 
   /**

--- a/test/e2e/test-app/fixtures/sentry-custom-release.js
+++ b/test/e2e/test-app/fixtures/sentry-custom-release.js
@@ -1,0 +1,9 @@
+const { init } = require('../../../../');
+
+init({
+  dsn: process.env.DSN,
+  release: 'some-custom-release',
+  onFatalError: error => {
+    // We need this here otherwise we will get a dialog and travis will be stuck
+  },
+});


### PR DESCRIPTION
`super.prepareEvent` should be called before normalising the event.

Added tests to check this for both JavaScript and native.