### PR TITLE
Check for require with typeof

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -118,7 +118,7 @@ declare interface CrossApp extends App {
 
 /** Get the name of an electron app for <v5 and v7< */
 export function getNameFallback(): string {
-  if (!require) {
+  if (typeof require === 'undefined') {
     throw new SentryError(
       'Could not require("electron") to get appName. Please ensure you pass `appName` to Sentry options',
     );


### PR DESCRIPTION
If require is undefined the following code checking for the existence of require will throw a reference error so the nicer custom error message is never displayed to the user.