### PR TITLE
Fix: Add `release` and `environment` to electron uploader `initialScope`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
     ecmaVersion: 2018,
   },
   extends: ['@sentry-internal/sdk'],
-  ignorePatterns: ['build/**', 'dist/**', 'esm/**', 'example/**', 'scripts/**', 'test/integration/**'],
+  ignorePatterns: ['build/**', '**/dist/**', 'esm/**', 'example/**', 'scripts/**', 'test/integration/**'],
   overrides: [
     {
       files: ['*.ts', '*.tsx', '*.d.ts'],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2.5.2
+
+-fix: Add `release` and `environment` to electron uploader `initialScope`
+
 ## 2.5.1
 
 - feat: Context and breadcrumbs sent via Crashpad for native crashes in main process when `useCrashpadMinidumpUploader`

--- a/src/main/backend.ts
+++ b/src/main/backend.ts
@@ -9,7 +9,7 @@ import {
   Scope,
 } from '@sentry/core';
 import { NodeBackend } from '@sentry/node';
-import { Event, EventHint, ScopeContext, Severity, Transport, TransportOptions } from '@sentry/types';
+import { Event, EventHint, Severity, Transport, TransportOptions } from '@sentry/types';
 import { Dsn, forget, logger, SentryError } from '@sentry/utils';
 import { app, crashReporter, ipcMain } from 'electron';
 import { join } from 'path';
@@ -48,7 +48,7 @@ function hasKeys(obj: any): boolean {
 }
 
 /** Gets a Scope object with user, tags and extra */
-function getScope(): Partial<ScopeContext> {
+function getScope(options: ElectronOptions): any {
   const scope = getCurrentHub().getScope() as any | undefined;
 
   if (!scope) {
@@ -56,6 +56,8 @@ function getScope(): Partial<ScopeContext> {
   }
 
   return {
+    release: options.release,
+    environment: options.environment,
     /* eslint-disable @typescript-eslint/no-unsafe-member-access */
     ...(hasKeys(scope._user) && { user: scope._user }),
     ...(hasKeys(scope._tags) && { tags: scope._tags }),
@@ -283,7 +285,7 @@ export class MainBackend extends BaseBackend<ElectronOptions> implements CommonB
     // We don't add globalExtra for Linux because Breakpad doesn't support JSON like strings:
     // https://github.com/electron/electron/issues/29711
     const globalExtra =
-      process.platform !== 'linux' ? { sentry___initialScope: JSON.stringify(getScope()) } : undefined;
+      process.platform !== 'linux' ? { sentry___initialScope: JSON.stringify(getScope(this._options)) } : undefined;
 
     const dsn = new Dsn(dsnString);
 

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -142,7 +142,7 @@ describe('E2E Tests', () => {
       });
 
       // tslint:disable-next-line
-      it('Native crash in renderer process', async function() {
+      it('Native crash in renderer process', async function () {
         await context.start('sentry-basic', 'native-renderer');
         // It can take rather a long time to get the event on Mac
         await context.waitForEvents(testServer, 1, 20000);
@@ -175,6 +175,7 @@ describe('E2E Tests', () => {
         if (process.platform !== 'linux') {
           expect(event.data.user?.id).to.equal('ABCDEF1234567890');
           expect(event.namespaced?.initialScope?.user).to.equal('some_user');
+          expect(event.namespaced?.initialScope?.release).to.equal('some-release');
         }
       });
 
@@ -197,6 +198,7 @@ describe('E2E Tests', () => {
 
         if (process.platform !== 'linux') {
           expect(event.namespaced?.initialScope?.user).to.equal('some_user');
+          expect(event.namespaced?.initialScope?.release).to.equal('some-release');
         }
       });
 
@@ -216,6 +218,7 @@ describe('E2E Tests', () => {
         expect(event.method).to.equal('minidump');
 
         expect(event.namespaced?.initialScope?.user).to.equal('some_user');
+        expect(event.namespaced?.initialScope?.release).to.equal('some-release');
       });
 
       it('JavaScript exception in main process with user data', async () => {
@@ -228,7 +231,7 @@ describe('E2E Tests', () => {
       });
 
       // tslint:disable-next-line
-      it('Native crash in main process', async function() {
+      it('Native crash in main process', async function () {
         await context.start('sentry-basic', 'native-main');
 
         // wait for the main process to die
@@ -330,7 +333,7 @@ describe('E2E Tests', () => {
       });
 
       // tslint:disable-next-line
-      it('Custom release string for minidump', async function() {
+      it('Custom release string for minidump', async function () {
         await context.start('sentry-custom-release', 'native-renderer');
         // It can take rather a long time to get the event on Mac
         await context.waitForEvents(testServer, 1, 20000);
@@ -354,7 +357,7 @@ describe('E2E Tests', () => {
         expect(event.data.contexts && (event.data.contexts.electron as any).crashed_process).to.equal('renderer');
       });
 
-      it('JavaScript exception in contextIsolation renderer process', async function() {
+      it('JavaScript exception in contextIsolation renderer process', async function () {
         // contextIsolation only added >= 6
         if (majorVersion < 6) {
           this.skip();

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -142,7 +142,7 @@ describe('E2E Tests', () => {
       });
 
       // tslint:disable-next-line
-      it('Native crash in renderer process', async function () {
+      it('Native crash in renderer process', async function() {
         await context.start('sentry-basic', 'native-renderer');
         // It can take rather a long time to get the event on Mac
         await context.waitForEvents(testServer, 1, 20000);
@@ -231,7 +231,7 @@ describe('E2E Tests', () => {
       });
 
       // tslint:disable-next-line
-      it('Native crash in main process', async function () {
+      it('Native crash in main process', async function() {
         await context.start('sentry-basic', 'native-main');
 
         // wait for the main process to die
@@ -333,7 +333,7 @@ describe('E2E Tests', () => {
       });
 
       // tslint:disable-next-line
-      it('Custom release string for minidump', async function () {
+      it('Custom release string for minidump', async function() {
         await context.start('sentry-custom-release', 'native-renderer');
         // It can take rather a long time to get the event on Mac
         await context.waitForEvents(testServer, 1, 20000);
@@ -357,7 +357,7 @@ describe('E2E Tests', () => {
         expect(event.data.contexts && (event.data.contexts.electron as any).crashed_process).to.equal('renderer');
       });
 
-      it('JavaScript exception in contextIsolation renderer process', async function () {
+      it('JavaScript exception in contextIsolation renderer process', async function() {
         // contextIsolation only added >= 6
         if (majorVersion < 6) {
           this.skip();

--- a/test/e2e/test-app/fixtures/sentry-electron-uploader-main.js
+++ b/test/e2e/test-app/fixtures/sentry-electron-uploader-main.js
@@ -2,6 +2,7 @@ const { init, configureScope } = require('../../../../');
 
 init({
   appName: 'test-app',
+  release: 'some-release',
   dsn: process.env.DSN,
   debug: true,
   useCrashpadMinidumpUploader: true,

--- a/test/e2e/test-app/fixtures/sentry-electron-uploader-renderer.js
+++ b/test/e2e/test-app/fixtures/sentry-electron-uploader-renderer.js
@@ -2,6 +2,7 @@ const { init, configureScope } = require('../../../../');
 
 init({
   appName: 'test-app',
+  release: 'some-release',
   dsn: process.env.DSN,
   debug: true,
   useCrashpadMinidumpUploader: true,


### PR DESCRIPTION
I'm not sure how long it will take to get #361 merged so this PR adds this functionality to v2.

ref @nornagon comment here **https://github.com/getsentry/sentry-electron/pull/340#issuecomment-901318422** 

![image](https://user-images.githubusercontent.com/1150298/130599249-717e6790-612e-4545-a744-6c268ed9ddce.png)