### PR TITLE
Make `beforeSend` work from renderers

### DIFF
--- a/src/renderer/integrations/event-to-main.ts
+++ b/src/renderer/integrations/event-to-main.ts
@@ -29,7 +29,7 @@ export class EventToMain implements Integration {
         // Remove the environment as it defaults to 'production' and overwrites the main process environment
         delete event.environment;
 
-        ipc.sendEvent(JSON.stringify(normalize(event, 20, 2_000)));
+        ipc.sendEvent(JSON.stringify(normalize([event, hint], 20, 2_000)));
       }
 
       // Events are handled and sent from the main process so we return null here so nothing is sent from the renderer

--- a/src/renderer/integrations/event-to-main.ts
+++ b/src/renderer/integrations/event-to-main.ts
@@ -1,4 +1,4 @@
-import { Event, EventProcessor, Hub, Integration } from '@sentry/types';
+import { EventProcessor, Hub, Integration } from '@sentry/types';
 import { normalize } from '@sentry/utils';
 
 import { getIPC } from '../ipc';

--- a/test/e2e/test-apps/other/render-beforesend-hint/event.json
+++ b/test/e2e/test-apps/other/render-beforesend-hint/event.json
@@ -1,0 +1,106 @@
+{
+  "method": "envelope",
+  "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
+  "appId": "277345",
+  "data": {
+    "sdk": {
+      "name": "sentry.javascript.electron",
+      "packages": [
+        {
+          "name": "npm:@sentry/electron",
+          "version": "{{version}}"
+        }
+      ],
+      "version": "{{version}}"
+    },
+    "contexts": {
+      "app": {
+        "app_name": "render-beforesend-hint",
+        "app_version": "1.0.0",
+        "app_start_time": "{{time}}"
+      },
+      "browser": {
+        "name": "Chrome"
+      },
+      "chrome": {
+        "name": "Chrome",
+        "type": "runtime",
+        "version": "{{version}}"
+      },
+      "device": {
+        "arch": "{{arch}}",
+        "family": "Desktop",
+        "memory_size": 0,
+        "free_memory": 0,
+        "processor_count": 0,
+        "processor_frequency": 0,
+        "cpu_description": "{{cpu}}",
+        "screen_resolution":"{{screen}}",
+        "screen_density": 1,
+        "language": "{{language}}"
+      },
+      "node": {
+        "name": "Node",
+        "type": "runtime",
+        "version": "{{version}}"
+      },
+      "os": {
+        "name": "{{platform}}",
+        "version": "{{version}}"
+      },
+      "runtime": {
+        "name": "Electron",
+        "version": "{{version}}"
+      }
+    },
+    "release": "render-beforesend-hint@1.0.0",
+    "environment": "development",
+    "user": {
+      "ip_address": "{{auto}}"
+    },
+    "exception": {
+      "values": [
+        {
+          "type": "Error",
+          "value": "Some renderer error",
+          "stacktrace": {
+            "frames": [
+              {
+                "colno": 0,
+                "filename": "app:///src/index.html",
+                "function": "{{function}}",
+                "in_app": true,
+                "lineno": 0
+              }
+            ]
+          },
+          "mechanism": {
+            "handled": true,
+            "type": "generic"
+          }
+        }
+      ]
+    },
+    "level": "error",
+    "event_id": "{{id}}",
+    "platform": "javascript",
+    "timestamp": 0,
+    "breadcrumbs": [],
+    "request": {
+      "url": "app:///src/index.html"
+    },
+    "tags": {
+      "event.environment": "javascript",
+      "event.origin": "electron",
+      "event.process": "renderer",
+      "event_type": "javascript"
+    }
+  },
+  "attachments": [
+    {
+      "type": "attachment",
+      "length": 10,
+      "filename": "file.txt"
+    }
+  ]
+}

--- a/test/e2e/test-apps/other/render-beforesend-hint/package.json
+++ b/test/e2e/test-apps/other/render-beforesend-hint/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "render-beforesend-hint",
+  "version": "1.0.0",
+  "main": "src/main.js",
+  "dependencies": {
+    "@sentry/electron": "3.0.0"
+  }
+}

--- a/test/e2e/test-apps/other/render-beforesend-hint/recipe.only.yml
+++ b/test/e2e/test-apps/other/render-beforesend-hint/recipe.only.yml
@@ -1,0 +1,2 @@
+description: Scope and Breadcrumbs
+command: yarn

--- a/test/e2e/test-apps/other/render-beforesend-hint/src/index.html
+++ b/test/e2e/test-apps/other/render-beforesend-hint/src/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <script>
+      const { init, configureScope } = require('@sentry/electron');
+
+      init({
+        debug: true,
+        beforeSend: (event, hint) => {
+          hint.attachments = [{ filename: 'file.txt', data: '0123456789' }];
+          return event;
+        },
+      });
+
+      setTimeout(() => {
+        throw new Error('Some renderer error');
+      }, 1000);
+    </script>
+  </body>
+</html>

--- a/test/e2e/test-apps/other/render-beforesend-hint/src/main.js
+++ b/test/e2e/test-apps/other/render-beforesend-hint/src/main.js
@@ -1,0 +1,23 @@
+const path = require('path');
+
+const { app, BrowserWindow } = require('electron');
+const { init } = require('@sentry/electron');
+
+init({
+  dsn: '__DSN__',
+  debug: true,
+  autoSessionTracking: false,
+  onFatalError: () => {},
+});
+
+app.on('ready', () => {
+  const mainWindow = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+
+  mainWindow.loadFile(path.join(__dirname, 'index.html'));
+});


### PR DESCRIPTION
Renderer events are passed to the main process via the `EventToMain` integration. The downside of using an integration/global event processor to do this is that the renderer `beforeSend` never gets called.

This PR calls `beforeSend` from `EventToMain` so that it functions as it should!

This closes #533.