### PR TITLE
Fix: Webpack compile warning

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -103,7 +103,7 @@ declare interface CrossApp extends App {
 /** Get the name of an electron app for <v5 and v7< */
 export function getNameFallback(): string {
   // tslint:disable-next-line: strict-type-predicates
-  if (require === undefined) {
+  if (!require) {
     throw new SentryError(
       'Could not require("electron") to get appName. Please ensure you pass `appName` to Sentry options',
     );

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -12,7 +12,7 @@ const SENTRY_KEY = '37f8a2ee37c0409d8970bc7559c7c7e4';
 should();
 use(chaiAsPromised);
 
-const tests = getTests('1.7.16', '1.8.8', '2.0.18', '3.1.13', '4.2.12', '5.0.13', '6.1.7', '7.1.7', '8.0.0-beta.5');
+const tests = getTests('1.7.16', '1.8.8', '2.0.18', '3.1.13', '4.2.12', '5.0.13', '6.1.7', '7.1.11', '8.0.0');
 
 describe('E2E Tests', () => {
   let testServer: TestServer;


### PR DESCRIPTION
Fixes #211 and updates Electron test versions.

I'm also working on some tests to ensure this doesn't regress.