### PR TITLE
feat: Optionally attach screenshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## Unreleased
 
-- feat: Optionally attach screenshots (#510)
-- fix: Correctly parse mixed Chrome/node stack traces in the renderer (#509)
-
 ## 4.0.0-beta.1
 
 Updating the underlying Sentry JavaScript SDK's to v7 forces a major version bump due to minor breaking changes in user
@@ -20,6 +17,8 @@ Upgrading to v7 of the Sentry JavaScript SDKs (#471):
 - feat: Allow closing of SDK (#467)
 - fix: Ensure environment is overridden for minidumps (#497)
 - fix: Pass correct event to beforeSend (#481)
+- feat: Optionally attach screenshots (#510)
+- fix: Correctly parse mixed Chrome/node stack traces in the renderer (#509)
 
 ## 3.0.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feat: Optionally attach screenshots (#510)
 - fix: Correctly parse mixed Chrome/node stack traces in the renderer (#509)
 
 ## 4.0.0-beta.1

--- a/examples/electron-forge-webpack/event.json
+++ b/examples/electron-forge-webpack/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": false,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",

--- a/examples/electron-forge/event.json
+++ b/examples/electron-forge/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": false,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",

--- a/examples/electron-react-boilerplate/event.json
+++ b/examples/electron-react-boilerplate/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": false,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",

--- a/examples/electron-vite/event.json
+++ b/examples/electron-vite/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": false,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",

--- a/examples/webpack-context-isolation-preload/event.json
+++ b/examples/webpack-context-isolation-preload/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": false,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",

--- a/examples/webpack-context-isolation/event.json
+++ b/examples/webpack-context-isolation/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": false,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",

--- a/src/integrations.ts
+++ b/src/integrations.ts
@@ -11,6 +11,7 @@ import {
   MainProcessSession,
   OnUncaughtException,
   PreloadInjection,
+  Screenshots,
   SentryMinidump,
 } from './main/integrations';
 import { EventToMain, ScopeToMain } from './renderer/integrations';
@@ -27,6 +28,7 @@ export interface Integrations {
   MainProcessSession: MainProcessSession;
   AdditionalContext: AdditionalContext;
   ChildProcess: ChildProcess;
+  Screenshots: Screenshots;
   // For renderer process
   ScopeToMain: ScopeToMain;
   EventToMain: EventToMain;
@@ -53,6 +55,7 @@ export function getIntegrations(): Integrations {
         MainProcessSession: EmptyIntegration,
         AdditionalContext: EmptyIntegration,
         ChildProcess: EmptyIntegration,
+        Screenshots: EmptyIntegration,
       };
 }
 

--- a/src/main/electron-normalize.ts
+++ b/src/main/electron-normalize.ts
@@ -1,5 +1,5 @@
 import { parseSemver } from '@sentry/utils';
-import { app, BrowserWindow, crashReporter, NativeImage, Rectangle, WebContents } from 'electron';
+import { app, BrowserWindow, crashReporter, NativeImage, WebContents } from 'electron';
 import { basename } from 'path';
 
 import { Optional } from '../common/types';
@@ -190,17 +190,17 @@ export function getCrashesDirectory(): string {
 }
 
 interface OlderBrowserWindow extends Omit<BrowserWindow, 'capturePage'> {
-  capturePage(rect?: Rectangle, callback?: (i: NativeImage) => void): void;
+  capturePage(callback?: (i: NativeImage) => void): void;
 }
 
 /** Captures a NativeImage from a BrowserWindow */
-export function capturePage(window: BrowserWindow, rect?: Rectangle): Promise<NativeImage> {
+export function capturePage(window: BrowserWindow): Promise<NativeImage> {
   // Pre-Electron 5, BrowserWindow.capturePage() uses callbacks
   if (version.major < 5) {
     return new Promise<NativeImage>((resolve) => {
-      (window as OlderBrowserWindow).capturePage(rect, resolve);
+      (window as OlderBrowserWindow).capturePage(resolve);
     });
   }
 
-  return window.capturePage(rect);
+  return window.capturePage();
 }

--- a/src/main/integrations/index.ts
+++ b/src/main/integrations/index.ts
@@ -8,3 +8,4 @@ export { MainProcessSession } from './main-process-session';
 export { AdditionalContext } from './additional-context';
 export { Net } from './net-breadcrumbs';
 export { ChildProcess } from './child-process';
+export { Screenshots } from './screenshots';

--- a/src/main/integrations/screenshots.ts
+++ b/src/main/integrations/screenshots.ts
@@ -1,5 +1,4 @@
 import { getCurrentHub } from '@sentry/core';
-import { NodeClient } from '@sentry/node';
 import { Event, EventHint, EventProcessor, Integration } from '@sentry/types';
 import { logger } from '@sentry/utils';
 import { BrowserWindow } from 'electron';
@@ -17,8 +16,7 @@ export class Screenshots implements Integration {
 
   /** @inheritDoc */
   public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void): void {
-    const attachScreenshot = !!(getCurrentHub().getClient<NodeClient>()?.getOptions() as ElectronMainOptions)
-      .attachScreenshot;
+    const attachScreenshot = !!(getCurrentHub().getClient()?.getOptions() as ElectronMainOptions).attachScreenshot;
 
     if (attachScreenshot) {
       addGlobalEventProcessor(async (event: Event, hint: EventHint) => {
@@ -41,7 +39,7 @@ export class Screenshots implements Integration {
                 count += 1;
               }
             } catch (e) {
-              // Ignore all errors so we don't break event submission if something goes wrong
+              // Catch all errors so we don't break event submission if something goes wrong
               logger.error('Error capturing screenshot', e);
             }
           }

--- a/src/main/integrations/screenshots.ts
+++ b/src/main/integrations/screenshots.ts
@@ -30,11 +30,11 @@ export class Screenshots implements Integration {
             }
 
             try {
-              if (!window.isDestroyed()) {
+              if (!window.isDestroyed() && window.isVisible()) {
                 const filename = count === 1 ? 'screenshot.png' : `screenshot-${count}.png`;
-                const screenshot = (await capturePage(window)).toPNG();
+                const image = await capturePage(window);
 
-                hint.attachments.push({ filename, data: screenshot, contentType: 'image/png' });
+                hint.attachments.push({ filename, data: image.toPNG(), contentType: 'image/png' });
 
                 count += 1;
               }

--- a/src/main/integrations/screenshots.ts
+++ b/src/main/integrations/screenshots.ts
@@ -3,6 +3,7 @@ import { NodeClient } from '@sentry/node';
 import { Event, EventHint, EventProcessor, Integration } from '@sentry/types';
 import { BrowserWindow } from 'electron';
 
+import { capturePage } from '../electron-normalize';
 import { ElectronMainOptions } from '../sdk';
 
 /** Adds Screenshots to events */
@@ -31,7 +32,7 @@ export class Screenshots implements Integration {
 
             try {
               if (!window.isDestroyed()) {
-                const screenshot = (await window.capturePage()).toPNG();
+                const screenshot = (await capturePage(window)).toPNG();
 
                 hint.attachments.push({
                   filename: count === 1 ? 'screenshot.png' : `screenshot-${count}.png`,

--- a/src/main/integrations/screenshots.ts
+++ b/src/main/integrations/screenshots.ts
@@ -1,0 +1,54 @@
+import { getCurrentHub } from '@sentry/core';
+import { NodeClient } from '@sentry/node';
+import { Event, EventHint, EventProcessor, Integration } from '@sentry/types';
+import { BrowserWindow } from 'electron';
+
+import { ElectronMainOptions } from '../sdk';
+
+/** Adds Screenshots to events */
+export class Screenshots implements Integration {
+  /** @inheritDoc */
+  public static id: string = 'Screenshots';
+
+  /** @inheritDoc */
+  public name: string = Screenshots.id;
+
+  /** @inheritDoc */
+  public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void): void {
+    const attachScreenshot = !!(getCurrentHub().getClient<NodeClient>()?.getOptions() as ElectronMainOptions)
+      .attachScreenshot;
+
+    if (attachScreenshot) {
+      addGlobalEventProcessor(async (event: Event, hint: EventHint) => {
+        // We don't capture screenshots for transactions or native crashes
+        if (!event.transaction && event.platform !== 'native') {
+          let count = 1;
+
+          for (const window of BrowserWindow.getAllWindows()) {
+            if (!hint.attachments) {
+              hint.attachments = [];
+            }
+
+            try {
+              if (!window.isDestroyed()) {
+                const screenshot = (await window.capturePage()).toPNG();
+
+                hint.attachments.push({
+                  filename: count === 1 ? 'screenshot.png' : `screenshot-${count}.png`,
+                  data: screenshot,
+                  contentType: 'image/png',
+                });
+
+                count += 1;
+              }
+            } catch (_) {
+              // Ignore all errors so we don't break event submission if something goes wrong
+            }
+          }
+        }
+
+        return event;
+      });
+    }
+  }
+}

--- a/src/main/integrations/screenshots.ts
+++ b/src/main/integrations/screenshots.ts
@@ -1,6 +1,7 @@
 import { getCurrentHub } from '@sentry/core';
 import { NodeClient } from '@sentry/node';
 import { Event, EventHint, EventProcessor, Integration } from '@sentry/types';
+import { logger } from '@sentry/utils';
 import { BrowserWindow } from 'electron';
 
 import { capturePage } from '../electron-normalize';
@@ -32,18 +33,16 @@ export class Screenshots implements Integration {
 
             try {
               if (!window.isDestroyed()) {
+                const filename = count === 1 ? 'screenshot.png' : `screenshot-${count}.png`;
                 const screenshot = (await capturePage(window)).toPNG();
 
-                hint.attachments.push({
-                  filename: count === 1 ? 'screenshot.png' : `screenshot-${count}.png`,
-                  data: screenshot,
-                  contentType: 'image/png',
-                });
+                hint.attachments.push({ filename, data: screenshot, contentType: 'image/png' });
 
                 count += 1;
               }
-            } catch (_) {
+            } catch (e) {
               // Ignore all errors so we don't break event submission if something goes wrong
+              logger.error('Error capturing screenshot', e);
             }
           }
         }

--- a/src/main/sdk.ts
+++ b/src/main/sdk.ts
@@ -15,6 +15,7 @@ import {
   Net,
   OnUncaughtException,
   PreloadInjection,
+  Screenshots,
   SentryMinidump,
 } from './integrations';
 import { configureIPC } from './ipc';
@@ -30,6 +31,7 @@ export const defaultIntegrations: Integration[] = [
   new OnUncaughtException(),
   new PreloadInjection(),
   new AdditionalContext(),
+  new Screenshots(),
   ...defaultNodeIntegrations.filter((integration) => integration.name !== 'OnUncaughtException'),
 ];
 
@@ -62,6 +64,11 @@ export interface ElectronMainOptionsInternal extends Options<ElectronOfflineTran
    * scheme is used.
    */
   getRendererName?: (contents: WebContents) => string | undefined;
+
+  /**
+   * If set to true, screenshots will be captured and included for all events.
+   */
+  attachScreenshot?: boolean;
 }
 
 // getSessions and ipcMode properties are optional because they have defaults

--- a/src/main/sdk.ts
+++ b/src/main/sdk.ts
@@ -68,7 +68,9 @@ export interface ElectronMainOptionsInternal extends Options<ElectronOfflineTran
   /**
    * Screenshots may contain PII and is an opt-in feature
    *
-   * If set to true, screenshots will be captured and included for all events.
+   * If set to true, screenshots will be captured and included with all JavaScript events.
+   * Screenshots are not included for native crashes since it's not possible to capture images of crashed Electron
+   * renderers.
    */
   attachScreenshot?: boolean;
 }

--- a/src/main/sdk.ts
+++ b/src/main/sdk.ts
@@ -66,6 +66,8 @@ export interface ElectronMainOptionsInternal extends Options<ElectronOfflineTran
   getRendererName?: (contents: WebContents) => string | undefined;
 
   /**
+   * Screenshots may contain PII and is an opt-in feature
+   *
    * If set to true, screenshots will be captured and included for all events.
    */
   attachScreenshot?: boolean;

--- a/test/e2e/test-apps/javascript/main-error-custom-release/event.json
+++ b/test/e2e/test-apps/javascript/main-error-custom-release/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": false,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",

--- a/test/e2e/test-apps/javascript/main-error/event.json
+++ b/test/e2e/test-apps/javascript/main-error/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": false,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",

--- a/test/e2e/test-apps/javascript/main-unhandledrejection/event.json
+++ b/test/e2e/test-apps/javascript/main-unhandledrejection/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": false,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",

--- a/test/e2e/test-apps/javascript/preload-error-protocol/event.json
+++ b/test/e2e/test-apps/javascript/preload-error-protocol/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": false,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",

--- a/test/e2e/test-apps/javascript/preload-error/event.json
+++ b/test/e2e/test-apps/javascript/preload-error/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": false,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",

--- a/test/e2e/test-apps/javascript/renderer-error-custom-env/event.json
+++ b/test/e2e/test-apps/javascript/renderer-error-custom-env/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": false,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",

--- a/test/e2e/test-apps/javascript/renderer-error-custom-release/event.json
+++ b/test/e2e/test-apps/javascript/renderer-error-custom-release/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": false,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",

--- a/test/e2e/test-apps/javascript/renderer-error-protocol/event.json
+++ b/test/e2e/test-apps/javascript/renderer-error-protocol/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": false,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",

--- a/test/e2e/test-apps/javascript/renderer-error/event.json
+++ b/test/e2e/test-apps/javascript/renderer-error/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": false,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",

--- a/test/e2e/test-apps/native-electron/gpu/event.json
+++ b/test/e2e/test-apps/native-electron/gpu/event.json
@@ -10,9 +10,9 @@
   },
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": true,
   "data": {
     "event_id": "{{id}}",
     "timestamp": 0
-  }
+  },
+  "attachments": [ { "attachment_type": "event.minidump" } ]
 }

--- a/test/e2e/test-apps/native-electron/main-custom-release/event-no-crashpad.json
+++ b/test/e2e/test-apps/native-electron/main-custom-release/event-no-crashpad.json
@@ -3,9 +3,9 @@
   "method": "minidump",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": true,
   "data": {
     "event_id": "{{id}}",
     "timestamp": 0
-  }
+  },
+  "attachments": [ { "attachment_type": "event.minidump" } ]
 }

--- a/test/e2e/test-apps/native-electron/main-custom-release/event.json
+++ b/test/e2e/test-apps/native-electron/main-custom-release/event.json
@@ -11,7 +11,6 @@
   },
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": true,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",
@@ -70,5 +69,6 @@
       "event.process": "browser",
       "event_type": "native"
     }
-  }
+  },
+  "attachments": [ { "attachment_type": "event.minidump" } ]
 }

--- a/test/e2e/test-apps/native-electron/main/event-no-crashpad.json
+++ b/test/e2e/test-apps/native-electron/main/event-no-crashpad.json
@@ -3,9 +3,9 @@
   "method": "minidump",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": true,
   "data": {
     "event_id": "{{id}}",
     "timestamp": 0
-  }
+  },
+  "attachments": [ { "attachment_type": "event.minidump" } ]
 }

--- a/test/e2e/test-apps/native-electron/main/event.json
+++ b/test/e2e/test-apps/native-electron/main/event.json
@@ -11,7 +11,6 @@
   },
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": true,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",
@@ -70,5 +69,6 @@
       "event.process": "browser",
       "event_type": "native"
     }
-  }
+  },
+  "attachments": [ { "attachment_type": "event.minidump" } ]
 }

