### PR TITLE
fix: Fix broken serialization of node transaction spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 3.0.2
+
+- fix: Fix broken serialization of node transaction spans (#419)
+
 ## 3.0.1
 
 - fix: Fixes a potential issue on macOS where the window URL is not accessible after crash (#417)

--- a/src/common/merge.ts
+++ b/src/common/merge.ts
@@ -15,7 +15,16 @@ function removePrivateProperties(event: Event): void {
 export function mergeEvents(defaults: Event, event: Event): Event {
   removePrivateProperties(event);
 
-  const newEvent = deepMerge(defaults, event);
+  const newEvent: Event = deepMerge(defaults, event);
+
+  // We need to copy spans across manually
+  //
+  // Spans contain a custom toJSON function for serialization and without
+  // this they are serialised with camelCase properties rather than the
+  // snake_case required by the Sentry API.
+  if (event.spans || defaults.spans) {
+    newEvent.spans = event.spans || defaults.spans;
+  }
 
   // We don't want packages array in sdk to get merged with duplicates
   return {

--- a/test/e2e/recipe/normalize.ts
+++ b/test/e2e/recipe/normalize.ts
@@ -148,11 +148,26 @@ function normalizeEvent(event: Event): Event {
   if (event.spans) {
     for (const span of event.spans) {
       const spanAny = span as any;
-      spanAny.span_id = '{{id}}';
-      spanAny.parent_span_id = '{{id}}';
-      spanAny.start_timestamp = 0;
-      spanAny.timestamp = 0;
-      spanAny.trace_id = '{{id}}';
+
+      if (spanAny.span_id) {
+        spanAny.span_id = '{{id}}';
+      }
+
+      if (spanAny.parent_span_id) {
+        spanAny.parent_span_id = '{{id}}';
+      }
+
+      if (spanAny.start_timestamp) {
+        spanAny.start_timestamp = 0;
+      }
+
+      if (spanAny.timestamp) {
+        spanAny.timestamp = 0;
+      }
+
+      if (spanAny.trace_id) {
+        spanAny.trace_id = '{{id}}';
+      }
     }
   }
 

--- a/test/e2e/test-apps/other/custom-tracing/event.json
+++ b/test/e2e/test-apps/other/custom-tracing/event.json
@@ -1,0 +1,88 @@
+{
+  "method": "envelope",
+  "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
+  "appId": "277345",
+  "dumpFile": false,
+  "data": {
+    "sdk": {
+      "name": "sentry.javascript.electron",
+      "packages": [
+        {
+          "name": "npm:@sentry/electron",
+          "version": "{{version}}"
+        }
+      ],
+      "version": "{{version}}"
+    },
+    "contexts": {
+      "app": {
+        "app_name": "custom-tracing",
+        "app_version": "1.0.0",
+        "app_start_time": "{{time}}"
+      },
+      "browser": {
+        "name": "Chrome"
+      },
+      "chrome": {
+        "name": "Chrome",
+        "type": "runtime",
+        "version": "{{version}}"
+      },
+      "device": {
+        "arch": "{{arch}}",
+        "family": "Desktop",
+        "memory_size": 0,
+        "free_memory": 0,
+        "processor_count": 0,
+        "processor_frequency": 0,
+        "cpu_description": "{{cpu}}",
+        "screen_resolution": "{{screen}}",
+        "screen_density": 1,
+        "language": "{{language}}"
+      },
+      "node": {
+        "name": "Node",
+        "type": "runtime",
+        "version": "{{version}}"
+      },
+      "os": {
+        "name": "{{platform}}",
+        "version": "{{version}}"
+      },
+      "runtime": {
+        "name": "Electron",
+        "version": "{{version}}"
+      },
+      "trace": {
+        "op": "task",
+        "span_id": "{{id}}",
+        "trace_id": "{{id}}"
+      }
+    },
+    "spans": [
+      {
+        "trace_id": "{{id}}",
+        "span_id": "{{id}}",
+        "start_timestamp": 0,
+        "parent_span_id": "{{id}}",
+        "op": "initializeServices",
+        "timestamp": 0
+      }
+    ],
+    "tags": {
+      "event.origin": "electron",
+      "event.environment": "javascript",
+      "event.process": "browser",
+      "transaction": "InitSequence"
+    },
+    "transaction": "InitSequence",
+    "type": "transaction",
+    "start_timestamp": 0,
+    "timestamp": 0,
+    "release": "custom-tracing@1.0.0",
+    "environment": "development",
+    "event_id": "{{id}}",
+    "platform": "node",
+    "breadcrumbs": []
+  }
+}

--- a/test/e2e/test-apps/other/custom-tracing/event.json
+++ b/test/e2e/test-apps/other/custom-tracing/event.json
@@ -72,8 +72,7 @@
     "tags": {
       "event.origin": "electron",
       "event.environment": "javascript",
-      "event.process": "browser",
-      "transaction": "InitSequence"
+      "event.process": "browser"
     },
     "transaction": "InitSequence",
     "type": "transaction",

--- a/test/e2e/test-apps/other/custom-tracing/package.json
+++ b/test/e2e/test-apps/other/custom-tracing/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "browser-tracing",
+  "name": "custom-tracing",
   "version": "1.0.0",
   "main": "src/main.js",
   "dependencies": {

--- a/test/e2e/test-apps/other/custom-tracing/recipe.yml
+++ b/test/e2e/test-apps/other/custom-tracing/recipe.yml
@@ -1,0 +1,2 @@
+description: Custom Tracing
+command: yarn

--- a/test/e2e/test-apps/other/custom-tracing/src/main.js
+++ b/test/e2e/test-apps/other/custom-tracing/src/main.js
@@ -2,8 +2,7 @@
 const { app } = require('electron');
 
 const Sentry = require('@sentry/electron');
-// eslint-disable-next-line no-unused-vars
-const Tracing = require('@sentry/tracing');
+require('@sentry/tracing');
 
 Sentry.init({
   dsn: '__DSN__',
@@ -15,8 +14,6 @@ Sentry.init({
 
 async function doTransaction() {
   const transaction = Sentry.startTransaction({ name: 'InitSequence', op: 'task' });
-  Sentry.configureScope((scope) => scope.setSpan(transaction));
-
   const initializeServicesSpan = transaction.startChild({ op: 'initializeServices' });
 
   setTimeout(() => {

--- a/test/e2e/test-apps/other/custom-tracing/src/main.js
+++ b/test/e2e/test-apps/other/custom-tracing/src/main.js
@@ -1,0 +1,28 @@
+// eslint-disable-next-line import/order
+const { app } = require('electron');
+
+const Sentry = require('@sentry/electron');
+// eslint-disable-next-line no-unused-vars
+const Tracing = require('@sentry/tracing');
+
+Sentry.init({
+  dsn: '__DSN__',
+  debug: true,
+  autoSessionTracking: false,
+  tracesSampleRate: 1.0,
+  onFatalError: () => {},
+});
+
+async function doTransaction() {
+  const transaction = Sentry.startTransaction({ name: 'InitSequence', op: 'task' });
+  Sentry.configureScope((scope) => scope.setSpan(transaction));
+
+  const initializeServicesSpan = transaction.startChild({ op: 'initializeServices' });
+
+  setTimeout(() => {
+    initializeServicesSpan.finish();
+    transaction.finish();
+  }, 500);
+}
+
+app.on('ready', () => doTransaction());


### PR DESCRIPTION
Fixes #418

The Electron SDK has a `mergeEvents` function which uses `deepmerge`. This saves having a large manual merge function which has to be kept up to date if any of the event objects change. 

The Sentry tracing `Span` has a custom `toJSON` implementation to convert camelCase properties to snake_case to match the Sentry API guidelines. When the event gets merged with the defaults this function is lost.

This PR:
- Manually copies the spans so their `toJSON` function is still there
- Adds an e2e test to ensure this doesn't break in the future
- Improves the e2e event normalisation code so it doesn't add properties