### PR TITLE
fix: Page titles in breadcrumbs should not change

### DIFF
--- a/src/main/integrations/electron-breadcrumbs.ts
+++ b/src/main/integrations/electron-breadcrumbs.ts
@@ -183,14 +183,10 @@ export class ElectronBreadcrumbs implements Integration {
         };
 
         if (id) {
-          const state = getRendererProperties(id);
+          breadcrumb.data = { ...getRendererProperties(id) };
 
-          if (!this._options.captureWindowTitles && state?.title) {
-            delete state.title;
-          }
-
-          if (state) {
-            breadcrumb.data = state;
+          if (!this._options.captureWindowTitles && breadcrumb.data?.title) {
+            delete breadcrumb.data?.title;
           }
         }
 


### PR DESCRIPTION
We noticed an issue where page titles were showing up in breadcrumbs and discovered that the breadcrumbs' `data` properties are references to `RENDERERS` object [here](https://github.com/getsentry/sentry-electron/blob/ef1839a2b2268909ab8f2209dc5f8a5c6fd1fec4/src/main/renderers.ts#L12). Thus, if the page title changes after a breadcrumb is created but before it is sent with an event, [this handler](https://github.com/getsentry/sentry-electron/blob/ef1839a2b2268909ab8f2209dc5f8a5c6fd1fec4/src/main/renderers.ts#L43) will also change the `data` property of the breadcrumb.

This change prevents that by setting the `data` property of the breadcrumb to a clone of the renderer state. Also, this change prevents the breadcrumb integration from modifying the renderer state when writing its `data` prop. 