--- a/test/e2e/test-apps/native-electron/renderer-custom-release/event-no-crashpad.json
+++ b/test/e2e/test-apps/native-electron/renderer-custom-release/event-no-crashpad.json
@@ -3,9 +3,9 @@
   "method": "minidump",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": true,
   "data": {
     "event_id": "{{id}}",
     "timestamp": 0
-  }
+  },
+  "attachments": [ { "attachment_type": "event.minidump" } ]
 }

--- a/test/e2e/test-apps/native-electron/renderer-custom-release/event.json
+++ b/test/e2e/test-apps/native-electron/renderer-custom-release/event.json
@@ -11,9 +11,9 @@
   },
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": true,
   "data": {
     "event_id": "{{id}}",
     "timestamp": 0
-  }
+  },
+  "attachments": [ { "attachment_type": "event.minidump" } ]
 }

--- a/test/e2e/test-apps/native-electron/renderer/event-no-crashpad.json
+++ b/test/e2e/test-apps/native-electron/renderer/event-no-crashpad.json
@@ -3,9 +3,9 @@
   "method": "minidump",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": true,
   "data": {
     "event_id": "{{id}}",
     "timestamp": 0
-  }
+  },
+  "attachments": [ { "attachment_type": "event.minidump" } ]
 }

--- a/test/e2e/test-apps/native-electron/renderer/event.json
+++ b/test/e2e/test-apps/native-electron/renderer/event.json
@@ -11,9 +11,9 @@
   },
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": true,
   "data": {
     "event_id": "{{id}}",
     "timestamp": 0
-  }
+  },
+  "attachments": [ { "attachment_type": "event.minidump" } ]
 }

