### PR TITLE
fix: Improve error messages for incorrectly bundled code

### DIFF
--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -1,6 +1,3 @@
-import { ensureProcess } from '../common';
-ensureProcess('renderer');
-
 import { Integrations as BrowserIntegrations } from '@sentry/browser';
 
 import * as ElectronRendererIntegrations from './integrations';

--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -2,10 +2,12 @@
 /* eslint-disable no-console */
 import { logger } from '@sentry/utils';
 
-import { IPCChannel, IPCInterface, PROTOCOL_SCHEME } from '../common';
+import { ensureProcess, IPCChannel, IPCInterface, PROTOCOL_SCHEME } from '../common';
 
 /** Gets the available IPC implementation */
 function getImplementation(): IPCInterface {
+  ensureProcess('renderer');
+
   // Favour IPC if it's been exposed by a preload script
   if (window.__SENTRY_IPC__) {
     return window.__SENTRY_IPC__;

--- a/test/e2e/context.ts
+++ b/test/e2e/context.ts
@@ -195,7 +195,7 @@ export class ProcessStatus {
     if (process.platform === 'win32') {
       spawnSync('taskkill /F /IM electron.exe', { shell: true });
     } else if (process.platform === 'darwin') {
-      spawnSync(`kill ${pid}`, { shell: true });
+      spawnSync(`kill -9 ${pid}`, { shell: true });
     }
   }
 

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -37,7 +37,7 @@ describe('E2E Tests', () => {
       });
 
       afterEach(async function () {
-        this.timeout(5_000);
+        this.timeout(10_000);
         await testContext?.stop();
 
         if (this.currentTest?.state === 'failed') {

--- a/test/e2e/test-apps/other/error-entry-point/package.json
+++ b/test/e2e/test-apps/other/error-entry-point/package.json
@@ -6,7 +6,6 @@
     "build": "vite build --config vite.config.main.js"
   },
   "dependencies": {
-    "electron-squirrel-startup": "^1.0.0",
     "@sentry/electron": "3.0.0"
   },
   "devDependencies": {

--- a/test/e2e/test-apps/other/error-entry-point/package.json
+++ b/test/e2e/test-apps/other/error-entry-point/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "error-entry-point",
+  "version": "1.0.0",
+  "main": "dist/main/index.js",
+  "scripts": {
+    "build": "vite build --config vite.config.main.js"
+  },
+  "dependencies": {
+    "electron-squirrel-startup": "^1.0.0",
+    "@sentry/electron": "3.0.0"
+  },
+  "devDependencies": {
+    "vite": "^2.7.10",
+    "electron": "13.1.9"
+  }
+}

--- a/test/e2e/test-apps/other/error-entry-point/recipe.yml
+++ b/test/e2e/test-apps/other/error-entry-point/recipe.yml
@@ -1,5 +1,5 @@
 description: Error thrown if renderer code loaded in main process
 command: yarn && yarn build
-condition: version.major >= 7
+condition: version.major >= 15
 timeout: 120
 expectedError: This code is intended to run in the Electron renderer

--- a/test/e2e/test-apps/other/error-entry-point/recipe.yml
+++ b/test/e2e/test-apps/other/error-entry-point/recipe.yml
@@ -1,0 +1,5 @@
+description: Error thrown if entry point not found
+command: yarn && yarn build
+condition: version.major >= 7
+timeout: 120
+expectedError: This code is intended to run in the Electron renderer

--- a/test/e2e/test-apps/other/error-entry-point/recipe.yml
+++ b/test/e2e/test-apps/other/error-entry-point/recipe.yml
@@ -1,4 +1,4 @@
-description: Error thrown if entry point not found
+description: Error thrown if renderer code loaded in main process
 command: yarn && yarn build
 condition: version.major >= 7
 timeout: 120

--- a/test/e2e/test-apps/other/error-entry-point/src/main/index.js
+++ b/test/e2e/test-apps/other/error-entry-point/src/main/index.js
@@ -1,0 +1,17 @@
+import { app } from 'electron';
+
+global.process.on('unhandledRejection', (error) => {
+  app.quit();
+});
+
+function start() {
+  // We need to do this async otherwise we get a dialog which will break CI
+  //
+  // Because we're using ESM in the main process, this will pick
+  // up the renderer entry point and throw an error
+  import('@sentry/electron').then((_Sentry) => {
+    //
+  });
+}
+
+start();

--- a/test/e2e/test-apps/other/error-entry-point/vite.config.main.js
+++ b/test/e2e/test-apps/other/error-entry-point/vite.config.main.js
@@ -1,0 +1,35 @@
+import { join } from 'path';
+import { builtinModules } from 'module';
+
+const PACKAGE_ROOT = __dirname;
+
+const config = {
+  mode: 'production',
+  root: PACKAGE_ROOT,
+  envDir: process.cwd(),
+  resolve: {
+    alias: {
+      '/@/': `${join(PACKAGE_ROOT, 'src')}/`,
+    },
+  },
+  build: {
+    target: `node8`,
+    outDir: 'dist/main',
+    assetsDir: '.',
+    minify: true,
+    lib: {
+      entry: 'src/main/index.js',
+      formats: ['cjs'],
+    },
+    rollupOptions: {
+      external: ['electron', ...builtinModules],
+      output: {
+        entryFileNames: '[name].js',
+      },
+    },
+    emptyOutDir: true,
+    brotliSize: false,
+  },
+};
+
+export default config;


### PR DESCRIPTION
Fixes #422 

This PR:
- Wraps `dynamicRequire` so the error message is useful
- Moves `ensureProcess('renderer')` to first usage of `window`
  - Adds a test for this

Turns out the existing `ensureProcess` call is completely stripped out because ESM does not support side effects!