### PR TITLE
fix: Delete sdkProcessingMetadata in minidump pipeline

### DIFF
--- a/src/main/integrations/electron-minidump.ts
+++ b/src/main/integrations/electron-minidump.ts
@@ -169,6 +169,8 @@ export class ElectronMinidump implements Integration {
     // Apply the scope to the event
     await scope.applyToEvent(event);
 
+    delete event.sdkProcessingMetadata;
+
     // Normalise paths
     return normalizeEvent(event, app.getAppPath());
   }


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-electron/issues/507

See: https://github.com/getsentry/sentry-javascript/blob/f372d842ba39d5f107c055e97c5219a05c543dba/packages/core/src/envelope.ts?q=sdkProcessingMetadata#L86

Delete `event.sdkProcessingMetadata` before the event is sent as a minidump to Sentry.