### PR TITLE
fix: Don't throw on HTTP errors 

### DIFF
--- a/src/main/integrations/main-process-session.ts
+++ b/src/main/integrations/main-process-session.ts
@@ -49,7 +49,7 @@ export class MainProcessSession implements Integration {
       await endSession();
     } catch (e) {
       // Ignore and log any errors which would prevent app exit
-      logger.log('[MainProcessSession] Error ending session', e);
+      logger.warn('[MainProcessSession] Error ending session:', e);
     }
 
     app.exit();

--- a/src/main/transports/electron-offline-net.ts
+++ b/src/main/transports/electron-offline-net.ts
@@ -40,11 +40,11 @@ export class ElectronOfflineNetTransport extends ElectronNetTransport {
         return response;
       } catch (error) {
         if (error instanceof HTTPError && error.status !== 'rate_limit') {
-          logger.log('Dropping request');
           // We don't queue HTTP errors that are not rate limited
-          throw error;
+          logger.warn('Dropping request:', error);
+          return { status: 'failed' };
         } else {
-          logger.log('Error sending', error);
+          logger.log('Error sending:', error);
         }
       }
     } else {


### PR DESCRIPTION
This is a partial fix for #454

We should not be throwing for HTTP errors!