### PR TITLE
Fix: Undefined event breadcrumbs results in spurious breadcrumbs after serialization

### DIFF
--- a/src/renderer/backend.ts
+++ b/src/renderer/backend.ts
@@ -97,6 +97,8 @@ export class RendererBackend extends BaseBackend<ElectronOptions> implements Com
    * @inheritDoc
    */
   public sendEvent(event: Event): void {
+    // Ensure breadcrumbs is not `undefined` as `walk` translates it into a string
+    event.breadcrumbs = event.breadcrumbs || [];
     window.__SENTRY_IPC__?.sendEvent(event);
   }
 


### PR DESCRIPTION
Fixes #329 

The event payload had `{ breadcrumbs: undefined, ... }` and when this was passed through `walk` it was getting converted to the string `'[undefined]'` which was passed through IPC. In the the main process this was being interpreted as 11 individual breadcrumbs, each a single character long!