--- a/test/e2e/test-apps/native-sentry/gpu/event.json
+++ b/test/e2e/test-apps/native-sentry/gpu/event.json
@@ -66,9 +66,5 @@
       "event_type": "native"
     }
   },
-  "attachments": [
-    {
-      "attachment_type": "event.minidump"
-    }
-  ]
+  "attachments": [ { "attachment_type": "event.minidump" } ]
 }

--- a/test/e2e/test-apps/native-sentry/gpu/event.json
+++ b/test/e2e/test-apps/native-sentry/gpu/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": true,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",
@@ -66,5 +65,10 @@
       "event.process": "GPU",
       "event_type": "native"
     }
-  }
+  },
+  "attachments": [
+    {
+      "attachment_type": "event.minidump"
+    }
+  ]
 }

--- a/test/e2e/test-apps/native-sentry/main-custom-release/event.json
+++ b/test/e2e/test-apps/native-sentry/main-custom-release/event.json
@@ -68,9 +68,5 @@
       "event_type": "native"
     }
   },
-  "attachments": [
-    {
-      "attachment_type": "event.minidump"
-    }
-  ]
+  "attachments": [ { "attachment_type": "event.minidump" } ]
 }

--- a/test/e2e/test-apps/native-sentry/main-custom-release/event.json
+++ b/test/e2e/test-apps/native-sentry/main-custom-release/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": true,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",
@@ -68,5 +67,10 @@
       "event.process": "browser",
       "event_type": "native"
     }
