### PR TITLE
Feat: Allow usage without remote module

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -3,6 +3,7 @@ import { BaseBackend } from '@sentry/core';
 import { NodeOptions } from '@sentry/node';
 import { Client, Event, Options, Scope } from '@sentry/types';
 import { App } from 'electron';
+import { SentryError } from '@sentry/utils';
 
 /** IPC to ping the main process when initializing in the renderer. */
 export const IPC_PING = 'sentry-electron.ping';
@@ -27,6 +28,13 @@ export const IPC_SCOPE = 'sentry-electron.scope';
  * @see ElectronOptions
  */
 export interface ElectronOptions extends Options, BrowserOptions, NodeOptions {
+  /**
+   * The name of the application. Primarily used for crash directory naming. If this property is not supplied,
+   * it will be retrieved using the Electron `app.getName/name` API. If you disable the Electron `remote` module in
+   * the renderer, this property is required.
+   */
+  appName?: string;
+
   /**
    * Enables crash reporting for JavaScript errors in this process. Defaults to
    * `true`.
@@ -93,8 +101,31 @@ declare interface CrossApp extends App {
 }
 
 /** Get the name of an electron app for <v5 and v7< */
-export function getName(app: App): string {
-  const a = app as CrossApp;
+export function getNameFallback(): string {
+  // tslint:disable-next-line: strict-type-predicates
+  if (require === undefined) {
+    throw new SentryError(
+      'Could not require("electron") to get appName. Please ensure you pass `appName` to Sentry options',
+    );
+  }
+
+  const electron = require('electron');
+
+  // if we're in the main process
+  if (electron && electron.app) {
+    const appMain = electron.app as CrossApp;
+    return appMain.name || appMain.getName();
+  }
+
+  // We're in the renderer process but the remote module is not available
+  if (!electron || !electron.remote) {
+    throw new SentryError(
+      'The Electron `remote` module was not available to get appName. Please ensure you pass `appName` to Sentry options',
+    );
+  }
+
+  // Remote is available so get the app name
+  const a = electron.remote.app as CrossApp;
   return a.name || a.getName();
 }
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -2,8 +2,8 @@ import { BrowserOptions, ReportDialogOptions } from '@sentry/browser';
 import { BaseBackend } from '@sentry/core';
 import { NodeOptions } from '@sentry/node';
 import { Client, Event, Options, Scope } from '@sentry/types';
-import { App } from 'electron';
 import { SentryError } from '@sentry/utils';
+import { App } from 'electron';
 
 /** IPC to ping the main process when initializing in the renderer. */
 export const IPC_PING = 'sentry-electron.ping';

--- a/src/main/backend.ts
+++ b/src/main/backend.ts
@@ -13,7 +13,7 @@ import { Dsn, forget, logger, SentryError } from '@sentry/utils';
 import { app, crashReporter, ipcMain } from 'electron';
 import { join } from 'path';
 
-import { CommonBackend, ElectronOptions, getName, IPC_EVENT, IPC_PING, IPC_SCOPE } from '../common';
+import { CommonBackend, ElectronOptions, getNameFallback, IPC_EVENT, IPC_PING, IPC_SCOPE } from '../common';
 import { captureMinidump } from '../sdk';
 
 import { normalizeUrl } from './normalize';
@@ -195,7 +195,7 @@ export class MainBackend extends BaseBackend<ElectronOptions> implements CommonB
     crashReporter.start({
       companyName: '',
       ignoreSystemCrashHandler: true,
-      productName: getName(app),
+      productName: this._options.appName || getNameFallback(),
       submitURL: MinidumpUploader.minidumpUrlFromDsn(dsn),
       uploadToServer: false,
     });

--- a/src/main/backend.ts
+++ b/src/main/backend.ts
@@ -4,12 +4,13 @@ import {
   captureEvent,
   captureMessage,
   configureScope,
+  Dsn,
   getCurrentHub,
   Scope,
 } from '@sentry/core';
 import { NodeBackend } from '@sentry/node/dist/backend';
 import { Event, EventHint, Severity, Transport, TransportOptions } from '@sentry/types';
-import { Dsn, forget, logger, SentryError } from '@sentry/utils';
+import { forget, logger, SentryError } from '@sentry/utils';
 import { app, crashReporter, ipcMain } from 'electron';
 import { join } from 'path';
 

--- a/src/main/backend.ts
+++ b/src/main/backend.ts
@@ -4,13 +4,12 @@ import {
   captureEvent,
   captureMessage,
   configureScope,
-  Dsn,
   getCurrentHub,
   Scope,
 } from '@sentry/core';
 import { NodeBackend } from '@sentry/node/dist/backend';
 import { Event, EventHint, Severity, Transport, TransportOptions } from '@sentry/types';
-import { forget, logger, SentryError } from '@sentry/utils';
+import { Dsn, forget, logger, SentryError } from '@sentry/utils';
 import { app, crashReporter, ipcMain } from 'electron';
 import { join } from 'path';
 

--- a/src/main/client.ts
+++ b/src/main/client.ts
@@ -44,7 +44,7 @@ export class MainClient extends BaseClient<MainBackend, ElectronOptions> impleme
     return super._prepareEvent(event, scope, hint).then((filledEvent: Event | null) =>
       new SyncPromise<Event>(async resolve => {
         if (filledEvent) {
-          resolve(normalizeEvent(await addEventDefaults(filledEvent)));
+          resolve(normalizeEvent(await addEventDefaults(this._options.appName, filledEvent)));
         } else {
           resolve(filledEvent);
         }

--- a/src/main/context.ts
+++ b/src/main/context.ts
@@ -6,7 +6,7 @@ import { platform, release } from 'os';
 import { join } from 'path';
 import { promisify } from 'util';
 
-import { getNameFallback, ElectronOptions } from '../common';
+import { getNameFallback } from '../common';
 
 const execFile = promisify(child.execFile);
 const readdir = promisify(fs.readdir);

--- a/src/main/context.ts
+++ b/src/main/context.ts
@@ -6,7 +6,7 @@ import { platform, release } from 'os';
 import { join } from 'path';
 import { promisify } from 'util';
 
-import { getName } from '../common';
+import { getNameFallback, ElectronOptions } from '../common';
 
 const execFile = promisify(child.execFile);
 const readdir = promisify(fs.readdir);
@@ -216,11 +216,13 @@ async function getOsContext(): Promise<OsContext> {
  * runtimes, limited device information, operating system context and defaults
  * for the release and environment.
  */
-async function getEventDefaults(): Promise<Event> {
+async function getEventDefaults(appName: string | undefined): Promise<Event> {
+  const name = appName || getNameFallback();
+
   return {
     contexts: {
       app: {
-        app_name: getName(app),
+        app_name: name,
         app_version: app.getVersion(),
         build_type: getBuildType(),
       },
@@ -249,19 +251,19 @@ async function getEventDefaults(): Promise<Event> {
     },
     environment: process.defaultApp ? 'development' : 'production',
     extra: { crashed_process: 'browser' },
-    release: `${getName(app).replace(/\W/g, '-')}${app.getVersion()}`,
+    release: `${name.replace(/\W/g, '-')}${app.getVersion()}`,
     user: { ip_address: '{{auto}}' },
   };
 }
 
 /** Merges the given event payload with SDK defaults. */
-export async function addEventDefaults(event: Event): Promise<Event> {
+export async function addEventDefaults(appName: string | undefined, event: Event): Promise<Event> {
   // The event defaults are cached as long as the app is running. We create the
   // promise here synchronously to avoid multiple events computing them at the
   // same time.
   // tslint:disable-next-line: no-promise-as-boolean
   if (!defaultsPromise) {
-    defaultsPromise = getEventDefaults();
+    defaultsPromise = getEventDefaults(appName);
   }
 
   const { contexts = {} } = event;

--- a/src/main/uploader.ts
+++ b/src/main/uploader.ts
@@ -1,6 +1,5 @@
-import { Dsn } from '@sentry/core';
 import { Event } from '@sentry/types';
-import { logger } from '@sentry/utils';
+import { Dsn, logger } from '@sentry/utils';
 import FormData = require('form-data');
 import * as fs from 'fs';
 import fetch from 'node-fetch';

--- a/src/main/uploader.ts
+++ b/src/main/uploader.ts
@@ -1,5 +1,6 @@
+import { Dsn } from '@sentry/core';
 import { Event } from '@sentry/types';
-import { Dsn, logger } from '@sentry/utils';
+import { logger } from '@sentry/utils';
 import FormData = require('form-data');
 import * as fs from 'fs';
 import fetch from 'node-fetch';

--- a/src/renderer/backend.ts
+++ b/src/renderer/backend.ts
@@ -1,9 +1,9 @@
 import { BrowserBackend } from '@sentry/browser/dist/backend';
 import { BaseBackend, getCurrentHub } from '@sentry/core';
 import { Event, EventHint, Severity } from '@sentry/types';
-import { crashReporter, ipcRenderer, remote } from 'electron';
+import { crashReporter, ipcRenderer } from 'electron';
 
-import { CommonBackend, ElectronOptions, getName, IPC_EVENT, IPC_PING, IPC_SCOPE } from '../common';
+import { CommonBackend, ElectronOptions, getNameFallback, IPC_EVENT, IPC_PING, IPC_SCOPE } from '../common';
 
 /** Timeout used for registering with the main process. */
 const PING_TIMEOUT = 500;
@@ -98,7 +98,7 @@ export class RendererBackend extends BaseBackend<ElectronOptions> implements Com
     crashReporter.start({
       companyName: '',
       ignoreSystemCrashHandler: true,
-      productName: getName(remote.app),
+      productName: this._options.appName || getNameFallback(),
       submitURL: '',
       uploadToServer: false,
     });


### PR DESCRIPTION
cc @koenoe

This allows usage of `sentry-electron` with the `remote` module disabled in renderers:
```
const mainWindow = new BrowserWindow({
  webPreferences: {
    enableRemoteModule: false
  }
})
```
To support this you have to pass the app name to sentry options:
```
const { init } = require('@sentry/electron');

init({
  dsn: 'https://343434343434343@sentry.io/5656565',
  appName: 'My Great App',
});
```

### TODO
Add some tests!
