### PR TITLE
escape base path in normalizeUrl function

### DIFF
--- a/src/main/normalize.ts
+++ b/src/main/normalize.ts
@@ -15,7 +15,7 @@ const APP_PATH = app.getAppPath().replace(/\\/g, '/');
  */
 export function normalizeUrl(url: string, base: string = APP_PATH): string {
   // Escape RegExp special characters
-  const escapedBase = base.replace( /[|\\{}()[\]^$+*?.]/g, '\\$&');
+  const escapedBase = base.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&');
   return decodeURI(url)
     .replace(/\\/g, '/')
     .replace(new RegExp(`(file:\/\/)?\/*${escapedBase}\/*`, 'ig'), 'app:///');

--- a/src/main/normalize.ts
+++ b/src/main/normalize.ts
@@ -14,9 +14,11 @@ const APP_PATH = app.getAppPath().replace(/\\/g, '/');
  * @returns The normalized URL.
  */
 export function normalizeUrl(url: string, base: string = APP_PATH): string {
+  // Escape RegExp special characters
+  const escapedBase = base.replace( /[|\\{}()[\]^$+*?.]/g, '\\$&');
   return decodeURI(url)
     .replace(/\\/g, '/')
-    .replace(new RegExp(`(file:\/\/)?\/*${base}\/*`, 'ig'), 'app:///');
+    .replace(new RegExp(`(file:\/\/)?\/*${escapedBase}\/*`, 'ig'), 'app:///');
 }
 
 /**

--- a/test/unit/normalize.test.ts
+++ b/test/unit/normalize.test.ts
@@ -22,6 +22,23 @@ describe('Normalize URLs', () => {
     );
   });
 
+
+  it('Example app with parentheses', () => {
+    const base = 'c:/Users/Username/sentry-electron (beta)/example';
+
+    expect(normalizeUrl('C:\\Users\\Username\\sentry-electron%20(beta)\\example\\renderer.js', base)).to.equal(
+      'app:///renderer.js',
+    );
+
+    expect(normalizeUrl('C:\\Users\\Username\\sentry-electron%20(beta)\\example\\sub-directory\\renderer.js', base)).to.equal(
+      'app:///sub-directory/renderer.js',
+    );
+
+    expect(normalizeUrl('file:///C:/Users/Username/sentry-electron%20(beta)/example/index.html', base)).to.equal(
+      'app:///index.html',
+    );
+  });
+
   it('Asar packaged app in Windows Program Files', () => {
     const base = 'C:/Program Files/My App/resources/app.asar';
 

--- a/test/unit/normalize.test.ts
+++ b/test/unit/normalize.test.ts
@@ -22,7 +22,6 @@ describe('Normalize URLs', () => {
     );
   });
 
-
   it('Example app with parentheses', () => {
     const base = 'c:/Users/Username/sentry-electron (beta)/example';
 
@@ -30,9 +29,9 @@ describe('Normalize URLs', () => {
       'app:///renderer.js',
     );
 
-    expect(normalizeUrl('C:\\Users\\Username\\sentry-electron%20(beta)\\example\\sub-directory\\renderer.js', base)).to.equal(
-      'app:///sub-directory/renderer.js',
-    );
+    expect(
+      normalizeUrl('C:\\Users\\Username\\sentry-electron%20(beta)\\example\\sub-directory\\renderer.js', base),
+    ).to.equal('app:///sub-directory/renderer.js');
 
     expect(normalizeUrl('file:///C:/Users/Username/sentry-electron%20(beta)/example/index.html', base)).to.equal(
       'app:///index.html',


### PR DESCRIPTION
This PR handles app paths that have parentheses and other RegExp characters.