### PR TITLE
fix: ElectronNetTransport stripping query params from requests

### DIFF
--- a/src/main/transports/electron-net.ts
+++ b/src/main/transports/electron-net.ts
@@ -137,7 +137,12 @@ export class ElectronNetTransport extends Transports.BaseTransport {
       );
     }
 
-    const options = this._getRequestOptions(new url.URL(request.url));
+    const parsedUrl = new url.URL(request.url);
+    const options = this._getRequestOptions(parsedUrl);
+
+    // Ensure query fallback exists
+    options.path += parsedUrl.search;
+
     options.headers = {
       ...options.headers,
       'Content-Type': 'application/x-sentry-envelope',


### PR DESCRIPTION
Ensuring that the query params are present after being stripped out by `_getRequestOptions` [here](https://github.com/getsentry/sentry-javascript/blob/2d3b86122a618500b0c7a1d1017e1d561f789c1f/packages/node/src/transports/base/index.ts#L121).