### PR TITLE
feat: Make the store completely async

### DIFF
--- a/src/main/integrations/electron-minidump.ts
+++ b/src/main/integrations/electron-minidump.ts
@@ -96,9 +96,10 @@ export class ElectronMinidump implements Integration {
     }
 
     // Check if last crash report was likely to have been unreported in the last session
-    const previousSessionCrashed = unreportedDuringLastSession(crashReporter.getLastCrashReport()?.date);
-    // Check if a previous session was not closed
-    checkPreviousSession(previousSessionCrashed).catch((error) => logger.error(error));
+    void unreportedDuringLastSession(crashReporter.getLastCrashReport()?.date).then((crashed) => {
+      // Check if a previous session was not closed
+      checkPreviousSession(crashed).catch((error) => logger.error(error));
+    });
   }
 
   /**

--- a/src/main/integrations/main-process-session.ts
+++ b/src/main/integrations/main-process-session.ts
@@ -14,7 +14,7 @@ export class MainProcessSession implements Integration {
 
   /** @inheritDoc */
   public setupOnce(): void {
-    startSession();
+    void startSession();
 
     // We track sessions via the 'will-quit' event which is the last event emitted before close.
     //

--- a/src/main/integrations/sentry-minidump/index.ts
+++ b/src/main/integrations/sentry-minidump/index.ts
@@ -26,7 +26,7 @@ export class SentryMinidump implements Integration {
   private _scopeStore?: Store<Scope>;
 
   /** Temp store for the scope of last run */
-  private _scopeLastRun?: Scope;
+  private _scopeLastRun?: Promise<Scope>;
 
   private _minidumpLoader?: MinidumpLoader;
 
@@ -170,14 +170,14 @@ export class SentryMinidump implements Integration {
   private _setupScopeListener(): void {
     const hubScope = getCurrentHub().getScope();
     if (hubScope) {
-      hubScope.addScopeListener((updatedScope) => {
+      hubScope.addScopeListener(async (updatedScope) => {
         const scope = Scope.clone(updatedScope);
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         (scope as any)._eventProcessors = [];
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         (scope as any)._scopeListeners = [];
 
-        this._scopeStore?.set(scope);
+        await this._scopeStore?.set(scope);
       });
     }
   }
@@ -224,7 +224,7 @@ export class SentryMinidump implements Integration {
           return false;
         }
 
-        const storedScope = Scope.clone(this._scopeLastRun);
+        const storedScope = Scope.clone(await this._scopeLastRun);
         let newEvent = await storedScope.applyToEvent(event);
 
         const hubScope = hub.getScope();

--- a/src/main/sessions.ts
+++ b/src/main/sessions.ts
@@ -1,7 +1,7 @@
 import { getCurrentHub } from '@sentry/core';
 import { makeSession, updateSession } from '@sentry/hub';
 import { flush, NodeClient } from '@sentry/node';
-import { SerializedSession, SessionContext, SessionStatus } from '@sentry/types';
+import { SerializedSession, Session, SessionContext, SessionStatus } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
 import { sentryCachePath } from './fs';
@@ -13,22 +13,21 @@ const PERSIST_INTERVAL_MS = 60_000;
 const sessionStore = new Store<SessionContext | undefined>(sentryCachePath, 'session', undefined);
 
 /** Previous session that did not exit cleanly */
-let previousSession = sessionStore.get();
-const previousSessionModified = sessionStore.getModifiedDate();
+let previousSession: Promise<Partial<Session> | undefined> | undefined = sessionStore.get();
 
 let persistTimer: NodeJS.Timer | undefined;
 
 /** Starts a session */
-export function startSession(): void {
+export async function startSession(): Promise<void> {
   const hub = getCurrentHub();
-  sessionStore.set(hub.startSession());
+  await sessionStore.set(hub.startSession(), true);
 
   // Every PERSIST_INTERVAL, write the session to disk
-  persistTimer = setInterval(() => {
+  persistTimer = setInterval(async () => {
     const currentSession = hub.getScope()?.getSession();
     // Only bother saving if it hasn't already ended
     if (currentSession && currentSession.status === 'ok') {
-      sessionStore.set(currentSession);
+      await sessionStore.set(currentSession);
     }
   }, PERSIST_INTERVAL_MS);
 }
@@ -54,19 +53,20 @@ export async function endSession(): Promise<void> {
     logger.log('No session');
   }
 
-  sessionStore.set(undefined, true);
+  await sessionStore.set(undefined, true);
 
   await flush();
 }
 
 /** Determines if a Date is likely to have occurred in the previous uncompleted session */
-export function unreportedDuringLastSession(crashDate: Date | undefined): boolean {
+export async function unreportedDuringLastSession(crashDate: Date | undefined): Promise<boolean> {
   if (!crashDate) {
     return false;
   }
 
+  const previousSessionModified = await sessionStore.getModifiedDate();
   // There is no previous session
-  if (!previousSessionModified) {
+  if (previousSessionModified == undefined) {
     return false;
   }
 
@@ -87,9 +87,11 @@ export function unreportedDuringLastSession(crashDate: Date | undefined): boolea
 export async function checkPreviousSession(crashed: boolean): Promise<void> {
   const client = getCurrentHub().getClient<NodeClient>();
 
-  if (previousSession && client) {
+  const previous = await previousSession;
+
+  if (previous && client) {
     // Ignore if the previous session is already ended
-    if (previousSession.status !== 'ok') {
+    if (previous.status !== 'ok') {
       previousSession = undefined;
       return;
     }
@@ -98,13 +100,13 @@ export async function checkPreviousSession(crashed: boolean): Promise<void> {
 
     logger.log(`Found previous ${status} session`);
 
-    const sesh = makeSession(previousSession);
+    const sesh = makeSession(previous);
 
     updateSession(sesh, {
       status,
       errors: (sesh.errors || 0) + 1,
-      release: (previousSession as unknown as SerializedSession).attrs?.release,
-      environment: (previousSession as unknown as SerializedSession).attrs?.environment,
+      release: (previous as unknown as SerializedSession).attrs?.release,
+      environment: (previous as unknown as SerializedSession).attrs?.environment,
     });
 
     await client.sendSession(sesh);

--- a/src/main/transports/queue.ts
+++ b/src/main/transports/queue.ts
@@ -33,7 +33,7 @@ export class PersistedRequestQueue {
   public async add(request: QueuedTransportRequest): Promise<void> {
     const bodyPath = uuid4();
 
-    this._queue.update((queue) => {
+    await this._queue.update((queue) => {
       queue.push({
         bodyPath,
         date: request.date || new Date(),
@@ -60,7 +60,7 @@ export class PersistedRequestQueue {
     let found: PersistedRequest | undefined;
     const cutOff = Date.now() - MILLISECONDS_PER_DAY * this._maxAgeDays;
 
-    this._queue.update((queue) => {
+    await this._queue.update((queue) => {
       while ((found = queue.shift())) {
         // We drop events created in v3 of the SDK or before the cut-off
         if ('type' in found || found.date.getTime() < cutOff) {


### PR DESCRIPTION
Closes #534

Converts all the store methods to be async and calls async `fs` methods instead of the sync ones.