### PR TITLE
Feat: Allow custom naming of rederer processes

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -45,6 +45,13 @@ export interface ElectronOptions extends Options, BrowserOptions, NodeOptions {
    * Defaults to `true`.
    */
   enableUnresponsive?: boolean;
+
+  /**
+   * Callback to allow custom naming of renderer processes
+   * If the callback is not set, or it returns `undefined`, the default naming
+   * scheme is used.
+   */
+  getRendererName?(contents: Electron.WebContents): string | undefined;
 }
 
 /** Common interface for Electron clients. */

--- a/src/main/integrations/electron.ts
+++ b/src/main/integrations/electron.ts
@@ -6,6 +6,7 @@ import {
   screen,
   // tslint:disable-next-line:no-implicit-dependencies
 } from 'electron';
+import { ElectronClient } from '../../dispatch';
 
 /** Electron integration that cleans up the event. */
 export class Electron implements Integration {
@@ -35,7 +36,14 @@ export class Electron implements Integration {
       // SetImmediate is required for contents.id to be correct
       // https://github.com/electron/electron/issues/12036
       setImmediate(() => {
-        this.instrumentBreadcrumbs(`WebContents[${contents.id}]`, contents, ['dom-ready', 'load-url', 'destroyed']);
+        const options = (getCurrentHub().getClient() as ElectronClient).getOptions();
+        const customName = options.getRendererName && options.getRendererName(contents);
+
+        this.instrumentBreadcrumbs(customName || `WebContents[${contents.id}]`, contents, [
+          'dom-ready',
+          'load-url',
+          'destroyed',
+        ]);
       });
     });
   }

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -218,5 +218,14 @@ tests.forEach(([version, arch]) => {
         expect(appReadyBreadCrumbs.length).to.equal(2);
       }
     });
+
+    it('Custom named renderer process', async () => {
+      await context.start('sentry-custom-renderer-name', 'javascript-renderer');
+      await context.waitForEvents(1);
+      const event = context.testServer.events[0];
+
+      expect(context.testServer.events.length).to.equal(1);
+      expect(event.data.extra && event.data.extra.crashed_process).to.equal('renderer');
+    });
   });
 });

--- a/test/e2e/test-app/fixtures/sentry-custom-renderer-name.js
+++ b/test/e2e/test-app/fixtures/sentry-custom-renderer-name.js
@@ -1,0 +1,11 @@
+const { init } = require('../../../../');
+
+init({
+  dsn: process.env.DSN,
+  onFatalError: error => {
+    // We need this here otherwise we will get a dialog and travis will be stuck
+  },
+  getRendererName(_) {
+    return 'renderer';
+  },
+});


### PR DESCRIPTION
When you have multiple windows `renderer[3]` is not particularly helpful.

Usage:
```typescript
const names = ['main-window', 'file-viewer'];
// or more likely something more complex in your window manager

init({
  dsn: `__DSN__`,
  getRendererName(contents: Electron.webContents) {
    return names[contents.id];
  },
});
```