### PR TITLE
Fix exponential backoff delay overflowing the maximum delay in setTimeout, causing a high number of requests and errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased
+## 3.0.5
+
+- fix: Limit retryDelay to avoid integer overflows in setTimeout (#441)
 
 ## 3.0.4
 
@@ -26,7 +28,9 @@
 A large refactor and simplification of the SDK moving most of the functionality into integrations used with
 `@sentry/browser` and `@sentry/node`.
 
-- Session tracking data sent by default. See our [release health docs for more details](https://docs.sentry.io/product/releases/health/). You can opt out of this behaviour by setting `autoSessionTracking: false` during SDK initialization.
+- Session tracking data sent by default. See our
+  [release health docs for more details](https://docs.sentry.io/product/releases/health/). You can opt out of this
+  behaviour by setting `autoSessionTracking: false` during SDK initialization.
 - Performance monitoring of renderer instances using the `BrowserTracing` integration from `@sentry/tracing`
 - Preload script no longer required [for most scenarios](https://github.com/getsentry/sentry-electron/issues/376)
 - Optional relative imports for main/renderer/preload entry points to help with bundlers

--- a/src/main/transports/electron-offline-net.ts
+++ b/src/main/transports/electron-offline-net.ts
@@ -73,7 +73,7 @@ export class ElectronOfflineNetTransport extends ElectronNetTransport {
     }, this._retryDelay);
 
     this._retryDelay *= 3;
-    
+
     // If the delay is bigger than 2^31 (max signed 32-bit int), setTimeout throws
     // an error and falls back to 1 which can cause a huge number of requests.
     if (this._retryDelay > MAX_DELAY) {

--- a/src/main/transports/electron-offline-net.ts
+++ b/src/main/transports/electron-offline-net.ts
@@ -74,8 +74,8 @@ export class ElectronOfflineNetTransport extends ElectronNetTransport {
 
     this._retryDelay *= 3;
     
-    // If the delay is bigger than 2^32 / 2 (max signed 32-bit int), setTimeout
-    // throws an error and falls back to 1 which can cause a huge number of requests.
+    // If the delay is bigger than 2^31 (max signed 32-bit int), setTimeout throws
+    // an error and falls back to 1 which can cause a huge number of requests.
     if (this._retryDelay > MAX_DELAY) {
       this._retryDelay = MAX_DELAY;
     }


### PR DESCRIPTION
The `setTimeout` function has an interesting implementation detail where, if the delay is bigger than the biggest signed 32-bit integer, it will throw an error and run the callback after 1ms.

The error looks something like this:

```
TimeoutOverflowWarning: Infinity does not fit into a 32-bit signed integer.
Timeout duration was set to 1.
```

Since this error is also reported to Sentry by default, this causes a huge number of errors which can block the main thread.

My workaround for this is to limit the delay to 2,000,000,000 ms so it never overflows.