### PR TITLE
fix: Delete sdk metadata from event before sending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 3.0.3
+
+- fix: Delete sdk metadata from event before sending (#424)
+- fix: Improve error messages for incorrectly bundled code (#423)
+
 ## 3.0.2
 
 - fix: Fix broken serialization of node transaction spans (#419)

--- a/src/main/transports/electron-net.ts
+++ b/src/main/transports/electron-net.ts
@@ -78,6 +78,9 @@ export class ElectronNetTransport extends Transports.BaseTransport {
       );
     }
 
+    // Delete this metadata as this should not be sent to Sentry.
+    delete event.sdkProcessingMetadata;
+
     const eventPayload = JSON.stringify(event);
     const body = Buffer.from(`${envelopeHeaders}\n${itemHeaders}\n${eventPayload}\n`);
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1150298/156057587-2982cc08-f02d-433b-a0e2-970bbb20f8df.png)
