### PR TITLE
test: Run e2e tests in parallel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,24 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        electron:
+          [
+            '1.8.8',
+            '2.0.18',
+            '3.1.13',
+            '4.2.12',
+            '5.0.13',
+            '6.1.12',
+            '7.3.3',
+            '8.5.5',
+            '9.4.4',
+            '10.4.7',
+            '11.4.8',
+            '12.0.11',
+            '13.1.2',
+          ]
+    env:
+      ELECTRON_VERSION: ${{ matrix.electron }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -13,21 +13,25 @@ const SENTRY_KEY = '37f8a2ee37c0409d8970bc7559c7c7e4';
 should();
 use(chaiAsPromised);
 
-const tests = getTests(
-  '1.8.8',
-  '2.0.18',
-  '3.1.13',
-  '4.2.12',
-  '5.0.13',
-  '6.1.12',
-  '7.3.3',
-  '8.5.5',
-  '9.4.4',
-  '10.4.7',
-  '11.4.8',
-  '12.0.11',
-  '13.1.2',
-);
+const versions = process.env.ELECTRON_VERSION
+  ? [process.env.ELECTRON_VERSION]
+  : [
+      '1.8.8',
+      '2.0.18',
+      '3.1.13',
+      '4.2.12',
+      '5.0.13',
+      '6.1.12',
+      '7.3.3',
+      '8.5.5',
+      '9.4.4',
+      '10.4.7',
+      '11.4.8',
+      '12.0.11',
+      '13.1.2',
+    ];
+
+const tests = getTests(...versions);
 
 describe('Bundle Tests', () => {
   it('Webpack contextIsolation app', async () => {


### PR DESCRIPTION
With e2e tests run in parallel the total run time goes from ~12 minutes to ~8 minutes. 

The limiting factor is the Github Actions limit of 5 concurrent macOS builds. Without this limit, the total time would be more like 6 minutes.