### PR TITLE
Fix: Possible race condition with `initialScope` over IPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2.5.3
+
+-fix: Possible race condition with `initialScope` over IPC
+
 ## 2.5.2
 
 -fix: Add `release` and `environment` to electron uploader `initialScope`

--- a/src/renderer/client.ts
+++ b/src/renderer/client.ts
@@ -13,6 +13,9 @@ export class RendererClient extends BaseClient<RendererBackend, ElectronOptions>
    * @param options Configuration options for this SDK.
    */
   public constructor(options: ElectronOptions) {
+    // We only handle initialScope in the main process otherwise it can cause race conditions over IPC
+    delete options.initialScope;
+
     super(RendererBackend, options);
   }
 


### PR DESCRIPTION
This change fixes a race condition over IPC found in the v3 branch where `initialScope` passed to the renderer could cause the initial scope to be lost in the main process.

`initialScope` was added so that we could have user ids in crashes sent via the build in electron uploader. That feature will only work if passed to `init` in the main process so this is a non-breaking change.