### PR TITLE
feat: Throw useful errors if code loaded in incorrect process

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -3,3 +3,4 @@ export * from './normalize';
 export * from './walk';
 export * from './merge';
 export * from './mode';
+export * from './process';

--- a/src/common/process.ts
+++ b/src/common/process.ts
@@ -1,0 +1,13 @@
+/** Checks that code is running in the correct process */
+export function ensureProcess(expected: 'main' | 'renderer'): void {
+  // eslint-disable-next-line no-restricted-globals
+  const current = typeof window !== 'undefined' ? 'renderer' : 'main';
+
+  if (current !== expected) {
+    throw new Error(`This code is intended to run in the Electron ${expected} process but is currently running in the ${current} process.
+This can occur if a bundler picks the wrong entry point.
+
+You can work around this by using a relative import:
+import * as Sentry from '@sentry/electron/${current}';`);
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,3 +1,6 @@
+import { ensureProcess } from '../common';
+ensureProcess('main');
+
 import { Integrations as NodeIntegrations } from '@sentry/node';
 
 import * as ElectronMainIntegrations from './integrations';

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -1,3 +1,6 @@
+import { ensureProcess } from '../common';
+ensureProcess('renderer');
+
 import { Integrations as BrowserIntegrations } from '@sentry/browser';
 
 import * as ElectronRendererIntegrations from './integrations';

--- a/test/e2e/test-apps/other/error-main-in-renderer/package.json
+++ b/test/e2e/test-apps/other/error-main-in-renderer/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "error-main-in-renderer",
+  "version": "1.0.0",
+  "main": "src/main.js",
+  "dependencies": {
+    "@sentry/electron": "3.0.0"
+  }
+}

--- a/test/e2e/test-apps/other/error-main-in-renderer/recipe.yml
+++ b/test/e2e/test-apps/other/error-main-in-renderer/recipe.yml
@@ -1,0 +1,3 @@
+description: Error logged when main code loaded in renderer process
+command: yarn
+expectedError: This code is intended to run in the Electron main

--- a/test/e2e/test-apps/other/error-main-in-renderer/src/index.html
+++ b/test/e2e/test-apps/other/error-main-in-renderer/src/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <script>
+      const { init } = require('@sentry/electron/main');
+
+      init({
+        debug: true,
+      });
+    </script>
+  </body>
+</html>

--- a/test/e2e/test-apps/other/error-main-in-renderer/src/main.js
+++ b/test/e2e/test-apps/other/error-main-in-renderer/src/main.js
@@ -1,0 +1,27 @@
+const path = require('path');
+
+const { app, BrowserWindow } = require('electron');
+const { init } = require('@sentry/electron');
+
+init({
+  dsn: '__DSN__',
+  debug: true,
+  autoSessionTracking: false,
+  onFatalError: () => {},
+});
+
+app.on('ready', () => {
+  const mainWindow = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+
+  mainWindow.loadFile(path.join(__dirname, 'index.html'));
+});
+
+setTimeout(() => {
+  process.exit();
+}, 2000);

--- a/test/e2e/test-apps/other/error-renderer-in-main/package.json
+++ b/test/e2e/test-apps/other/error-renderer-in-main/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "error-renderer-in-main",
+  "version": "1.0.0",
+  "main": "src/main.js",
+  "dependencies": {
+    "@sentry/electron": "3.0.0"
+  }
+}

--- a/test/e2e/test-apps/other/error-renderer-in-main/recipe.yml
+++ b/test/e2e/test-apps/other/error-renderer-in-main/recipe.yml
@@ -1,0 +1,3 @@
+description: Error logged when renderer code loaded in main process
+command: yarn
+expectedError: This code is intended to run in the Electron renderer

--- a/test/e2e/test-apps/other/error-renderer-in-main/src/index.html
+++ b/test/e2e/test-apps/other/error-renderer-in-main/src/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <script>
+      const { init } = require('@sentry/electron');
+
+      init({
+        debug: true,
+      });
+    </script>
+  </body>
+</html>

--- a/test/e2e/test-apps/other/error-renderer-in-main/src/main.js
+++ b/test/e2e/test-apps/other/error-renderer-in-main/src/main.js
@@ -1,0 +1,15 @@
+// eslint-disable-next-line import/order
+const { app } = require('electron');
+
+// This is required because we can't deal with the error dialog in CI
+global.process.on('uncaughtException', (error) => {
+  console.log(error);
+  app.quit();
+});
+
+const { init } = require('@sentry/electron/renderer');
+
+init({
+  dsn: '__DSN__',
+  debug: true,
+});


### PR DESCRIPTION
We make a best effort to have the correct code bundled automatically for each process via `package.json/exports` but it will not work in all cases. 

This is likely to occur for example when using ES modules in the main process and loading via the root export:
```ts
import * as Sentry from '@sentry/electron';
```

Previously users would see an error with either `windows is not defined` or `Cannot read properties of undefined (reading 'isReady')` which gives users no idea how to fix this.

These changes provide a better developer experience if a bundler loads the incorrect code for an Electron process by displaying a useful message which guides the user to a solution. 

```
Error: This code is intended to run in the Electron renderer process but is currently running in the main process.
    This can occur if a bundler picks the wrong entry point.

    You can work around this by using a relative import:
    import * as Sentry from '@sentry/electron/main';
```





