### PR TITLE
feat: Allow closing of SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- feat: Allow closing of SDK (#467)
+
 ## 3.0.7
 
-- fix: export map and sideEffects
+- fix: export map and sideEffects (#464)
 - fix: Don't capture window titles by default (#463)
 - fix: Don't throw on HTTP errors (#458)
 - fix: Throw error if main process code is loaded in renderer (#457)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -44,7 +44,7 @@ export {
   withScope,
 } from '@sentry/core';
 
-export { NodeOptions, NodeBackend, NodeClient, lastEventId } from '@sentry/node';
+export { flush, close, NodeOptions, NodeBackend, NodeClient, lastEventId } from '@sentry/node';
 
 export { ElectronNetTransport } from './transports/electron-net';
 export { ElectronOfflineNetTransport } from './transports/electron-offline-net';

--- a/src/main/integrations/sentry-minidump/index.ts
+++ b/src/main/integrations/sentry-minidump/index.ts
@@ -7,7 +7,7 @@ import { app, crashReporter } from 'electron';
 import { mergeEvents } from '../../../common';
 import { getEventDefaults } from '../../context';
 import { CRASH_REASONS, onChildProcessGone, onRendererProcessGone, usesCrashpad } from '../../electron-normalize';
-import { sentryCachePath } from '../../fs';
+import { sentryCachePath, unlinkAsync } from '../../fs';
 import { getRendererProperties, trackRendererProperties } from '../../renderers';
 import { ElectronMainOptions } from '../../sdk';
 import { checkPreviousSession, sessionCrashed } from '../../sessions';
@@ -202,17 +202,27 @@ export class SentryMinidump implements Integration {
 
     try {
       const paths = await uploader.getNewMinidumps();
-      // We only want to read the scope from disk in case there was a crash last run
+
       if (paths.length > 0) {
-        const currentCloned = Scope.clone(getCurrentHub().getScope());
+        const hub = getCurrentHub();
+        const enabled = !!hub.getClient()?.getOptions().enabled;
+
+        // If the SDK is not enabled, we delete the minidump files so they
+        // dont accumulate and/or get sent later
+        if (!enabled) {
+          paths.forEach((path) => forget(unlinkAsync(path)));
+          return false;
+        }
+
+        const currentCloned = Scope.clone(hub.getScope());
         const storedScope = Scope.clone(this._scopeLastRun);
         let newEvent = await storedScope.applyToEvent(event);
 
         if (newEvent) {
           newEvent = await currentCloned.applyToEvent(newEvent);
 
+          // We handle beforeSend and sampleRate manually here because native crashes do not go through @sentry/core
           const { beforeSend, sampleRate } = options;
-
           if (typeof sampleRate === 'number' && Math.random() > sampleRate) {
             logger.warn(
               `Discarding event because it's not included in the random sample (sampling rate = ${sampleRate})`,

--- a/src/main/integrations/sentry-minidump/index.ts
+++ b/src/main/integrations/sentry-minidump/index.ts
@@ -205,11 +205,11 @@ export class SentryMinidump implements Integration {
 
       if (paths.length > 0) {
         const hub = getCurrentHub();
-        const enabled = !!hub.getClient()?.getOptions().enabled;
+        const enabled = hub.getClient()?.getOptions().enabled;
 
         // If the SDK is not enabled, we delete the minidump files so they
         // dont accumulate and/or get sent later
-        if (!enabled) {
+        if (enabled === false) {
           paths.forEach((path) => forget(unlinkAsync(path)));
           return false;
         }

--- a/test/e2e/recipe/index.ts
+++ b/test/e2e/recipe/index.ts
@@ -4,6 +4,7 @@ import { mkdirSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
 
 import { SDK_VERSION } from '../../../src/main/version';
+import { delay } from '../../helpers';
 import { TestContext } from '../context';
 import { ERROR_ID, RATE_LIMIT_ID, SERVER_PORT, TestServer } from '../server';
 import { createLogger, getTestLog, walkSync } from '../utils';
@@ -163,6 +164,11 @@ export class RecipeRunner {
       (event) =>
         event.condition === undefined || evaluateCondition('event comparison', this._electronVersion, event.condition),
     );
+
+    // If no events are expected, delay to ensure that none are sent!
+    if (expectedEvents.length === 0) {
+      await delay(2_000);
+    }
 
     await context.waitForEvents(testServer, expectedEvents.length);
 

--- a/test/e2e/test-apps/other/close/package.json
+++ b/test/e2e/test-apps/other/close/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "closed-sdk-drops-native",
+  "version": "1.0.0",
+  "main": "src/main.js",
+  "dependencies": {
+    "@sentry/electron": "3.0.0"
+  }
+}

--- a/test/e2e/test-apps/other/close/recipe.yml
+++ b/test/e2e/test-apps/other/close/recipe.yml
@@ -1,0 +1,2 @@
+description: Native crashes dropped when SDK closed
+command: yarn

--- a/test/e2e/test-apps/other/close/src/index.html
+++ b/test/e2e/test-apps/other/close/src/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <script>
+      const { init } = require('@sentry/electron');
+
+      init({
+        debug: true,
+      });
+
+      setTimeout(() => {
+        process.crash();
+      }, 500);
+    </script>
+  </body>
+</html>

--- a/test/e2e/test-apps/other/close/src/main.js
+++ b/test/e2e/test-apps/other/close/src/main.js
@@ -1,0 +1,25 @@
+const path = require('path');
+
+const { app, BrowserWindow } = require('electron');
+const { init, close } = require('@sentry/electron');
+
+init({
+  dsn: '__DSN__',
+  debug: true,
+  autoSessionTracking: false,
+  onFatalError: () => {},
+});
+
+app.on('ready', () => {
+  close().then(() => {
+    const mainWindow = new BrowserWindow({
+      show: false,
+      webPreferences: {
+        nodeIntegration: true,
+        contextIsolation: false,
+      },
+    });
+
+    mainWindow.loadFile(path.join(__dirname, 'index.html'));
+  });
+});


### PR DESCRIPTION
Closes #465 

- Exports `close` and `flush` from `@sentry/node` for the main process
- Exposes `close` and `flush` from the root export and errors if they're called from the renderer
- When `enabled === false`, deletes minidump files rather than sending
- Add a test for the above