### PR TITLE
fix: Do not require options with defaults in Typescript

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ export { IPCMode } from './common';
  *
  * @see ElectronOptions for documentation on configuration options.
  */
-export function init(options: ElectronOptions): void {
+export function init(options: Partial<ElectronOptions>): void {
   // Filter out any EmptyIntegrations
   removeEmptyIntegrations(options);
 

--- a/src/integrations.ts
+++ b/src/integrations.ts
@@ -84,7 +84,7 @@ class EmptyIntegration implements Integration {
 }
 
 /** Filters out any EmptyIntegrations that are found */
-export function removeEmptyIntegrations(options: ElectronOptions): void {
+export function removeEmptyIntegrations(options: Partial<ElectronOptions>): void {
   if (Array.isArray(options.integrations)) {
     options.integrations = options.integrations.filter((i) => i.name !== EmptyIntegration.id);
   } else if (typeof options.integrations === 'function') {


### PR DESCRIPTION
When initialising with `Sentry.init({...})` make options with default optional in Typescript.
i.e. `ipcMode` and `getSessions`.

See https://github.com/getsentry/sentry-electron/issues/370#issuecomment-1030156807