### PR TITLE
api: Rename `capture` to `events`

### DIFF
--- a/test/e2e/test-apps/other/child-process/src/main.js
+++ b/test/e2e/test-apps/other/child-process/src/main.js
@@ -7,7 +7,7 @@ init({
   dsn: '__DSN__',
   debug: true,
   autoSessionTracking: false,
-  integrations: [new Integrations.ChildProcess({ capture: ['killed'] })],
+  integrations: [new Integrations.ChildProcess({ events: ['killed'] })],
   onFatalError: () => {},
 });
 


### PR DESCRIPTION
While working on the docs, I realised that the options for the `ChildProcess` integration would be more clear if `events` was used instead of `capture`. Better to get this out of the way before releasing a stable release!

So this:
```ts
interface ChildProcessOptions {
  breadcrumbs: Readonly<ExitReason[]>;
  capture: Readonly<ExitReason[]>;
}
```
Becomes:
```ts
interface ChildProcessOptions {
  breadcrumbs: Readonly<ExitReason[]>;
  events: Readonly<ExitReason[]>;
}
```

- `breadcrumbs` controls which events generate Sentry breadcrumbs 
- `events` controls which events generate Sentry events.