### PR TITLE
Fix: Missing scope updates from isolated renderer

### DIFF
--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -363,6 +363,7 @@ describe('E2E Tests', () => {
 
         expect(testServer.events.length).to.equal(1);
         expect(event.dump_file).to.be.false;
+        expect(event.data.user?.id).to.equal('abc-123');
       });
     });
   });

--- a/test/e2e/isolated-app/src/renderer.js
+++ b/test/e2e/isolated-app/src/renderer.js
@@ -1,4 +1,9 @@
 require('./sentry');
+const { configureScope } = require('../../../..');
+
+configureScope(scope => {
+  scope.setUser({ id: 'abc-123' });
+});
 
 setTimeout(() => {
   throw new Error('Some renderer error');

--- a/yarn.lock
+++ b/yarn.lock
@@ -3543,6 +3543,11 @@ tslib@^1.10.0, tslib@^1.7.1, tslib@^1.8.1, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
+tslib@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
+
 tslint-config-prettier@^1.18.0:
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz#75f140bde947d35d8f0d238e0ebf809d64592c37"


### PR DESCRIPTION
Fixes #316

- Call `_setupScopeListener` from all renderer contexts
- Update isolated test to check user scope is passed from isolated context
- Also limit walk depth to negate #263 