### PR TITLE
Fix: environment

### DIFF
--- a/examples/electron-forge-webpack/event.json
+++ b/examples/electron-forge-webpack/event.json
@@ -50,7 +50,7 @@
       }
     },
     "release": "electron-forge-webpack@1.0.0",
-    "environment": "production",
+    "environment": "development",
     "user": {
       "ip_address": "{{auto}}"
     },

--- a/examples/electron-forge/event.json
+++ b/examples/electron-forge/event.json
@@ -50,7 +50,7 @@
       }
     },
     "release": "electron-forge@1.0.0",
-    "environment": "production",
+    "environment": "development",
     "user": {
       "ip_address": "{{auto}}"
     },

--- a/examples/webpack-context-isolation/event.json
+++ b/examples/webpack-context-isolation/event.json
@@ -50,7 +50,7 @@
       }
     },
     "release": "webpack-context-isolation@1.0.0",
-    "environment": "production",
+    "environment": "development",
     "user": {
       "ip_address": "{{auto}}",
       "id": "abc-123"

--- a/src/main/context.ts
+++ b/src/main/context.ts
@@ -5,6 +5,7 @@ import { app } from 'electron';
 import { platform, release } from 'os';
 import { join } from 'path';
 
+import { isPackaged } from './electron-normalize';
 import { readDirAsync, readFileAsync } from './fs';
 import { SDK_VERSION } from './version';
 
@@ -281,6 +282,11 @@ export function getDefaultReleaseName(): string {
   return `${app_name.replace(/\W/g, '-')}@${app.getVersion()}`;
 }
 
+/** Gets the default environment */
+export function getDefaultEnvironment(): string {
+  return isPackaged ? 'production' : 'development';
+}
+
 /**
  * Computes Electron-specific default fields for events.
  *
@@ -292,7 +298,7 @@ async function _getEventDefaults(release?: string): Promise<Event> {
   return {
     sdk: getSdkInfo(),
     contexts: await getContexts(),
-    environment: process.defaultApp ? 'development' : 'production',
+    environment: getDefaultEnvironment(),
     release: release || getDefaultReleaseName(),
     user: { ip_address: '{{auto}}' },
     tags: {

--- a/src/main/electron-normalize.ts
+++ b/src/main/electron-normalize.ts
@@ -1,8 +1,18 @@
 import { parseSemver } from '@sentry/utils';
 import { app, crashReporter, RenderProcessGoneDetails, WebContents } from 'electron';
+import { basename } from 'path';
 
 const parsed = parseSemver(process.versions.electron);
 const version = { major: parsed.major || 0, minor: parsed.minor || 0, patch: parsed.patch || 0 };
+
+/** Returns if the app is packaged. Copied from Electron to support < v3 */
+export const isPackaged = (() => {
+  const execFile = basename(process.execPath).toLowerCase();
+  if (process.platform === 'win32') {
+    return execFile !== 'electron.exe';
+  }
+  return execFile !== 'electron';
+})();
 
 /**
  * Electron >=8.4 | >=9.1 | >=10

--- a/src/main/sdk.ts
+++ b/src/main/sdk.ts
@@ -2,7 +2,7 @@ import { defaultIntegrations as defaultNodeIntegrations, init as nodeInit, NodeO
 import { Integration } from '@sentry/types';
 import { WebContents } from 'electron';
 
-import { getDefaultReleaseName } from './context';
+import { getDefaultEnvironment, getDefaultReleaseName } from './context';
 import { hookIPC } from './hook-ipc';
 import {
   ElectronEvents,
@@ -41,6 +41,11 @@ export function init(options: ElectronMainOptions): void {
   // If we don't set a release, @sentry/node will automatically fetch from environment variables
   if (options.release === undefined) {
     options.release = getDefaultReleaseName();
+  }
+
+  // If we don't set an environment, @sentry/core defaults to production
+  if (options.environment === undefined) {
+    options.environment = getDefaultEnvironment();
   }
 
   // Unless autoSessionTracking is specifically disabled, we track sessions as the

--- a/src/renderer/integrations/event-to-main.ts
+++ b/src/renderer/integrations/event-to-main.ts
@@ -17,6 +17,10 @@ export class EventToMain implements Integration {
     addGlobalEventProcessor((event: Event) => {
       // Ensure breadcrumbs is not `undefined` as `walk` translates it into a string
       event.breadcrumbs = event.breadcrumbs || [];
+
+      // Remove the environment as it defaults to 'production' and overwrites the main process environment
+      delete event.environment;
+
       // eslint-disable-next-line no-restricted-globals
       window.__SENTRY_IPC__?.sendEvent(JSON.stringify(event, walk));
       // Events are handled and sent from the main process so we return null here so nothing is sent from the renderer

--- a/test/e2e/test-apps/javascript/main-error-custom-release/event.json
+++ b/test/e2e/test-apps/javascript/main-error-custom-release/event.json
@@ -49,7 +49,7 @@
       }
     },
     "release": "custom-name",
-    "environment": "production",
+    "environment": "development",
     "user": {
       "ip_address": "{{auto}}"
     },

--- a/test/e2e/test-apps/javascript/main-error/event.json
+++ b/test/e2e/test-apps/javascript/main-error/event.json
@@ -49,7 +49,7 @@
       }
     },
     "release": "javascript-main@1.0.0",
-    "environment": "production",
+    "environment": "development",
     "user": {
       "ip_address": "{{auto}}"
     },

--- a/test/e2e/test-apps/javascript/main-unhandledrejection/event.json
+++ b/test/e2e/test-apps/javascript/main-unhandledrejection/event.json
@@ -49,7 +49,7 @@
       }
     },
     "release": "javascript-main-unhandledrejection@1.0.0",
-    "environment": "production",
+    "environment": "development",
     "user": {
       "ip_address": "{{auto}}"
     },

--- a/test/e2e/test-apps/javascript/renderer-error-custom-env/README.md
+++ b/test/e2e/test-apps/javascript/renderer-error-custom-env/README.md
@@ -1,0 +1,6 @@
+# JavaScript Renderer Error with custom environment
+
+| Setting       | Value      |
+| ------------- | ---------- |
+| Category      | JavaScript |
+| Build Command | yarn       |

--- a/test/e2e/test-apps/javascript/renderer-error-custom-env/event.json
+++ b/test/e2e/test-apps/javascript/renderer-error-custom-env/event.json
@@ -16,7 +16,7 @@
     },
     "contexts": {
       "app": {
-        "app_name": "javascript-renderer-unhandledrejection",
+        "app_name": "javascript-renderer-custom-env",
         "app_version": "1.0.0"
       },
       "browser": {
@@ -49,8 +49,8 @@
         "crashed_url": "app:///src/index.html"
       }
     },
-    "release": "javascript-renderer-unhandledrejection@1.0.0",
-    "environment": "development",
+    "release": "javascript-renderer-custom-env@1.0.0",
+    "environment": "custom-env",
     "user": {
       "ip_address": "{{auto}}"
     },
@@ -58,7 +58,7 @@
       "values": [
         {
           "type": "Error",
-          "value": "Unhanded promise rejection in renderer process",
+          "value": "Some renderer error",
           "stacktrace": {
             "frames": [
               {
@@ -71,8 +71,8 @@
             ]
           },
           "mechanism": {
-            "handled": false,
-            "type": "onunhandledrejection"
+            "handled": true,
+            "type": "generic"
           }
         }
       ]

--- a/test/e2e/test-apps/javascript/renderer-error-custom-env/package.json
+++ b/test/e2e/test-apps/javascript/renderer-error-custom-env/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "javascript-renderer-custom-env",
+  "version": "1.0.0",
+  "main": "src/main.js",
+  "dependencies": {
+    "@sentry/electron": "3.0.0"
+  }
+}

--- a/test/e2e/test-apps/javascript/renderer-error-custom-env/src/index.html
+++ b/test/e2e/test-apps/javascript/renderer-error-custom-env/src/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <script>
+      const { init } = require('@sentry/electron');
+
+      init({
+        debug: true,
+      });
+
+      setTimeout(() => {
+        throw new Error('Some renderer error');
+      }, 500);
+    </script>
+  </body>
+</html>

--- a/test/e2e/test-apps/javascript/renderer-error-custom-env/src/main.js
+++ b/test/e2e/test-apps/javascript/renderer-error-custom-env/src/main.js
@@ -1,0 +1,24 @@
+const path = require('path');
+
+const { app, BrowserWindow } = require('electron');
+const { init } = require('@sentry/electron');
+
+init({
+  dsn: '__DSN__',
+  debug: true,
+  environment: 'custom-env',
+  autoSessionTracking: false,
+  onFatalError: () => {},
+});
+
+app.on('ready', () => {
+  const mainWindow = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+
+  mainWindow.loadFile(path.join(__dirname, 'index.html'));
+});

--- a/test/e2e/test-apps/javascript/renderer-error-custom-release/event.json
+++ b/test/e2e/test-apps/javascript/renderer-error-custom-release/event.json
@@ -50,7 +50,7 @@
       }
     },
     "release": "custom-name",
-    "environment": "production",
+    "environment": "development",
     "user": {
       "ip_address": "{{auto}}"
     },

--- a/test/e2e/test-apps/javascript/renderer-error/event.json
+++ b/test/e2e/test-apps/javascript/renderer-error/event.json
@@ -50,7 +50,7 @@
       }
     },
     "release": "javascript-renderer@1.0.0",
-    "environment": "production",
+    "environment": "development",
     "user": {
       "ip_address": "{{auto}}"
     },

--- a/test/e2e/test-apps/other/browser-tracing/event.json
+++ b/test/e2e/test-apps/other/browser-tracing/event.json
@@ -111,7 +111,7 @@
       }
     ],
     "release": "some-release",
-    "environment": "production",
+    "environment": "development",
     "user": {
       "ip_address": "{{auto}}"
     },

--- a/test/e2e/test-apps/other/custom-renderer-name/event.json
+++ b/test/e2e/test-apps/other/custom-renderer-name/event.json
@@ -50,7 +50,7 @@
       }
     },
     "release": "custom-renderer-name@1.0.0",
-    "environment": "production",
+    "environment": "development",
     "user": {
       "ip_address": "{{auto}}"
     },

--- a/test/e2e/test-apps/other/scope-breadcrumbs/event.json
+++ b/test/e2e/test-apps/other/scope-breadcrumbs/event.json
@@ -50,7 +50,7 @@
       }
     },
     "release": "scope-breadcrumbs@1.0.0",
-    "environment": "production",
+    "environment": "development",
     "user": {
       "ip_address": "{{auto}}",
       "id": "1234567890"

--- a/test/e2e/test-apps/sessions/javascript-error/event.json
+++ b/test/e2e/test-apps/sessions/javascript-error/event.json
@@ -50,7 +50,7 @@
       }
     },
     "release": "error-session@1.0.0",
-    "environment": "production",
+    "environment": "development",
     "user": {
       "ip_address": "{{auto}}"
     },


### PR DESCRIPTION
I found a few issues where `environment: 'production'` was being added to events by `@sentry/core` and overwriting our defaults.