### PR TITLE
test: Test less Electron versions unless it's a release build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
           path: |
             ${{ github.workspace }}/*.tgz
       - id: set-matrix
-        run: echo "::set-output name=matrix::$(cat ./test/e2e/versions.json)"
+        run: echo "::set-output name=matrix::$(node ./scripts/e2e-test-versions.js)"
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 

--- a/scripts/e2e-test-versions.js
+++ b/scripts/e2e-test-versions.js
@@ -1,0 +1,11 @@
+const { readFileSync } = require('fs');
+
+const versions = JSON.parse(readFileSync('./test/e2e/versions.json', 'utf8'));
+
+if (process.env.GITHUB_REF && process.env.GITHUB_REF.includes('release/')) {
+  // For release builds we test all versions
+  console.log(JSON.stringify(versions));
+} else {
+  // Otherwise we test the oldest version and the last 10 versions
+  console.log(JSON.stringify([versions[0], ...versions.slice(-10)]));
+}


### PR DESCRIPTION
Closes #559 

Reduce CI e2e tests down to v2 + last 10 versions. Releases are still tested on all versions.

Before:
<img width="601" alt="image" src="https://user-images.githubusercontent.com/1150298/190668684-211830a7-0a40-4b25-b1bc-37f80c79a61b.png">

After:
<img width="608" alt="image" src="https://user-images.githubusercontent.com/1150298/190668502-f12aed42-04a9-45b7-8805-71a48b91fabd.png">
