### PR TITLE
feat: Do not start crash reporter in renderer

### DIFF
--- a/src/renderer/backend.ts
+++ b/src/renderer/backend.ts
@@ -87,7 +87,7 @@ export class RendererBackend extends BaseBackend<ElectronOptions> implements Com
   }
 
   /** Activates the Electron CrashReporter. */
-  private _installNativeHandler(): boolean {
+  private _installNativeHandler(): void {
     // this is only necessary for electron versions before 8
     const majorVersion = parseInt(process.versions.electron.match(/^(\d+)\./)[1], 10);
     if (majorVersion >= 8) {
@@ -104,8 +104,6 @@ export class RendererBackend extends BaseBackend<ElectronOptions> implements Com
       submitURL: '',
       uploadToServer: false,
     });
-
-    return true;
   }
 
   /** Checks if the main processes is available and logs a warning if not. */

--- a/src/renderer/backend.ts
+++ b/src/renderer/backend.ts
@@ -89,8 +89,8 @@ export class RendererBackend extends BaseBackend<ElectronOptions> implements Com
   /** Activates the Electron CrashReporter. */
   private _installNativeHandler(): void {
     // this is only necessary for electron versions before 8
-    const majorVersion = parseInt(process.versions.electron.match(/^(\d+)\./)[1], 10);
-    if (majorVersion >= 8) {
+    const versionMatch = process.versions.electron.match(/^(\d+)\./);
+    if (versionMatch && parseInt(versionMatch[1], 10) >= 8) {
       return;
     }
 

--- a/src/renderer/backend.ts
+++ b/src/renderer/backend.ts
@@ -52,7 +52,7 @@ export class RendererBackend extends BaseBackend<ElectronOptions> implements Com
   private _setupScopeListener(): void {
     const scope = getCurrentHub().getScope();
     if (scope) {
-      scope.addScopeListener((updatedScope) => {
+      scope.addScopeListener(updatedScope => {
         // We pass through JSON because in Electron >= 8, IPC uses v8's structured clone algorithm and throws errors if
         // objects have functions. Calling walk makes sure to break circular references.
         ipcRenderer.send(IPC_SCOPE, JSON.stringify(updatedScope, walk));

--- a/src/renderer/backend.ts
+++ b/src/renderer/backend.ts
@@ -61,27 +61,6 @@ export class RendererBackend extends BaseBackend<ElectronOptions> implements Com
     }
   }
 
-  /** Returns whether native reports are enabled. */
-  private _isNativeEnabled(): boolean {
-    // On macOS, we should start the Electron CrashReporter only in the main
-    // process. It uses Crashpad internally, which will catch errors from all
-    // sub processes thanks to out-of-processes crash handling. On other
-    // platforms we need to start the CrashReporter in every sub process. For
-    // more information see: https://goo.gl/nhqqwD
-    if (process.platform === 'darwin') {
-      return false;
-    }
-
-    // Mac AppStore builds cannot run the crash reporter due to the sandboxing
-    // requirements. In this case, we prevent enabling native crashes entirely.
-    // https://electronjs.org/docs/tutorial/mac-app-store-submission-guide#limitations-of-mas-build
-    if (process.mas) {
-      return false;
-    }
-
-    return this._options.enableNative !== false;
-  }
-
   /** Checks if the main processes is available and logs a warning if not. */
   private _pingMainProcess(): void {
     // For whatever reason we have to wait PING_TIMEOUT until we send the ping

--- a/src/renderer/backend.ts
+++ b/src/renderer/backend.ts
@@ -90,7 +90,7 @@ export class RendererBackend extends BaseBackend<ElectronOptions> implements Com
   private _installNativeHandler(): void {
     // this is only necessary for electron versions before 8
     const versionMatch = process.versions.electron.match(/^(\d+)\./);
-    if (versionMatch && parseInt(versionMatch[1], 10) >= 8) {
+    if (versionMatch && parseInt(versionMatch[1], 10) > 8) {
       return;
     }
 


### PR DESCRIPTION
This disables the starting of the crash handler in the renderer process. This is necessary for it to work on Electron 12.

This still needs validation.

Fixes #229 