### PR TITLE
feat: add error reporting for electron child-process-gone

### DIFF
--- a/src/main/integrations/electron-minidump.ts
+++ b/src/main/integrations/electron-minidump.ts
@@ -6,7 +6,12 @@ import { app, crashReporter } from 'electron';
 
 import { mergeEvents, normalizeEvent } from '../../common';
 import { getEventDefaults } from '../context';
-import { onRendererProcessGone, rendererRequiresCrashReporterStart, usesCrashpad } from '../electron-normalize';
+import {
+  onChildProcessGone,
+  onRendererProcessGone,
+  rendererRequiresCrashReporterStart,
+  usesCrashpad,
+} from '../electron-normalize';
 import { sessionCrashed } from './main-process-session';
 
 /** Is object defined and has keys */
@@ -76,10 +81,11 @@ export class ElectronMinidump implements Integration {
 
     this._startCrashReporter(options);
 
-    // If a renderer process crashes, mark any existing session as crashed
+    // If any child process crashes, mark any existing session as crashed
     onRendererProcessGone((_, __) => {
       sessionCrashed();
     });
+    onChildProcessGone((_, __) => sessionCrashed());
 
     // If we're using the Crashpad minidump uploader, we set extra parameters whenever the scope updates
     if (usesCrashpad()) {


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-electron/issues/335


I'm not sure how to create a test for this, so any help is appreciated. 

For electron versions older than 11 I'm reporting errors just for `gpu-process-crashed`.