### PR TITLE
Make `getSessions` and `ipcMode` on `ElectronMainOptions` optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.0.6
+
+- fix: Make `getSessions` and `ipcMode` on `ElectronMainOptions` optional (#448)
+- fix: Webpack issue with `electron-react-boilerplate` (#446)
+
 ## 3.0.5
 
 - fix: Limit retryDelay to avoid integer overflows in setTimeout (#441)

--- a/src/main/integrations/preload-injection.ts
+++ b/src/main/integrations/preload-injection.ts
@@ -7,7 +7,7 @@ import { existsSync } from 'fs';
 
 import { IPCMode } from '../../common';
 import { rendererRequiresCrashReporterStart } from '../electron-normalize';
-import { ElectronMainOptions } from '../sdk';
+import { ElectronMainOptionsInternal } from '../sdk';
 
 /**
  * Injects the preload script into the provided sessions.
@@ -23,7 +23,7 @@ export class PreloadInjection implements Integration {
 
   /** @inheritDoc */
   public setupOnce(): void {
-    const options = getCurrentHub().getClient<NodeClient>()?.getOptions() as ElectronMainOptions;
+    const options = getCurrentHub().getClient<NodeClient>()?.getOptions() as ElectronMainOptionsInternal;
 
     // If classic IPC mode is disabled, we shouldn't attempt to inject preload scripts
     // eslint-disable-next-line no-bitwise
@@ -39,7 +39,7 @@ export class PreloadInjection implements Integration {
   /**
    * Attempts to add the preload script the the provided sessions
    */
-  private _addPreloadToSessions(options: ElectronMainOptions): void {
+  private _addPreloadToSessions(options: ElectronMainOptionsInternal): void {
     let path = undefined;
     try {
       path = rendererRequiresCrashReporterStart()

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -5,12 +5,12 @@ import { app, ipcMain, protocol, WebContents } from 'electron';
 
 import { IPCChannel, IPCMode, mergeEvents, PROTOCOL_SCHEME } from '../common';
 import { supportsFullProtocol, whenAppReady } from './electron-normalize';
-import { ElectronMainOptions } from './sdk';
+import { ElectronMainOptionsInternal } from './sdk';
 
 /**
  * Handle events from the renderer processes
  */
-export function handleEvent(options: ElectronMainOptions, jsonEvent: string, contents?: WebContents): void {
+export function handleEvent(options: ElectronMainOptionsInternal, jsonEvent: string, contents?: WebContents): void {
   let event: Event;
   try {
     event = JSON.parse(jsonEvent) as Event;
@@ -32,7 +32,7 @@ function hasKeys(obj: any): boolean {
 /**
  * Handle scope updates from renderer processes
  */
-export function handleScope(options: ElectronMainOptions, jsonScope: string): void {
+export function handleScope(options: ElectronMainOptionsInternal, jsonScope: string): void {
   let rendererScope: Scope;
   try {
     rendererScope = JSON.parse(jsonScope) as Scope;
@@ -65,7 +65,7 @@ export function handleScope(options: ElectronMainOptions, jsonScope: string): vo
 }
 
 /** Enables Electron protocol handling */
-function configureProtocol(options: ElectronMainOptions): void {
+function configureProtocol(options: ElectronMainOptionsInternal): void {
   if (app.isReady()) {
     throw new SentryError("Sentry SDK should be initialized before the Electron app 'ready' event is fired");
   }
@@ -99,13 +99,13 @@ function configureProtocol(options: ElectronMainOptions): void {
 /**
  * Hooks IPC for communication with the renderer processes
  */
-function configureClassic(options: ElectronMainOptions): void {
+function configureClassic(options: ElectronMainOptionsInternal): void {
   ipcMain.on(IPCChannel.EVENT, ({ sender }, jsonEvent: string) => handleEvent(options, jsonEvent, sender));
   ipcMain.on(IPCChannel.SCOPE, (_, jsonScope: string) => handleScope(options, jsonScope));
 }
 
 /** Sets up communication channels with the renderer */
-export function configureIPC(options: ElectronMainOptions): void {
+export function configureIPC(options: ElectronMainOptionsInternal): void {
   if (!supportsFullProtocol() && options.ipcMode === IPCMode.Protocol) {
     throw new SentryError('IPCMode.Protocol is only supported in Electron >= v5');
   }

--- a/src/main/sdk.ts
+++ b/src/main/sdk.ts
@@ -30,7 +30,7 @@ export const defaultIntegrations: Integration[] = [
   ...defaultNodeIntegrations.filter((integration) => integration.name !== 'OnUncaughtException'),
 ];
 
-export interface ElectronMainOptions extends NodeOptions {
+export interface ElectronMainOptionsInternal extends NodeOptions {
   /**
    * Inter-process communication mode to receive event and scope from renderers
    *
@@ -41,6 +41,7 @@ export interface ElectronMainOptions extends NodeOptions {
    * defaults to IPCMode.Both for maximum compatibility
    */
   ipcMode: IPCMode;
+
   /**
    * A function that returns an array of Electron session objects
    *
@@ -50,6 +51,7 @@ export interface ElectronMainOptions extends NodeOptions {
    * Defaults to () => [session.defaultSession]
    */
   getSessions: () => Session[];
+
   /**
    * Callback to allow custom naming of renderer processes.
    *
@@ -59,7 +61,11 @@ export interface ElectronMainOptions extends NodeOptions {
   getRendererName?: (contents: WebContents) => string | undefined;
 }
 
-const defaultOptions: ElectronMainOptions = {
+// getSessions and ipcMode properties are optional because they have defaults
+export type ElectronMainOptions = Pick<Partial<ElectronMainOptionsInternal>, 'getSessions' | 'ipcMode'> &
+  Omit<ElectronMainOptionsInternal, 'getSessions' | 'ipcMode'>;
+
+const defaultOptions: ElectronMainOptionsInternal = {
   ipcMode: IPCMode.Both,
   getSessions: () => [session.defaultSession],
 };
@@ -67,8 +73,8 @@ const defaultOptions: ElectronMainOptions = {
 /**
  * Initialize Sentry in the Electron main process
  */
-export function init(partialOptions: Partial<ElectronMainOptions>): void {
-  const options: ElectronMainOptions = Object.assign(defaultOptions, partialOptions);
+export function init(userOptions: ElectronMainOptions): void {
+  const options: ElectronMainOptionsInternal = Object.assign(defaultOptions, userOptions);
   const defaults = defaultIntegrations;
 
   // If we don't set a release, @sentry/node will automatically fetch from environment variables


### PR DESCRIPTION
A better version of #435

Because we have defaults, in `ElectronMainOptionsInternal`, these properties are not optional so they don't need to checked checked whenever they're accessed.

`ElectronMainOptions` has these properties made optional using some TypeScript trickery: 

```ts
export type ElectronMainOptions = Pick<Partial<ElectronMainOptionsInternal>, 'getSessions' | 'ipcMode'> &
  Omit<ElectronMainOptionsInternal, 'getSessions' | 'ipcMode'>;
```