-  }
+  },
+  "attachments": [
+    {
+      "attachment_type": "event.minidump"
+    }
+  ]
 }

--- a/test/e2e/test-apps/native-sentry/main/event.json
+++ b/test/e2e/test-apps/native-sentry/main/event.json
@@ -68,9 +68,5 @@
       "event_type": "native"
     }
   },
-  "attachments": [
-    {
-      "attachment_type": "event.minidump"
-    }
-  ]
+  "attachments": [ { "attachment_type": "event.minidump" } ]
 }

--- a/test/e2e/test-apps/native-sentry/main/event.json
+++ b/test/e2e/test-apps/native-sentry/main/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": true,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",
@@ -68,5 +67,10 @@
       "event.process": "browser",
       "event_type": "native"
     }
-  }
+  },
+  "attachments": [
+    {
+      "attachment_type": "event.minidump"
+    }
+  ]
 }

--- a/test/e2e/test-apps/native-sentry/renderer-custom-release/event.json
+++ b/test/e2e/test-apps/native-sentry/renderer-custom-release/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": true,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",
@@ -71,5 +70,10 @@
       "event.process": "renderer",
       "event_type": "native"
     }
-  }
+  },
+  "attachments": [
+    {
+      "attachment_type": "event.minidump"
+    }
+  ]
 }

