### PR TITLE
Update to v7.12.1 of JavaScript SDKs

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,19 +57,19 @@
     "e2e": "cross-env TS_NODE_PROJECT=tsconfig.json xvfb-maybe mocha --require ts-node/register/transpile-only --retries 3 ./test/e2e/*.ts"
   },
   "dependencies": {
-    "@sentry/browser": "7.11.1",
-    "@sentry/core": "7.11.1",
-    "@sentry/hub": "7.11.1",
-    "@sentry/node": "7.11.1",
-    "@sentry/types": "7.11.1",
-    "@sentry/utils": "7.11.1",
+    "@sentry/browser": "7.12.1",
+    "@sentry/core": "7.12.1",
+    "@sentry/hub": "7.12.1",
+    "@sentry/node": "7.12.1",
+    "@sentry/types": "7.12.1",
+    "@sentry/utils": "7.12.1",
     "deepmerge": "^4.2.2",
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@sentry-internal/eslint-config-sdk": "7.11.1",
-    "@sentry-internal/typescript": "7.11.1",
-    "@sentry/tracing": "7.11.1",
+    "@sentry-internal/eslint-config-sdk": "7.12.1",
+    "@sentry-internal/typescript": "7.12.1",
+    "@sentry/tracing": "7.12.1",
     "@types/busboy": "^0.2.3",
     "@types/chai": "^4.2.10",
     "@types/chai-as-promised": "^7.1.5",

--- a/src/main/integrations/additional-context.ts
+++ b/src/main/integrations/additional-context.ts
@@ -1,4 +1,4 @@
-import { Event, EventProcessor, Integration } from '@sentry/types';
+import { DeviceContext, Event, EventProcessor, Integration } from '@sentry/types';
 import { app, screen as electronScreen } from 'electron';
 import { CpuInfo, cpus } from 'os';
 
@@ -19,21 +19,6 @@ const DEFAULT_OPTIONS: AdditionalContextOptions = {
   language: true,
 };
 
-interface LazyDeviceContext {
-  language?: string;
-  screen_resolution?: string;
-  screen_density?: number;
-}
-
-interface AdditionalDeviceContext extends LazyDeviceContext {
-  memory_size?: number;
-  free_memory?: number;
-  processor_count?: number;
-  cpu_description?: string;
-  processor_frequency?: number;
-  machine_arch?: string;
-}
-
 /** Adds Electron context to events and normalises paths. */
 export class AdditionalContext implements Integration {
   /** @inheritDoc */
@@ -43,7 +28,7 @@ export class AdditionalContext implements Integration {
   public name: string = AdditionalContext.id;
 
   private readonly _options: AdditionalContextOptions;
-  private _lazyDeviceContext: LazyDeviceContext = {};
+  private _lazyDeviceContext: DeviceContext = {};
 
   public constructor(options: Partial<AdditionalContextOptions> = {}) {
     this._options = {
@@ -76,7 +61,7 @@ export class AdditionalContext implements Integration {
 
   /** Adds additional context to event */
   private _addAdditionalContext(event: Event): Event {
-    const device: AdditionalDeviceContext = this._lazyDeviceContext;
+    const device: DeviceContext = this._lazyDeviceContext;
 
     const { memory, cpu } = this._options;
 
@@ -101,7 +86,7 @@ export class AdditionalContext implements Integration {
       }
     }
 
-    return mergeEvents(event, { contexts: { device: device as Record<string, string | number> } });
+    return mergeEvents(event, { contexts: { device } });
   }
 
   /** Sets the display info */

--- a/src/main/sdk.ts
+++ b/src/main/sdk.ts
@@ -32,7 +32,9 @@ export const defaultIntegrations: Integration[] = [
   new PreloadInjection(),
   new AdditionalContext(),
   new Screenshots(),
-  ...defaultNodeIntegrations.filter((integration) => integration.name !== 'OnUncaughtException'),
+  ...defaultNodeIntegrations.filter(
+    (integration) => integration.name !== 'OnUncaughtException' && integration.name !== 'Context',
+  ),
 ];
 
 export interface ElectronMainOptionsInternal extends Options<ElectronOfflineTransportOptions> {

--- a/test/e2e/test-apps/other/browser-tracing/package.json
+++ b/test/e2e/test-apps/other/browser-tracing/package.json
@@ -4,6 +4,6 @@
   "main": "src/main.js",
   "dependencies": {
     "@sentry/electron": "3.0.0",
-    "@sentry/tracing": "7.11.1"
+    "@sentry/tracing": "7.12.1"
   }
 }

--- a/test/e2e/test-apps/other/custom-tracing/package.json
+++ b/test/e2e/test-apps/other/custom-tracing/package.json
@@ -4,6 +4,6 @@
   "main": "src/main.js",
   "dependencies": {
     "@sentry/electron": "3.0.0",
-    "@sentry/tracing": "7.11.1"
+    "@sentry/tracing": "7.12.1"
   }
 }

--- a/test/e2e/test-apps/other/net-breadcrumbs-tracing/package.json
+++ b/test/e2e/test-apps/other/net-breadcrumbs-tracing/package.json
@@ -4,7 +4,7 @@
   "main": "src/main.js",
   "dependencies": {
     "@sentry/electron": "3.0.0",
-    "@sentry/tracing": "7.11.1",
+    "@sentry/tracing": "7.12.1",
     "electron-fetch": "1.7.4"
   }
 }

--- a/test/e2e/test-apps/other/net-breadcrumbs/package.json
+++ b/test/e2e/test-apps/other/net-breadcrumbs/package.json
@@ -4,7 +4,7 @@
   "main": "src/main.js",
   "dependencies": {
     "@sentry/electron": "3.0.0",
-    "@sentry/tracing": "7.11.1",
+    "@sentry/tracing": "7.12.1",
     "electron-fetch": "1.7.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -100,13 +100,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@sentry-internal/eslint-config-sdk@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.11.1.tgz#b6f4048815d35606e9111ea6604707155055e2cb"
-  integrity sha512-iZmJGHMcsLk+ovihIII1VReAhZvAUKLtesM7pCjOmcDM7TaPVPj4HAgRCwL3oPPryTljmYEgnr0XeqDhrUhoyA==
+"@sentry-internal/eslint-config-sdk@7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.12.1.tgz#2eea4ca6ad3013ddb274031f1cc377be7a2adb07"
+  integrity sha512-a8vrOTQAmnU7jECSy7wiXf3/Z156lSud1tWZmKI8FPakvmidISPu7m96TlAY/fSysv2UoiKMjpfpBizjttnIGA==
   dependencies:
-    "@sentry-internal/eslint-plugin-sdk" "7.11.1"
-    "@sentry-internal/typescript" "7.11.1"
+    "@sentry-internal/eslint-plugin-sdk" "7.12.1"
+    "@sentry-internal/typescript" "7.12.1"
     "@typescript-eslint/eslint-plugin" "^3.9.0"
     "@typescript-eslint/parser" "^3.9.0"
     eslint-config-prettier "^6.11.0"
@@ -115,82 +115,82 @@
     eslint-plugin-jsdoc "^30.0.3"
     eslint-plugin-simple-import-sort "^5.0.3"
 
-"@sentry-internal/eslint-plugin-sdk@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.11.1.tgz#b179bca47e31df3d5202ac36dd360f7d08b850a8"
-  integrity sha512-RcibkVAcRnvEj0G8Pj9sDva1KgzO6BvbXLEHCg2i/vF761OHGrn1WLhtasALRPD4xZjqr0+YPt8RoDeXlYEhVw==
+"@sentry-internal/eslint-plugin-sdk@7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.12.1.tgz#9aea7ba346f07036479fb114b6d4d3d90b218a22"
+  integrity sha512-q1Ke/14TWDbAoc2In7+jGNw0xXVfQgHows9/uhNXHhI68PjdtO2dKUR66kgbHiZe5O/4lGTlxzRTANBSKOShtA==
   dependencies:
     requireindex "~1.1.0"
 
-"@sentry-internal/typescript@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.11.1.tgz#651ce17e5d1a8fa95f9b8d59edcf428e17748b6e"
-  integrity sha512-vTqJiEuj4MFbVOxvTj0rMQOE4HEwnx/zkEoDCuZnb05OCeba8UzKc7xDBhnE+CuyYeEg7bjhA/o6iNMjPjMxQw==
+"@sentry-internal/typescript@7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.12.1.tgz#e08d8275aa8ac1f60c67fe605275eb031aba5eb6"
+  integrity sha512-79UcEk5++A7jUyTOa/DX/jJRW1OMcjtVqCk+aXF5hZbHM7qNjL1F8ZClxEq2SSstwuF0Q+ESHwK30VUR79NbwQ==
 
-"@sentry/browser@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.11.1.tgz#377d417e833ef54c78a93ef720a742bda5022625"
-  integrity sha512-k2XHuzPfnm8VJPK5eWd1+Y5VCgN42sLveb8Qxc3prb5PSL416NWMLZaoB7RMIhy430fKrSFiosnm6QDk2M6pbA==
+"@sentry/browser@7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.12.1.tgz#2be6fa5c2529a2a75abac4d00aca786362302a1a"
+  integrity sha512-pgyL65CrGFLe8sKcEG8KXAuVTE8zkAsyTlv/AuME06cSdxzO/memPK/r3BI6EM7WupIdga+V5tQUldeT1kgHNA==
   dependencies:
-    "@sentry/core" "7.11.1"
-    "@sentry/types" "7.11.1"
-    "@sentry/utils" "7.11.1"
+    "@sentry/core" "7.12.1"
+    "@sentry/types" "7.12.1"
+    "@sentry/utils" "7.12.1"
     tslib "^1.9.3"
 
-"@sentry/core@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.11.1.tgz#d68e796f3b6428aefd6086a1db00118df7a9a9e4"
-  integrity sha512-kaDSZ6VNuO4ZZdqUOOX6XM6x+kjo2bMnDQ3IJG51FPvVjr8lXYhXj1Ccxcot3pBYAIWPPby2+vNDOXllmXqoBA==
+"@sentry/core@7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.12.1.tgz#a22f1c530ed528a699ed204c36eb5fc8d308103d"
+  integrity sha512-DFHbzHFjukhlkRZ5xzfebx0IBzblW43kmfnalBBq7xEMscUvnhsYnlvL9Y20tuPZ/PrTcq4JAHbFluAvw6M0QQ==
   dependencies:
-    "@sentry/hub" "7.11.1"
-    "@sentry/types" "7.11.1"
-    "@sentry/utils" "7.11.1"
+    "@sentry/hub" "7.12.1"
+    "@sentry/types" "7.12.1"
+    "@sentry/utils" "7.12.1"
     tslib "^1.9.3"
 
-"@sentry/hub@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.11.1.tgz#1749b2b102ea1892ff388d65d66d3b402b393958"
-  integrity sha512-M6ClgdXdptS0lUBKB5KpXXe2qMQhsoiEN2pEGRI6+auqhfHCUQB1ZXsfjiOYexKC9fwx7TyFyZ9Jcaf2DTxEhw==
+"@sentry/hub@7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.12.1.tgz#dffad40cd2b8f44df2d5f20a89df87879cbbf1c3"
+  integrity sha512-KLVnVqXf+CRmXNy9/T8K2/js7QvOQ94xtgP5KnWJbu2rl+JhxnIGiBRF51lPXFIatt7zWwB9qNdMS8lVsvLMGQ==
   dependencies:
-    "@sentry/types" "7.11.1"
-    "@sentry/utils" "7.11.1"
+    "@sentry/types" "7.12.1"
+    "@sentry/utils" "7.12.1"
     tslib "^1.9.3"
 
-"@sentry/node@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.11.1.tgz#97fd26de26e8203a3c34e26b38f3c2a5ba46828b"
-  integrity sha512-EAAHou/eHSzwRK0Z5qnQiwXNbkpnjWjloaG979gftA+MS/kM0AxQHdOrSJQbOEaqRf3F7/eC4Hj+1tfglAuaLQ==
+"@sentry/node@7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.12.1.tgz#ced12d0db3ca5715d699858acb1e2f2ea1d7c59b"
+  integrity sha512-ZVT2+lLd3gbhOuCOczlFLHH2KnD4EXrq6jRp5Sb2vsSZGVHnVsbD5j7i54zbSBqcydlFqzVMqWSysGTKoYiimw==
   dependencies:
-    "@sentry/core" "7.11.1"
-    "@sentry/hub" "7.11.1"
-    "@sentry/types" "7.11.1"
-    "@sentry/utils" "7.11.1"
+    "@sentry/core" "7.12.1"
+    "@sentry/hub" "7.12.1"
+    "@sentry/types" "7.12.1"
+    "@sentry/utils" "7.12.1"
     cookie "^0.4.1"
     https-proxy-agent "^5.0.0"
     lru_map "^0.3.3"
     tslib "^1.9.3"
 
-"@sentry/tracing@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.11.1.tgz#50cbe82dd5b9a1307b31761cdd4b0d71132cf5c7"
-  integrity sha512-ilgnHfpdYUWKG/5yAXIfIbPVsCfrC4ONFBR/wN25/hdAyVfXMa3AJx7NCCXxZBOPDWH3hMW8rl4La5yuDbXofg==
+"@sentry/tracing@7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.12.1.tgz#9f92985f152054ac90b6ec83a33c44e8084a008e"
+  integrity sha512-WnweIt//IqkEkJSjA8DtnIeCdItYIqJSxNQ6qK+r546/ufxRYFBck2fbmM0oKZJVg2evbwhadrBTIUzYkqNj4A==
   dependencies:
-    "@sentry/hub" "7.11.1"
-    "@sentry/types" "7.11.1"
-    "@sentry/utils" "7.11.1"
+    "@sentry/hub" "7.12.1"
+    "@sentry/types" "7.12.1"
+    "@sentry/utils" "7.12.1"
     tslib "^1.9.3"
 
-"@sentry/types@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.11.1.tgz#06e2827f6ba37159c33644208a0453b86d25e232"
-  integrity sha512-gIEhOPxC2cjrxQ0+K2SFJ1P6e/an5osSxVc9OOtekN28eHtVsXFCLB8XVWeNQnS7N2VkrVrkqORMBz1kvIcvVQ==
+"@sentry/types@7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.12.1.tgz#eff76d938f9effc62a2ec76cd5c3f04de37f5c15"
+  integrity sha512-VGZs39SZgMcCGv7H0VyFy1LEFGsnFZH590JUopmz6nG63EpeYQ2xzhIoPNAiLKbyUvBEwukn+faCg3u3MGqhgQ==
 
-"@sentry/utils@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.11.1.tgz#1635c5b223369d9428bc83c9b8908c9c3287ee10"
-  integrity sha512-tRVXNT5O9ilkV31pyHeTqA1PcPQfMV/2OR6yUYM4ah+QVISovC0f0ybhByuH5nYg6x/Gsnx1o7pc8L1GE3+O7A==
+"@sentry/utils@7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.12.1.tgz#fcf80fdc332d0bd288e21b13efc7a2f0d604f75a"
+  integrity sha512-Dh8B13pC0u8uLM/zf+oZngyg808c6BDEO94F7H+h3IciCVVd92A0cOQwLGAEdf8srnJgpZJNAlSC8lFDhbFHzQ==
   dependencies:
-    "@sentry/types" "7.11.1"
+    "@sentry/types" "7.12.1"
     tslib "^1.9.3"
 
 "@sindresorhus/is@^0.14.0":


### PR DESCRIPTION
This also disables the node `Context` integration since this clashes with existing features in the Electron SDK and it's too complicated to migrate to using `Context` for now without causing breaking changes.