### PR TITLE
Improve compatibility with bundlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 ## Unreleased
 
+## 2.5.4
+
+- fix: Improve compatibility with bundlers
+
 ## 2.5.3
 
--fix: Possible race condition with `initialScope` over IPC
+- fix: Possible race condition with `initialScope` over IPC
 
 ## 2.5.2
 
--fix: Add `release` and `environment` to electron uploader `initialScope`
+- fix: Add `release` and `environment` to electron uploader `initialScope`
 
 ## 2.5.1
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "access": "public"
   },
   "scripts": {
+    "prebuild": "node scripts/update-version.js",
     "build": "run-p build:es6 build:esm",
     "build:es6": "tsc -p tsconfig.build.json",
     "build:esm": "tsc -p tsconfig.esm.json",

--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -1,0 +1,8 @@
+const { join } = require('path');
+const { readFileSync, writeFileSync } = require('fs');
+
+const version = require('../package.json').version;
+const path = join(__dirname, '../src/main/version.ts');
+const code = readFileSync(path, { encoding: 'utf8' });
+const modified = code.replace(/SDK_VERSION = '[\d\.]*'/, `SDK_VERSION = '${version}'`);
+writeFileSync(path, modified);

--- a/src/main/context.ts
+++ b/src/main/context.ts
@@ -7,10 +7,7 @@ import { join } from 'path';
 
 import { getNameFallback } from '../common';
 import { readDirAsync, readFileAsync } from './fs';
-
-/** SDK version used in every event. */
-// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-export const SDK_VERSION: string = require('../../package.json').version;
+import { SDK_VERSION } from './version';
 
 export const SDK_NAME = 'sentry.javascript.electron';
 

--- a/src/main/version.ts
+++ b/src/main/version.ts
@@ -1,0 +1,1 @@
+export const SDK_VERSION = '2.5.3';


### PR DESCRIPTION
Fixes #365 

Some bundler configurations do not automatically load json files. This PR backports a change from the v3 PR where the SDK version is written to a TypeScript file in a `prebuild` script.