### PR TITLE
fix: Use `esModuleInterop` for `deepmerge`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 3.0.4
+
+- fix: Use esModuleInterop for deepmerge (#432)
+- fix: Lazily initialise IPC in renderer (#428)
+
 ## 3.0.3
 
 - fix: Don't add empty breadcrumbs (#425)

--- a/src/common/merge.ts
+++ b/src/common/merge.ts
@@ -1,6 +1,5 @@
 import { Event } from '@sentry/types';
-// import * as deepmerge does not work with ES modules
-const deepMerge = require('deepmerge');
+import deepMerge from 'deepmerge';
 
 /** Removes private properties from event before merging */
 function removePrivateProperties(event: Event): void {

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -1,6 +1,6 @@
 import { should, use } from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
-import * as chaiSubset from 'chai-subset';
+import chaiAsPromised from 'chai-as-promised';
+import chaiSubset from 'chai-subset';
 import { join } from 'path';
 
 import { TestContext } from './context';

--- a/test/e2e/recipe/parser.ts
+++ b/test/e2e/recipe/parser.ts
@@ -1,7 +1,7 @@
 import { Event, Session } from '@sentry/types';
 import { readFileSync } from 'fs';
 import { dirname, sep } from 'path';
-import * as YAML from 'yaml';
+import YAML from 'yaml';
 
 import { TestServerEvent } from '../server';
 import { walkSync } from '../utils';

--- a/test/e2e/server/index.ts
+++ b/test/e2e/server/index.ts
@@ -1,8 +1,8 @@
 import { Event, Session } from '@sentry/types';
 import { Server } from 'http';
-import * as Koa from 'koa';
-import * as bodyParser from 'koa-bodyparser';
-import * as Router from 'koa-tree-router';
+import Koa from 'koa';
+import bodyParser from 'koa-bodyparser';
+import Router from 'koa-tree-router';
 import { inspect } from 'util';
 import { eventIsSession } from '../recipe';
 import { createLogger } from '../utils';

--- a/test/e2e/server/multi-part.ts
+++ b/test/e2e/server/multi-part.ts
@@ -1,7 +1,7 @@
 import { Event } from '@sentry/types';
-import * as Busboy from 'busboy';
-import * as Koa from 'koa';
-import * as Router from 'koa-tree-router';
+import Busboy from 'busboy';
+import Koa from 'koa';
+import Router from 'koa-tree-router';
 import { createGunzip } from 'zlib';
 
 import { createLogger } from '../utils';

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -17,6 +17,7 @@
     "module": "commonjs",
     "outDir": ".",
     "rootDir": "src",
-    "target": "es6"
+    "target": "es6",
+    "esModuleInterop": true,
   }
 }

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "esm",
-    "module": "es6"
+    "module": "es6",
+    "esModuleInterop": true,
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,5 @@
   ],
   "compilerOptions": {
     "rootDir": ".",
-    "esModuleInterop": false,
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,14 @@
 {
   "extends": "./tsconfig.build.json",
-  "include": ["src/**/*.ts", "test/**/*.ts"],
-  "exclude": ["dist"],
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ],
+  "exclude": [
+    "dist"
+  ],
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": ".",
+    "esModuleInterop": false,
   }
 }


### PR DESCRIPTION
Fixes #431

It looks like we need to use the TypeScript `esModuleInterop` compiler option for `deepmerge`