### PR TITLE
fix: Export utility types

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,9 +1,9 @@
-type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
+export type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
 
-type OrBool<T> = {
+export type OrBool<T> = {
   [P in keyof T]: T[P] | boolean;
 };
 
-type OrFalse<T> = {
+export type OrFalse<T> = {
   [P in keyof T]: T[P] | false;
 };

--- a/src/main/electron-normalize.ts
+++ b/src/main/electron-normalize.ts
@@ -2,6 +2,8 @@ import { parseSemver } from '@sentry/utils';
 import { app, BrowserWindow, crashReporter, WebContents } from 'electron';
 import { basename } from 'path';
 
+import { Optional } from '../common/types';
+
 const parsed = parseSemver(process.versions.electron);
 const version = { major: parsed.major || 0, minor: parsed.minor || 0, patch: parsed.patch || 0 };
 

--- a/src/main/integrations/child-process.ts
+++ b/src/main/integrations/child-process.ts
@@ -2,6 +2,7 @@ import { addBreadcrumb, captureMessage, getCurrentHub } from '@sentry/core';
 import { NodeClient } from '@sentry/node';
 import { Integration, Severity } from '@sentry/types';
 
+import { OrBool } from '../../common/types';
 import { EXIT_REASONS, ExitReason, onChildProcessGone, onRendererProcessGone } from '../electron-normalize';
 import { ElectronMainOptions } from '../sdk';
 

--- a/src/main/integrations/net-breadcrumbs.ts
+++ b/src/main/integrations/net-breadcrumbs.ts
@@ -5,6 +5,8 @@ import { fill } from '@sentry/utils';
 import { ClientRequest, ClientRequestConstructorOptions, IncomingMessage, net } from 'electron';
 import * as urlModule from 'url';
 
+import { OrBool, OrFalse } from '../../common/types';
+
 type ShouldTraceFn = (method: string, url: string) => boolean;
 
 interface NetOptions {


### PR DESCRIPTION
When using version `3.0.0-beta.4` I see some Typescript errors which seem to be because some utility types are not exported.

```
node_modules/@sentry/electron/main/electron-normalize.d.ts:14:41 - error TS2304: Cannot find name 'Optional'.

14 declare type RenderProcessGoneDetails = Optional<Electron.RenderProcessGoneDetails, 'exitCode'>;
                                           ~~~~~~~~

node_modules/@sentry/electron/main/electron-normalize.d.ts:19:24 - error TS2304: Cannot find name 'Optional'.

19 declare type Details = Optional<Electron.Details, 'exitCode'>;
                          ~~~~~~~~

node_modules/@sentry/electron/main/integrations/child-process.d.ts:19:35 - error TS2304: Cannot find name 'OrBool'.

19     constructor(options?: Partial<OrBool<ChildProcessOptions>>);
                                     ~~~~~~

node_modules/@sentry/electron/main/integrations/net-breadcrumbs.d.ts:26:59 - error TS2304: Cannot find name 'OrBool'.

26 export declare function normalizeOptions(options: Partial<OrBool<NetOptions>>): Partial<OrFalse<NetOptions>>;
                                                             ~~~~~~

node_modules/@sentry/electron/main/integrations/net-breadcrumbs.d.ts:26:89 - error TS2304: Cannot find name 'OrFalse'.

26 export declare function normalizeOptions(options: Partial<OrBool<NetOptions>>): Partial<OrFalse<NetOptions>>;
                                                                                           ~~~~~~~

node_modules/@sentry/electron/main/integrations/net-breadcrumbs.d.ts:35:35 - error TS2304: Cannot find name 'OrBool'.

35     constructor(options?: Partial<OrBool<NetOptions>>);
                                     ~~~~~~


Found 6 errors.
```

This change converts `types.ts` to a module using the `export` keyword and explicitly imports each use of the utility types.

After this change our Typescript project successfully type-checks.