### PR TITLE
Fix: Fixed location for win-ca write path

### DIFF
--- a/src/main/uploader.ts
+++ b/src/main/uploader.ts
@@ -117,7 +117,9 @@ export class MinidumpUploader {
         // Without this, Node.js cannot upload minidumps on corporate networks
         // that perform deep SSL inspection by installing a custom root certificate
         // on every machine.
-        require('win-ca/fallback');
+        const caPath = join(this._cacheDirectory, 'win-ca', 'pem');
+        // tslint:disable-next-line: no-unsafe-any
+        require('win-ca/api')({ fallback: true, save: caPath });
       }
 
       const body = new FormData();

--- a/src/main/uploader.ts
+++ b/src/main/uploader.ts
@@ -118,8 +118,13 @@ export class MinidumpUploader {
         // that perform deep SSL inspection by installing a custom root certificate
         // on every machine.
         const caPath = join(this._cacheDirectory, 'win-ca', 'pem');
-        // tslint:disable-next-line: no-unsafe-any
-        require('win-ca/api')({ fallback: true, save: caPath });
+        try {
+          // tslint:disable-next-line: no-unsafe-any
+          require('win-ca/api')({ fallback: true, save: caPath });
+        } catch (e) {
+          // If this fails, upload will still work on networks that don't MITM SSL
+          logger.warn('Could not initialize win-ca', e);
+        }
       }
 
       const body = new FormData();


### PR DESCRIPTION
Ensures that `win-ca` uses the Sentry cache path for writing certificate files. We know for sure this is writable. This should hopefully fix #204. 