### PR TITLE
fix: Native crashes not being uploaded because no submitUrl is set

### DIFF
--- a/src/main/backend.ts
+++ b/src/main/backend.ts
@@ -186,7 +186,7 @@ export class MainBackend extends BaseBackend<ElectronOptions> implements CommonB
       companyName: '',
       ignoreSystemCrashHandler: true,
       productName: app.getName(),
-      submitURL: '',
+      submitURL: 'xxx',
       uploadToServer: false,
     });
 

--- a/src/main/backend.ts
+++ b/src/main/backend.ts
@@ -174,10 +174,12 @@ export class MainBackend extends BaseBackend<ElectronOptions> implements CommonB
     // We are only called by the frontend if the SDK is enabled and a valid DSN
     // has been configured. If no DSN is present, this indicates a programming
     // error.
-    const dsn = this.options.dsn;
-    if (!dsn) {
+    const dsnString = this.options.dsn;
+    if (!dsnString) {
       throw new SentryError('Invariant exception: install() must not be called when disabled');
     }
+
+    const dsn = new Dsn(dsnString);
 
     // We will manually submit errors, but CrashReporter requires a submitURL in
     // some versions. Also, provide a productName and companyName, which we will
@@ -186,7 +188,7 @@ export class MainBackend extends BaseBackend<ElectronOptions> implements CommonB
       companyName: '',
       ignoreSystemCrashHandler: true,
       productName: app.getName(),
-      submitURL: 'xxx',
+      submitURL: MinidumpUploader.minidumpUrlFromDsn(dsn),
       uploadToServer: false,
     });
 
@@ -196,7 +198,7 @@ export class MainBackend extends BaseBackend<ElectronOptions> implements CommonB
     const reporter: CrashReporterExt = crashReporter as any;
     const crashesDirectory = reporter.getCrashesDirectory();
 
-    this.uploader = new MinidumpUploader(new Dsn(dsn), crashesDirectory, getCachePath());
+    this.uploader = new MinidumpUploader(dsn, crashesDirectory, getCachePath());
 
     // Flush already cached minidumps from the queue.
     forget(this.uploader.flushQueue());

--- a/src/main/uploader.ts
+++ b/src/main/uploader.ts
@@ -68,10 +68,16 @@ export class MinidumpUploader {
     this.type = process.platform === 'darwin' ? 'crashpad' : 'breakpad';
     this.knownPaths = [];
 
-    // TODO: We need to put this somewhere in core
-    // we have this in 3 places now (transports browser/node/here)
+    this.url = MinidumpUploader.minidumpUrlFromDsn(dsn);
+  }
+
+  /**
+   * Returns the minidump endpoint in Sentry
+   * @param dsn Dsn
+   */
+  public static minidumpUrlFromDsn(dsn: Dsn): string {
     const { host, path, projectId, port, protocol, user } = dsn;
-    this.url = `${protocol}://${host}${port !== '' ? `:${port}` : ''}${
+    return `${protocol}://${host}${port !== '' ? `:${port}` : ''}${
       path !== '' ? `/${path}` : ''
     }/api/${projectId}/minidump?sentry_key=${user}`;
   }


### PR DESCRIPTION
It seems that the crashHandler in some versions have troubles uploading native crashes if no `submitUrl` is set. This PR sets something in there so it works as expected.

Strange thing is, that we documented it but didn't set anything 🤔 
https://github.com/getsentry/sentry-electron/pull/164/files#diff-96bd4e745f003940949074e9dc09c1bfR182