### PR TITLE
Fix: Check for webContents.isDestroyed before hooking for breadcrumbs

### DIFF
--- a/src/main/integrations/electron.ts
+++ b/src/main/integrations/electron.ts
@@ -37,6 +37,10 @@ export class Electron implements Integration {
       // SetImmediate is required for contents.id to be correct
       // https://github.com/electron/electron/issues/12036
       setImmediate(() => {
+        if (contents.isDestroyed()) {
+          return;
+        }
+
         const options = (getCurrentHub().getClient() as ElectronClient).getOptions();
         const customName = options.getRendererName && options.getRendererName(contents);
 


### PR DESCRIPTION
## Descriptions

Hey, I am running to an error caused by an attempt to access a destroyed web contents. According to the error logged to Sentry, it originates from this line of code. See:
<img width="1056" alt="image" src="https://user-images.githubusercontent.com/44967897/85092728-acc3b180-b22d-11ea-8d6b-55edf47f6021.png">

### The cause

First of all, we have snippet of code intended as a security measure recommended by electron documentation. See:
https://electronjs.org/docs/tutorial/security#13-disable-or-limit-creation-of-new-windows
```ts
app.on('web-contents-created', (event, webContents) => {
  webContents.on('new-window', (event) => {
    event.preventDefault();
      
    // do global custom behavior if needed.
  });
});
```

The electron integrations is hooking into the same `web-contents-created` to collect breadcrumbs on the web contents. However, due to the use of `setImmediate`, there will be a race condition between when the `webContents` gets destroyed and the code within the `setImmediate` gets executed and will try to access an already destroyed `webContents`.

### This PR

Adds a check through `contents.isDestroyed()` method and returns early if returns `true`.