### PR TITLE
meta: Changelog entry for 3.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.8
+
+- fix: Page titles in breadcrumbs should not change (#551)
+
 ## 3.0.7
 
 - fix: export map and sideEffects


### PR DESCRIPTION
https://github.com/getsentry/sentry-electron/tree/3.x is a branch tracking the `3.x` set of releases, it was forked from commit 22c9755c29d9572e2555153add7da011a0080d6a

This PR updates the changelog for 3.0.8, as the fix in https://github.com/getsentry/sentry-electron/pull/551 should be backported to `3.x`. The fix was already cherry-picked onto the `3.x` branch: d9df8135a18903b6747d06699c1e789960f828b0