### PR TITLE
fix: Don't add empty breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 3.0.3
 
+- fix: Don't add empty breadcrumbs (#425)
 - fix: Delete sdk metadata from event before sending (#424)
 - fix: Improve error messages for incorrectly bundled code (#423)
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -56,7 +56,10 @@ export function handleScope(options: ElectronMainOptions, jsonScope: string): vo
       scope.setExtras(sentScope._extra);
     }
 
-    scope.addBreadcrumb(sentScope._breadcrumbs.pop(), options?.maxBreadcrumbs || 100);
+    const breadcrumb = sentScope._breadcrumbs.pop();
+    if (breadcrumb) {
+      scope.addBreadcrumb(breadcrumb, options?.maxBreadcrumbs || 100);
+    }
   });
   /* eslint-enable @typescript-eslint/no-unsafe-member-access */
 }


### PR DESCRIPTION
Looks like we were adding a breadcrumbs on every scope change even if there wasn't actually a breadcrumb!