### PR TITLE
fix(uploader): Add slash to minidump upload URL

### DIFF
--- a/src/main/uploader.ts
+++ b/src/main/uploader.ts
@@ -80,7 +80,7 @@ export class MinidumpUploader {
     const { host, path, projectId, port, protocol, user } = dsn;
     return `${protocol}://${host}${port !== '' ? `:${port}` : ''}${
       path !== '' ? `/${path}` : ''
-    }/api/${projectId}/minidump?sentry_key=${user}`;
+    }/api/${projectId}/minidump/?sentry_key=${user}`;
   }
 
   /**


### PR DESCRIPTION
The initial version of the Electron SDK used to send minidumps to an endpoint without the trailing slash since the server initially did not support this by mistake. This has long been fixed, and the current version of the SDK even requires the Envelope endpoint for most of its operation.

Both in the [endpoint docs](https://docs.sentry.io/platforms/native/guides/minidumps/#minidump-integration) and [Relay's operating guidelines](https://docs.sentry.io/product/relay/operating-guidelines/#request-routing), we only document the URL with a trailing slash. 