### PR TITLE
fix: use module.require in place of require for dynamic includes

### DIFF
--- a/src/main/context.ts
+++ b/src/main/context.ts
@@ -93,7 +93,7 @@ function matchFirst(regex: RegExp, text: string): string | undefined {
 /** Synchronously loads this app's package.json or throws if not possible. */
 function getPackageJson(): PackageJson {
   const packagePath = join(app.getAppPath(), 'package.json');
-  return require(packagePath) as PackageJson;
+  return module.require(packagePath) as PackageJson;
 }
 
 /** Returns the build type of this app, if possible. */


### PR DESCRIPTION
This is the proposed alternative solution of PR #134 

Looking though the code it looks like the `require()` call in `getPackageJson` is the only one that needs the `module.require` hack to be introduced for. If there are any that I missed, please let me know!

Ref: webpack/webpack#7728
Closes: getsentry/sentry-electron#132