### PR TITLE
fix: Throw error if main process code is loaded in renderer

### DIFF
--- a/src/main/sdk.ts
+++ b/src/main/sdk.ts
@@ -1,8 +1,10 @@
+import { ensureProcess, IPCMode } from '../common';
+ensureProcess('main');
+
 import { defaultIntegrations as defaultNodeIntegrations, init as nodeInit, NodeOptions } from '@sentry/node';
 import { Integration } from '@sentry/types';
 import { Session, session, WebContents } from 'electron';
 
-import { IPCMode } from '../common';
 import { getDefaultEnvironment, getDefaultReleaseName } from './context';
 import {
   AdditionalContext,


### PR DESCRIPTION
Ensures a warning is displayed if main process code is loaded in the renderer.

Fixes #456