### PR TITLE
Fix: Handle response error event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - feat: Context and breadcrumbs sent via Crashpad for native crashes in main process when `useCrashpadMinidumpUploader`
   enabled
+- fix: Handle net response error event
 
 ## 2.5.0
 

--- a/src/main/transports/net.ts
+++ b/src/main/transports/net.ts
@@ -108,6 +108,8 @@ export class NetTransport extends Transports.BaseTransport {
         const req = net.request(options as Electron.ClientRequestConstructorOptions);
         req.on('error', reject);
         req.on('response', (res: Electron.IncomingMessage) => {
+          res.on('error', reject);
+
           const status = Status.fromHttpCode(res.statusCode);
           if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
             resolve({ status });


### PR DESCRIPTION
Fixes #344 

I looks like the fix is as simple as handling the `error` event:
https://github.com/electron/electron/issues/24948