### PR TITLE
Fix: Bug when listing latest Electron versions

### DIFF
--- a/.github/workflows/new-versions-pr.yml
+++ b/.github/workflows/new-versions-pr.yml
@@ -23,5 +23,6 @@ jobs:
           branch: test/new-electron-versions
           delete-branch: true
           title: 'test: New Electron versions'
+          commit-message: 'test: New Electron versions'
           body: |
             Automatically generated PR to test new Electron releases

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "electron": "15.3.0",
     "@electron/get": "^1.13.0",
     "electron-mocha": "^11.0.0",
-    "electron-latest-versions": "^0.1.6",
+    "electron-latest-versions": "^0.1.7",
     "extract-zip": "^2.0.1",
     "koa": "^2.13.4",
     "koa-bodyparser": "^4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1085,10 +1085,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-electron-latest-versions@^0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/electron-latest-versions/-/electron-latest-versions-0.1.6.tgz#8feed891c06f7bf2c19ea1504a73c57a9a372ed5"
-  integrity sha512-/8S0y0o61uRIhoC/tCZDrXkyIhbFPQnaISomPCuuJajxI3uZvljYWv3WUFoWjyDgqnNHDeCns72owOMCm3sjXg==
+electron-latest-versions@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/electron-latest-versions/-/electron-latest-versions-0.1.7.tgz#f8c3cdc065efc0a11660eb372315d009877ae0bd"
+  integrity sha512-eUbkBwa6rsoh5nWKF2vPPezr3DWlzMgnmrclEneyc0EOUIZESZPtv8uoFX8saEVDMvSNBVZAiXeR2/xMZIjFzQ==
 
 electron-mocha@^11.0.0:
   version "11.0.0"


### PR DESCRIPTION
A bug meant not all versions were getting listed correctly.

https://github.com/getsentry/sentry-electron/pull/429/files

