### PR TITLE
fix: Allow async `beforeSend` in offline transport

### DIFF
--- a/src/main/transports/electron-offline-net.ts
+++ b/src/main/transports/electron-offline-net.ts
@@ -11,7 +11,7 @@ import { PersistedRequestQueue } from './queue';
 type BeforeSendResponse = 'send' | 'queue' | 'drop';
 
 export interface ElectronOfflineTransportOptions extends ElectronNetTransportOptions {
-  beforeSend?: (request: TransportRequest) => BeforeSendResponse;
+  beforeSend?: (request: TransportRequest) => BeforeSendResponse | Promise<BeforeSendResponse>;
 }
 
 const START_DELAY = 5_000;
@@ -72,6 +72,10 @@ export function makeElectronOfflineTransport(options: ElectronOfflineTransportOp
 
   async function makeRequest(request: TransportRequest): Promise<TransportMakeRequestResponse> {
     let action = (options.beforeSend || defaultBeforeSend)(request);
+
+    if (action instanceof Promise) {
+      action = await action;
+    }
 
     if (action === 'send') {
       try {


### PR DESCRIPTION
The Offline transport has an options that allows you to force queueing if the user has not enabled error reporting.

As per [this comment](https://github.com/getsentry/sentry-electron/issues/489#issuecomment-1185027206), I think it would be nice if this function can be async since it's likely to need to do file reads.