### PR TITLE
perf: dont double serialize IPC messages

### DIFF
--- a/src/main/backend.ts
+++ b/src/main/backend.ts
@@ -249,7 +249,14 @@ export class MainBackend extends BaseBackend<ElectronOptions> implements CommonB
       event.sender.send(IPC_PING);
     });
 
-    ipcMain.on(IPC_EVENT, (ipc: Electron.Event, event: Event) => {
+    ipcMain.on(IPC_EVENT, (ipc: Electron.Event, jsonEvent: string) => {
+      let event: Event;
+      try {
+        event = JSON.parse(jsonEvent) as Event;
+      } catch {
+        console.warn('sentry-electron received an invalid IPC_EVENT message');
+        return;
+      }
       event.extra = {
         ...this._getRendererExtra(ipc.sender),
         ...event.extra,
@@ -257,7 +264,14 @@ export class MainBackend extends BaseBackend<ElectronOptions> implements CommonB
       captureEvent(event);
     });
 
-    ipcMain.on(IPC_SCOPE, (_: any, rendererScope: Scope) => {
+    ipcMain.on(IPC_SCOPE, (_: any, jsonRendererScope: string) => {
+      let rendererScope: Scope;
+      try {
+        rendererScope = JSON.parse(jsonRendererScope) as Scope;
+      } catch {
+        console.warn('sentry-electron received an invalid IPC_SCOPE message');
+        return;
+      }
       // tslint:disable:no-unsafe-any
       const sentScope = Scope.clone(rendererScope) as any;
       configureScope(scope => {

--- a/src/renderer/backend.ts
+++ b/src/renderer/backend.ts
@@ -50,7 +50,7 @@ export class RendererBackend extends BaseBackend<ElectronOptions> implements Com
   public sendEvent(event: Event): void {
     // We pass through JSON because in Electron >= 8, IPC uses v8's structured clone algorithm and throws errors if
     // objects have functions
-    ipcRenderer.send(IPC_EVENT, JSON.parse(JSON.stringify(event)));
+    ipcRenderer.send(IPC_EVENT, JSON.stringify(event));
   }
 
   /**
@@ -62,7 +62,7 @@ export class RendererBackend extends BaseBackend<ElectronOptions> implements Com
       scope.addScopeListener(updatedScope => {
         // We pass through JSON because in Electron >= 8, IPC uses v8's structured clone algorithm and throws errors if
         // objects have functions
-        ipcRenderer.send(IPC_SCOPE, JSON.parse(JSON.stringify(updatedScope)));
+        ipcRenderer.send(IPC_SCOPE, JSON.stringify(updatedScope));
         scope.clearBreadcrumbs();
       });
     }


### PR DESCRIPTION
IPC uses the V8 serializer so I understand why we send it through `JSON.parse(JSON.stringify(` to ensure that no stray functions could break it, it's needless to do that in the renderer and _then_ send it through the serializer as well.  This PR is a small perf tweak to stringify in the renderer and parse in the main process which means the V8 serializer isn't _also_ serializing the object, rather just a string