### PR TITLE
fix: remove unnecessary requiring of package.json

### DIFF
--- a/src/main/context.ts
+++ b/src/main/context.ts
@@ -90,12 +90,6 @@ function matchFirst(regex: RegExp, text: string): string | undefined {
   return match ? match[1] : undefined;
 }
 
-/** Synchronously loads this app's package.json or throws if not possible. */
-function getPackageJson(): PackageJson {
-  const packagePath = join(app.getAppPath(), 'package.json');
-  return require(packagePath) as PackageJson;
-}
-
 /** Returns the build type of this app, if possible. */
 function getBuildType(): string | undefined {
   if (process.mas) {
@@ -253,7 +247,7 @@ async function getEventDefaults(): Promise<SentryEvent> {
     },
     environment: process.defaultApp ? 'development' : 'production',
     extra: { crashed_process: 'browser' },
-    release: `${getPackageJson().name}@${app.getVersion()}`,
+    release: `${app.getName()}@${app.getVersion()}`,
     user: { ip_address: '{{auto}}' },
   };
 }

--- a/src/main/context.ts
+++ b/src/main/context.ts
@@ -23,11 +23,6 @@ interface OsContext {
   kernel_version?: string;
 }
 
-/** Shim interface to access this app's package.json. */
-interface PackageJson {
-  name: string;
-}
-
 /** Linux version file to check for a distribution. */
 interface DistroFile {
   /** The file name, located in `/etc`. */


### PR DESCRIPTION
There is not a need to load the `package.json`, as electron
remote.app provides us this functionality natively. We were
loading `package.json` to parse the package name, which is what
`getAppName()` already returns (and we already use this too).

Ref: https://electronjs.org/docs/api/app#appgetname

`getPackageJson()` was only being used by `getEventDefaults()`.
It is no longer needed as we already have all required `package.json`
data to build the event defaults.

**Note:** _(Ulterior motive):_
This has the benefit of removing an expression based `require()`,
which makes webpack happy! 🎉 

Closes #132 