--- a/test/e2e/test-apps/native-sentry/renderer-custom-release/event.json
+++ b/test/e2e/test-apps/native-sentry/renderer-custom-release/event.json
@@ -71,9 +71,5 @@
       "event_type": "native"
     }
   },
-  "attachments": [
-    {
-      "attachment_type": "event.minidump"
-    }
-  ]
+  "attachments": [ { "attachment_type": "event.minidump" } ]
 }

--- a/test/e2e/test-apps/native-sentry/renderer/event.json
+++ b/test/e2e/test-apps/native-sentry/renderer/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": true,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",
@@ -71,5 +70,10 @@
       "event.process": "renderer",
       "event_type": "native"
     }
-  }
+  },
+  "attachments": [
+    {
+      "attachment_type": "event.minidump"
+    }
+  ]
 }

--- a/test/e2e/test-apps/native-sentry/renderer/event.json
+++ b/test/e2e/test-apps/native-sentry/renderer/event.json
@@ -71,9 +71,5 @@
       "event_type": "native"
     }
   },
-  "attachments": [
-    {
-      "attachment_type": "event.minidump"
-    }
-  ]
+  "attachments": [ { "attachment_type": "event.minidump" } ]
 }

--- a/test/e2e/test-apps/offline/native-crash/event.json
+++ b/test/e2e/test-apps/offline/native-crash/event.json
@@ -62,9 +62,5 @@
       "event_type": "native"
     }
   },
-  "attachments": [
-    {
-      "attachment_type": "event.minidump"
-    }
-  ]
+  "attachments": [ { "attachment_type": "event.minidump" } ]
 }

--- a/test/e2e/test-apps/offline/native-crash/event.json
+++ b/test/e2e/test-apps/offline/native-crash/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": true,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",
@@ -62,5 +61,10 @@
       "event.process": "renderer",
       "event_type": "native"
     }
-  }
+  },
+  "attachments": [
+    {
+      "attachment_type": "event.minidump"
+    }
+  ]
 }

--- a/test/e2e/test-apps/offline/renderer-error/event.json
+++ b/test/e2e/test-apps/offline/renderer-error/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": false,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",

--- a/test/e2e/test-apps/other/browser-tracing/event.json
+++ b/test/e2e/test-apps/other/browser-tracing/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": false,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",

--- a/test/e2e/test-apps/other/child-process/event.json
+++ b/test/e2e/test-apps/other/child-process/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": false,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",

--- a/test/e2e/test-apps/other/child-process/event2.json
+++ b/test/e2e/test-apps/other/child-process/event2.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": false,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",

--- a/test/e2e/test-apps/other/custom-renderer-name/event.json
+++ b/test/e2e/test-apps/other/custom-renderer-name/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": false,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",

--- a/test/e2e/test-apps/other/custom-tracing/event.json
+++ b/test/e2e/test-apps/other/custom-tracing/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": false,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",

--- a/test/e2e/test-apps/other/error-iframe/event.json
+++ b/test/e2e/test-apps/other/error-iframe/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": false,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",

