### PR TITLE
fix: getSessions should be typed as optional

### DIFF
--- a/src/main/sdk.ts
+++ b/src/main/sdk.ts
@@ -49,7 +49,7 @@ export interface ElectronMainOptions extends NodeOptions {
    *
    * Defaults to () => [session.defaultSession]
    */
-  getSessions: () => Session[];
+  getSessions?: () => Session[];
   /**
    * Callback to allow custom naming of renderer processes.
    *


### PR DESCRIPTION
Documented as optional but typed as required