### PR TITLE
fix: Create error object in case we cant detect it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,6 +104,7 @@ jobs:
     needs: job_1
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
       - name: Download Artifacts
         uses: actions/download-artifact@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: 'Test'
+name: 'Build & Test'
 on:
   push:
     branches:
@@ -27,7 +27,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: dist
-          path: dist
+          path: ${{ github.workspace }}/dist
 
   job_2:
     name: Lint
@@ -46,7 +46,7 @@ jobs:
         run: yarn lint
 
   job_3:
-    name: Test
+    name: Unit Tests
     needs: job_1
     runs-on: ${{ matrix.os }}
     strategy:
@@ -68,15 +68,19 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: dist
+          path: ${{ github.workspace }}/dist
       - name: Run Unit Tests
         run: yarn test
-      - name: Run E2E Tests
-        run: yarn e2e
 
   job_4:
-    name: Zeus
+    name: E2E Tests
     needs: job_1
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # we want that the matrix keeps running, default is to cancel them if it fails.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -86,10 +90,26 @@ jobs:
             ~/.cache
             **/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+      - run: yarn install
       - name: Download Artifacts
         uses: actions/download-artifact@v1
         with:
           name: dist
+          path: ${{ github.workspace }}/dist
+      - name: Run E2E Tests
+        run: yarn e2e
+
+  job_5:
+    name: Zeus
+    needs: job_1
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v1
+      - name: Download Artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: dist
+          path: ${{ github.workspace }}/dist
       - name: Pack
         run: yarn pack
       - name: Install Zeus

--- a/example/package.json
+++ b/example/package.json
@@ -9,7 +9,7 @@
     "start": "electron ."
   },
   "dependencies": {
-    "@sentry/electron": "^0.14.0"
+    "@sentry/electron": "^1.3.1"
   },
   "devDependencies": {
     "copy-webpack-plugin": "^4.6.0",

--- a/src/main/integrations/onuncaughtexception.ts
+++ b/src/main/integrations/onuncaughtexception.ts
@@ -39,7 +39,7 @@ export class OnUncaughtException implements Integration {
           }));
 
           let theError = error;
-          if (!isError(error) && error.message && error.stack && error.name) {
+          if (!isError(error) && error.stack) {
             theError = new Error();
             theError.message = error.message;
             theError.stack = error.stack;

--- a/src/main/integrations/onuncaughtexception.ts
+++ b/src/main/integrations/onuncaughtexception.ts
@@ -1,7 +1,7 @@
 import { getCurrentHub, NodeClient } from '@sentry/node';
 import { Event, Integration, Severity } from '@sentry/types';
-import { dialog } from 'electron';
 import { isError } from '@sentry/utils';
+import { dialog } from 'electron';
 
 /** Capture unhandled erros. */
 export class OnUncaughtException implements Integration {


### PR DESCRIPTION
This fixes a weird bug where we capture an exception which isn't detected as an error and therefore be captured as `Non-Error exception captured with keys: message, name, stack`