--- a/test/e2e/test-apps/other/net-breadcrumbs-tracing/event.json
+++ b/test/e2e/test-apps/other/net-breadcrumbs-tracing/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": false,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",

--- a/test/e2e/test-apps/other/net-breadcrumbs/event.json
+++ b/test/e2e/test-apps/other/net-breadcrumbs/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": false,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",

--- a/test/e2e/test-apps/other/scope-breadcrumbs/event.json
+++ b/test/e2e/test-apps/other/scope-breadcrumbs/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": false,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",

--- a/test/e2e/test-apps/other/screenshots/event.json
+++ b/test/e2e/test-apps/other/screenshots/event.json
@@ -15,7 +15,7 @@
     },
     "contexts": {
       "app": {
-        "app_name": "javascript-renderer-unhandledrejection",
+        "app_name": "javascript-screenshots",
         "app_version": "1.0.0",
         "app_start_time": "{{time}}"
       },
@@ -53,7 +53,7 @@
         "version": "{{version}}"
       }
     },
-    "release": "javascript-renderer-unhandledrejection@1.0.0",
+    "release": "javascript-screenshots@1.0.0",
     "environment": "development",
     "user": {
       "ip_address": "{{auto}}"
@@ -62,7 +62,7 @@
       "values": [
         {
           "type": "Error",
-          "value": "Unhanded promise rejection in renderer process",
+          "value": "Some renderer error",
           "stacktrace": {
             "frames": [
               {
@@ -75,8 +75,8 @@
             ]
           },
           "mechanism": {
-            "handled": false,
-            "type": "onunhandledrejection"
+            "handled": true,
+            "type": "generic"
           }
         }
       ]
@@ -95,5 +95,11 @@
       "event.process": "renderer",
       "event_type": "javascript"
     }
-  }
+  },
+  "attachments": [
+    {
+      "filename": "screenshot.png",
+      "content_type": "image/png"
+    }
+  ]
 }

--- a/test/e2e/test-apps/other/screenshots/package.json
+++ b/test/e2e/test-apps/other/screenshots/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "javascript-screenshots",
+  "version": "1.0.0",
+  "main": "src/main.js",
+  "dependencies": {
+    "@sentry/electron": "3.0.0"
+  }
+}

--- a/test/e2e/test-apps/other/screenshots/recipe.yml
+++ b/test/e2e/test-apps/other/screenshots/recipe.yml
@@ -1,0 +1,3 @@
+description: Screenshots on Error
+category: JavaScript
+command: yarn

--- a/test/e2e/test-apps/other/screenshots/recipe.yml
+++ b/test/e2e/test-apps/other/screenshots/recipe.yml
@@ -1,3 +1,2 @@
 description: Screenshots on Error
-category: JavaScript
 command: yarn

--- a/test/e2e/test-apps/other/screenshots/src/index.html
+++ b/test/e2e/test-apps/other/screenshots/src/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <script>
+      const { init } = require('@sentry/electron');
+
+      init({
+        debug: true,
+      });
+
+      setTimeout(() => {
+        throw new Error('Some renderer error');
+      }, 500);
+    </script>
+  </body>
+</html>

