### PR TITLE
Fix: Unify Electron version checks

### DIFF
--- a/src/electron-version.ts
+++ b/src/electron-version.ts
@@ -1,14 +1,19 @@
 import { parseSemver } from '@sentry/utils';
 
-const version = parseSemver(process.versions.electron);
-const major: number = version.major || 0;
-const minor: number = version.minor || 0;
+/**
+ * Parsed Electron version
+ */
+function version(): { major: number; minor: number; patch: number } {
+  const version = parseSemver(process.versions.electron);
+  return { major: version.major || 0, minor: version.minor || 0, patch: version.patch || 0 };
+}
 
 /**
  * Electron >=8.4 | >=9.1 | >=10
  * Use `render-process-gone` rather than `crashed`
  */
 export function supportsRenderProcessGone(): boolean {
+  const { major, minor } = version();
   return (major === 8 && minor >= 4) || (major === 9 && minor >= 1) || major >= 10;
 }
 
@@ -16,6 +21,7 @@ export function supportsRenderProcessGone(): boolean {
  * Electron < 9 requires `crashReporter.start()` in the renderer
  */
 export function requiresNativeHandlerRenderer(): boolean {
+  const { major } = version();
   return major < 9;
 }
 
@@ -23,5 +29,6 @@ export function requiresNativeHandlerRenderer(): boolean {
  * Electron >= 6 uses crashpad on Windows
  */
 export function supportsCrashpadOnWindows(): boolean {
+  const { major } = version();
   return major >= 6;
 }

--- a/src/electron-version.ts
+++ b/src/electron-version.ts
@@ -1,0 +1,34 @@
+import { parseSemver } from '@sentry/utils';
+
+const version = parseSemver(process.versions.electron);
+const major: number = version.major || 0;
+const minor: number = version.minor || 0;
+
+/**
+ * Electron >=8.4 | >=9.1 | >=10
+ * Use `render-process-gone` rather than `crashed`
+ */
+export function supportsRenderProcessGone(): boolean {
+  return (major === 8 && minor >= 4) || (major === 9 && minor >= 1) || major >= 10;
+}
+
+/**
+ * Electron < 9 requires `crashReporter.start()` in the renderer
+ */
+export function requiresNativeHandlerRenderer(): boolean {
+  return major < 9;
+}
+
+/**
+ * Electron >= 6 uses crashpad
+ */
+export function supportsCrashpadOnWindows(): boolean {
+  return major >= 6;
+}
+
+/**
+ * Electron >= 6 has context isolation
+ */
+export function supportsContextIsolation(): boolean {
+  return major >= 6;
+}

--- a/src/electron-version.ts
+++ b/src/electron-version.ts
@@ -20,7 +20,7 @@ export function requiresNativeHandlerRenderer(): boolean {
 }
 
 /**
- * Electron >= 6 uses crashpad
+ * Electron >= 6 uses crashpad on Windows
  */
 export function supportsCrashpadOnWindows(): boolean {
   return major >= 6;

--- a/src/electron-version.ts
+++ b/src/electron-version.ts
@@ -25,10 +25,3 @@ export function requiresNativeHandlerRenderer(): boolean {
 export function supportsCrashpadOnWindows(): boolean {
   return major >= 6;
 }
-
-/**
- * Electron >= 6 has context isolation
- */
-export function supportsContextIsolation(): boolean {
-  return major >= 6;
-}

--- a/src/main/uploader.ts
+++ b/src/main/uploader.ts
@@ -1,9 +1,10 @@
 /* eslint-disable max-lines */
 import { API } from '@sentry/core';
 import { Event, Status, Transport } from '@sentry/types';
-import { Dsn, logger, parseSemver, timestampWithMs } from '@sentry/utils';
+import { Dsn, logger, timestampWithMs } from '@sentry/utils';
 import { basename, join } from 'path';
 
+import { supportsCrashpadOnWindows } from '../electron-version';
 import { mkdirp, readDirAsync, readFileAsync, renameAsync, statAsync, unlinkAsync } from './fs';
 import { Store } from './store';
 import { NetTransport, SentryElectronRequest } from './transports/net';
@@ -63,7 +64,7 @@ export class MinidumpUploader {
     private readonly _cacheDirectory: string,
     private readonly _transport: Transport,
   ) {
-    const crashpadWindows = process.platform === 'win32' && (parseSemver(process.versions.electron).major || 0) >= 6;
+    const crashpadWindows = process.platform === 'win32' && supportsCrashpadOnWindows();
     this._type = process.platform === 'darwin' || crashpadWindows ? 'crashpad' : 'breakpad';
     this._crashpadSubDirectory = process.platform === 'darwin' ? 'completed' : 'reports';
     this._knownPaths = [];

--- a/src/renderer/backend.ts
+++ b/src/renderer/backend.ts
@@ -4,7 +4,7 @@ import { Event, EventHint, Scope, Severity } from '@sentry/types';
 import { walk } from '@sentry/utils';
 
 import { CommonBackend, ElectronOptions, getNameFallback, IPC_EVENT, IPC_PING, IPC_SCOPE } from '../common';
-import { requiresNativeHandlerRenderer, supportsContextIsolation } from '../electron-version';
+import { requiresNativeHandlerRenderer } from '../electron-version';
 
 /** Requires and returns electron or undefined if it's unavailable  */
 function requireElectron(): Electron.AllElectron | undefined {

--- a/src/renderer/backend.ts
+++ b/src/renderer/backend.ts
@@ -108,7 +108,7 @@ export class RendererBackend extends BaseBackend<ElectronOptions> implements Com
     window.__SENTRY_IPC__ = ipcObject;
 
     // We attempt to use contextBridge if it's available (Electron >= 6)
-    if (supportsContextIsolation() && contextBridge) {
+    if (contextBridge) {
       // This will fail if contextIsolation is not enabled but we have no other way to detect this from the renderer
       try {
         contextBridge.exposeInMainWorld('__SENTRY_IPC__', ipcObject);

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -22,9 +22,9 @@ const tests = getTests(
   '6.1.12',
   '7.3.3',
   '8.5.5',
-  '9.3.5',
-  '10.1.7',
-  '11.0.4',
+  '9.4.2',
+  '10.3.1',
+  '11.2.2',
 );
 
 describe('Bundle Tests', () => {
@@ -53,8 +53,8 @@ describe('E2E Tests', () => {
       return;
     }
 
-    if (majorVersion === 4 && process.platform === 'win32') {
-      // We skip electron version 4 on Windows as it wont pass on Travis
+    if ((majorVersion === 4 || majorVersion === 3) && process.platform === 'win32') {
+      // We skip electron version 3-4 on Windows as these versions don't exit correctly and stay open consuming CPU
       return;
     }
 


### PR DESCRIPTION
The codebase has numerous ways to feature-check Electron versions as APIs are changed or deprecated.

These changes:
- Move all Electron version parsing and checks to a single file
- Bump the e2e test versions
- Skips v3 and v4 from e2e tests on Windows. My local tests seem to suggest these versions don't close and stay open consuming cpu