### PR TITLE
fix(minidump): Add filenames to attachment items

### DIFF
--- a/src/main/uploader.ts
+++ b/src/main/uploader.ts
@@ -212,16 +212,14 @@ export class MinidumpUploader {
     // Remove all metadata files and forget about them.
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     Promise.all(
-      files
-        .filter(file => file.endsWith('.txt') && !file.endsWith('log.txt'))
-        .map(async file => {
-          const path = join(this._crashesDirectory, file);
-          try {
-            await unlinkAsync(path);
-          } catch (e) {
-            logger.warn('Could not delete', path);
-          }
-        }),
+      files.filter(file => file.endsWith('.txt') && !file.endsWith('log.txt')).map(async file => {
+        const path = join(this._crashesDirectory, file);
+        try {
+          await unlinkAsync(path);
+        } catch (e) {
+          logger.warn('Could not delete', path);
+        }
+      }),
     );
 
     return files.filter(file => file.endsWith('.dmp')).map(file => join(this._crashesDirectory, file));
@@ -301,6 +299,7 @@ export class MinidumpUploader {
         attachment_type: 'event.minidump',
         length: minidumpContent.length,
         type: 'attachment',
+        filename: basename(minidumpPath),
       });
 
       bodyBuffer = Buffer.concat([bodyBuffer, Buffer.from(`${minidumpHeader}\n`), minidumpContent, Buffer.from('\n')]);

--- a/src/main/uploader.ts
+++ b/src/main/uploader.ts
@@ -212,14 +212,16 @@ export class MinidumpUploader {
     // Remove all metadata files and forget about them.
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     Promise.all(
-      files.filter(file => file.endsWith('.txt') && !file.endsWith('log.txt')).map(async file => {
-        const path = join(this._crashesDirectory, file);
-        try {
-          await unlinkAsync(path);
-        } catch (e) {
-          logger.warn('Could not delete', path);
-        }
-      }),
+      files
+        .filter(file => file.endsWith('.txt') && !file.endsWith('log.txt'))
+        .map(async file => {
+          const path = join(this._crashesDirectory, file);
+          try {
+            await unlinkAsync(path);
+          } catch (e) {
+            logger.warn('Could not delete', path);
+          }
+        }),
     );
 
     return files.filter(file => file.endsWith('.dmp')).map(file => join(this._crashesDirectory, file));


### PR DESCRIPTION
The minidump attachment is missing a `filename` header which causes it to get
dropped in Sentry. While this is bug across Relay and Sentry, the filename of
attachments should always be added to item headers.

See https://github.com/getsentry/develop/pull/140