--- a/test/e2e/test-apps/other/screenshots/src/main.js
+++ b/test/e2e/test-apps/other/screenshots/src/main.js
@@ -13,7 +13,7 @@ init({
 
 app.on('ready', () => {
   const mainWindow = new BrowserWindow({
-    show: false,
+    show: true,
     webPreferences: {
       nodeIntegration: true,
       contextIsolation: false,

--- a/test/e2e/test-apps/other/screenshots/src/main.js
+++ b/test/e2e/test-apps/other/screenshots/src/main.js
@@ -1,0 +1,24 @@
+const path = require('path');
+
+const { app, BrowserWindow } = require('electron');
+const { init } = require('@sentry/electron');
+
+init({
+  dsn: '__DSN__',
+  debug: true,
+  autoSessionTracking: false,
+  attachScreenshot: true,
+  onFatalError: () => {},
+});
+
+app.on('ready', () => {
+  const mainWindow = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+
+  mainWindow.loadFile(path.join(__dirname, 'index.html'));
+});

--- a/test/e2e/test-apps/sessions/abnormal-exit-electron-uploader/session-previous.json
+++ b/test/e2e/test-apps/sessions/abnormal-exit-electron-uploader/session-previous.json
@@ -2,7 +2,6 @@
   "appId": "277345",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "method": "envelope",
-  "dumpFile": false,
   "data": {
     "sid": "{{id}}",
     "did": "some_user",

--- a/test/e2e/test-apps/sessions/abnormal-exit-electron-uploader/session.json
+++ b/test/e2e/test-apps/sessions/abnormal-exit-electron-uploader/session.json
@@ -2,7 +2,6 @@
   "appId": "277345",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "method": "envelope",
-  "dumpFile": false,
   "data": {
     "sid": "{{id}}",
     "did": "some_user",

--- a/test/e2e/test-apps/sessions/abnormal-exit/session-previous.json
+++ b/test/e2e/test-apps/sessions/abnormal-exit/session-previous.json
@@ -2,7 +2,6 @@
   "appId": "277345",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "method": "envelope",
-  "dumpFile": false,
   "data": {
     "sid": "{{id}}",
     "init": true,

--- a/test/e2e/test-apps/sessions/abnormal-exit/session.json
+++ b/test/e2e/test-apps/sessions/abnormal-exit/session.json
@@ -2,7 +2,6 @@
   "appId": "277345",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "method": "envelope",
-  "dumpFile": false,
   "data": {
     "sid": "{{id}}",
     "init": true,

--- a/test/e2e/test-apps/sessions/good/session-next.json
+++ b/test/e2e/test-apps/sessions/good/session-next.json
@@ -2,7 +2,6 @@
   "appId": "277345",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "method": "envelope",
-  "dumpFile": false,
   "data": {
     "sid": "{{id}}",
     "init": true,

--- a/test/e2e/test-apps/sessions/good/session.json
+++ b/test/e2e/test-apps/sessions/good/session.json
@@ -2,7 +2,6 @@
   "appId": "277345",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "method": "envelope",
-  "dumpFile": false,
   "data": {
     "sid": "{{id}}",
     "init": true,

--- a/test/e2e/test-apps/sessions/javascript-error/event.json
+++ b/test/e2e/test-apps/sessions/javascript-error/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": false,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",

--- a/test/e2e/test-apps/sessions/javascript-error/session-end.json
+++ b/test/e2e/test-apps/sessions/javascript-error/session-end.json
@@ -2,7 +2,6 @@
   "appId": "277345",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "method": "envelope",
-  "dumpFile": false,
   "data": {
     "sid": "{{id}}",
     "init": false,

--- a/test/e2e/test-apps/sessions/javascript-error/session-error.json
+++ b/test/e2e/test-apps/sessions/javascript-error/session-error.json
@@ -2,7 +2,6 @@
   "appId": "277345",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "method": "envelope",
-  "dumpFile": false,
   "data": {
     "sid": "{{id}}",
     "init": true,

--- a/test/e2e/test-apps/sessions/native-crash-main-electron-uploader/event.json
+++ b/test/e2e/test-apps/sessions/native-crash-main-electron-uploader/event.json
@@ -69,9 +69,5 @@
       "event_type": "native"
     }
   },
-  "attachments": [
-    {
-      "attachment_type": "event.minidump"
-    }
-  ]
+  "attachments": [ { "attachment_type": "event.minidump" } ]
 }

--- a/test/e2e/test-apps/sessions/native-crash-main-electron-uploader/event.json
+++ b/test/e2e/test-apps/sessions/native-crash-main-electron-uploader/event.json
@@ -2,7 +2,6 @@
   "method": "minidump",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": true,
   "namespacedData": {
     "initialScope": {
       "release":"session-native-crash-main-electron-uploader@1.0.0",
@@ -69,5 +68,10 @@
       "event.process": "browser",
       "event_type": "native"
     }
-  }
+  },
+  "attachments": [
+    {
+      "attachment_type": "event.minidump"
+    }
+  ]
 }

--- a/test/e2e/test-apps/sessions/native-crash-main-electron-uploader/session-previous.json
+++ b/test/e2e/test-apps/sessions/native-crash-main-electron-uploader/session-previous.json
@@ -2,7 +2,6 @@
   "appId": "277345",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "method": "envelope",
-  "dumpFile": false,
   "data": {
     "sid": "{{id}}",
     "did": "some_user",

--- a/test/e2e/test-apps/sessions/native-crash-main-electron-uploader/session.json
+++ b/test/e2e/test-apps/sessions/native-crash-main-electron-uploader/session.json
@@ -2,7 +2,6 @@
   "appId": "277345",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "method": "envelope",
-  "dumpFile": false,
   "data": {
     "sid": "{{id}}",
     "did": "some_user",

--- a/test/e2e/test-apps/sessions/native-crash-main/event.json
+++ b/test/e2e/test-apps/sessions/native-crash-main/event.json
@@ -68,9 +68,5 @@
       "event_type": "native"
     }
   },
-  "attachments": [
-    {
-      "attachment_type": "event.minidump"
-    }
-  ]
+  "attachments": [ { "attachment_type": "event.minidump" } ]
 }

--- a/test/e2e/test-apps/sessions/native-crash-main/event.json
+++ b/test/e2e/test-apps/sessions/native-crash-main/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": true,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",
@@ -68,5 +67,10 @@
       "event.process": "browser",
       "event_type": "native"
     }
-  }
+  },
+  "attachments": [
+    {
+      "attachment_type": "event.minidump"
+    }
+  ]
 }

--- a/test/e2e/test-apps/sessions/native-crash-main/session-1.json
+++ b/test/e2e/test-apps/sessions/native-crash-main/session-1.json
@@ -2,7 +2,6 @@
   "appId": "277345",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "method": "envelope",
-  "dumpFile": false,
   "data": {
     "sid": "{{id}}",
     "init": true,

--- a/test/e2e/test-apps/sessions/native-crash-main/session-2.json
+++ b/test/e2e/test-apps/sessions/native-crash-main/session-2.json
@@ -2,7 +2,6 @@
   "appId": "277345",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "method": "envelope",
-  "dumpFile": false,
   "data": {
     "sid": "{{id}}",
     "init": true,

--- a/test/e2e/test-apps/sessions/native-crash-main/session-3.json
+++ b/test/e2e/test-apps/sessions/native-crash-main/session-3.json
@@ -2,7 +2,6 @@
   "appId": "277345",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "method": "envelope",
-  "dumpFile": false,
   "data": {
     "sid": "{{id}}",
     "init": false,

--- a/test/e2e/test-apps/sessions/native-crash-renderer-electron-uploader/event-no-crashpad.json
+++ b/test/e2e/test-apps/sessions/native-crash-renderer-electron-uploader/event-no-crashpad.json
@@ -7,9 +7,5 @@
     "event_id": "{{id}}",
     "timestamp": 0
   },
-  "attachments": [
-    {
-      "attachment_type": "event.minidump"
-    }
-  ]
+  "attachments": [ { "attachment_type": "event.minidump" } ]
 }

--- a/test/e2e/test-apps/sessions/native-crash-renderer-electron-uploader/event-no-crashpad.json
+++ b/test/e2e/test-apps/sessions/native-crash-renderer-electron-uploader/event-no-crashpad.json
@@ -3,9 +3,13 @@
   "method": "minidump",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": true,
   "data": {
     "event_id": "{{id}}",
     "timestamp": 0
-  }
+  },
+  "attachments": [
+    {
+      "attachment_type": "event.minidump"
+    }
+  ]
 }

--- a/test/e2e/test-apps/sessions/native-crash-renderer-electron-uploader/event.json
+++ b/test/e2e/test-apps/sessions/native-crash-renderer-electron-uploader/event.json
@@ -15,9 +15,5 @@
     "event_id": "{{id}}",
     "timestamp": 0
   },
-  "attachments": [
-    {
-      "attachment_type": "event.minidump"
-    }
-  ]
+  "attachments": [ { "attachment_type": "event.minidump" } ]
 }

--- a/test/e2e/test-apps/sessions/native-crash-renderer-electron-uploader/event.json
+++ b/test/e2e/test-apps/sessions/native-crash-renderer-electron-uploader/event.json
@@ -11,9 +11,13 @@
   },
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": true,
   "data": {
     "event_id": "{{id}}",
     "timestamp": 0
-  }
+  },
+  "attachments": [
+    {
+      "attachment_type": "event.minidump"
+    }
+  ]
 }

