### PR TITLE
fix: Don't capture window titles by default with `ElectronBreadcrumbs` integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.0.7
+
+- fix: Don't capture window titles by default (#463)
+- fix: Don't throw on HTTP errors (#458)
+- fix: Throw error if main process code is loaded in renderer (#457)
+- fix: Don't exit if preventDefault used in will-quit event (#451)
+
 ## 3.0.6
 
 - fix: Update Sentry SDKs to `6.19.2`

--- a/src/main/integrations/electron-breadcrumbs.ts
+++ b/src/main/integrations/electron-breadcrumbs.ts
@@ -50,11 +50,11 @@ interface ElectronBreadcrumbsOptions<T> {
   powerMonitor: T;
 
   /**
-   * Whether to include window titles with webContents/browserWindow breadcrumbs
+   * Whether to capture window titles with webContents/browserWindow breadcrumbs
    *
    * default: false
    */
-  includeWindowTitles: boolean;
+  captureWindowTitles: boolean;
 }
 
 const DEFAULT_OPTIONS: ElectronBreadcrumbsOptions<EventFunction> = {
@@ -80,7 +80,7 @@ const DEFAULT_OPTIONS: ElectronBreadcrumbsOptions<EventFunction> = {
     ].includes(name),
   screen: () => true,
   powerMonitor: () => true,
-  includeWindowTitles: false,
+  captureWindowTitles: false,
 };
 
 /** Converts all user supplied options to function | false */
@@ -88,7 +88,7 @@ export function normalizeOptions(
   options: Partial<ElectronBreadcrumbsOptions<EventTypes>>,
 ): Partial<ElectronBreadcrumbsOptions<EventFunction | false>> {
   return (Object.keys(options) as (keyof ElectronBreadcrumbsOptions<EventTypes>)[]).reduce((obj, k) => {
-    if (k === 'includeWindowTitles') {
+    if (k === 'captureWindowTitles') {
       obj[k] = !!options[k];
     } else {
       const val: EventTypes = options[k];
@@ -185,7 +185,7 @@ export class ElectronBreadcrumbs implements Integration {
         if (id) {
           const state = getRendererProperties(id);
 
-          if (!this._options.includeWindowTitles && state?.title) {
+          if (!this._options.captureWindowTitles && state?.title) {
             delete state.title;
           }
 


### PR DESCRIPTION
Fixes #459

To re-enable:

```ts
init({
  dsn: '__DSN__',
  integrations: [new ElectronBreadcrumbs({ includeWindowTitles: true })]
})
```
