### PR TITLE
fix: macOS info

### DIFF
--- a/src/main/context.ts
+++ b/src/main/context.ts
@@ -122,7 +122,7 @@ async function getDarwinInfo(): Promise<OsContext> {
     // We try to load the actual macOS version by executing the `sw_vers` tool.
     // This tool should be available on every standard macOS installation. In
     // case this fails, we stick with the values computed above.
-    const output = (await execFile('/usr/bin/sw_vers')).toString();
+    const output = (await execFile('/usr/bin/sw_vers')).stdout;
     darwinInfo.name = matchFirst(/^ProductName:\s+(.*)$/m, output);
     darwinInfo.version = matchFirst(/^ProductVersion:\s+(.*)$/m, output);
     darwinInfo.build = matchFirst(/^BuildVersion:\s+(.*)$/m, output);


### PR DESCRIPTION
Fixes #130 

I'm guessing this worked at some point because `toString()` was converting the returned object into something that worked with the regex. 

Here is what `execFile` returns:

![image](https://user-images.githubusercontent.com/1150298/47224155-1f2a2180-d3bb-11e8-99f9-1724aee11cdb.png)