--- a/test/e2e/test-apps/sessions/native-crash-renderer-electron-uploader/session.json
+++ b/test/e2e/test-apps/sessions/native-crash-renderer-electron-uploader/session.json
@@ -2,7 +2,6 @@
   "appId": "277345",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "method": "envelope",
-  "dumpFile": false,
   "data": {
     "sid": "{{id}}",
     "init": true,

--- a/test/e2e/test-apps/sessions/native-crash-renderer/event.json
+++ b/test/e2e/test-apps/sessions/native-crash-renderer/event.json
@@ -2,7 +2,6 @@
   "method": "envelope",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "dumpFile": true,
   "data": {
     "sdk": {
       "name": "sentry.javascript.electron",

--- a/test/e2e/test-apps/sessions/native-crash-renderer/session.json
+++ b/test/e2e/test-apps/sessions/native-crash-renderer/session.json
@@ -2,7 +2,6 @@
   "appId": "277345",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "method": "envelope",
-  "dumpFile": false,
   "data": {
     "sid": "{{id}}",
     "init": true,


### PR DESCRIPTION
Closes #505 

- Adds `attachScreenshot` property to main process options
- Adds `Screenshots` integration which is included by default so it can be enabled via the above option
- On JavaScript error, windows are captured as PNG and added as attachments
- Modified e2e server so that it captures different types of attachments rather than just minidumps
- Modified all e2e test events to use `attachments` rather than `dumpFile`