### PR TITLE
feat: Update to v7.15.0 of Sentry JavaScript SDKs

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,19 +57,19 @@
     "e2e": "cross-env TS_NODE_PROJECT=tsconfig.json xvfb-maybe mocha --require ts-node/register/transpile-only --retries 3 ./test/e2e/*.ts"
   },
   "dependencies": {
-    "@sentry/browser": "7.13.0",
-    "@sentry/core": "7.13.0",
-    "@sentry/hub": "7.13.0",
-    "@sentry/node": "7.13.0",
-    "@sentry/types": "7.13.0",
-    "@sentry/utils": "7.13.0",
+    "@sentry/browser": "7.15.0",
+    "@sentry/core": "7.15.0",
+    "@sentry/hub": "7.15.0",
+    "@sentry/node": "7.15.0",
+    "@sentry/types": "7.15.0",
+    "@sentry/utils": "7.15.0",
     "deepmerge": "4.2.2",
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@sentry-internal/eslint-config-sdk": "7.13.0",
-    "@sentry-internal/typescript": "7.13.0",
-    "@sentry/tracing": "7.13.0",
+    "@sentry-internal/eslint-config-sdk": "7.15.0",
+    "@sentry-internal/typescript": "7.15.0",
+    "@sentry/tracing": "7.15.0",
     "@types/busboy": "^0.2.3",
     "@types/chai": "^4.2.10",
     "@types/chai-as-promised": "^7.1.5",

--- a/src/main/sessions.ts
+++ b/src/main/sessions.ts
@@ -1,5 +1,4 @@
-import { getCurrentHub } from '@sentry/core';
-import { makeSession, updateSession } from '@sentry/hub';
+import { getCurrentHub, makeSession, updateSession } from '@sentry/core';
 import { flush, NodeClient } from '@sentry/node';
 import { SerializedSession, Session, SessionContext, SessionStatus } from '@sentry/types';
 import { logger } from '@sentry/utils';

--- a/yarn.lock
+++ b/yarn.lock
@@ -100,13 +100,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@sentry-internal/eslint-config-sdk@7.13.0":
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.13.0.tgz#0aca52992a90ba52f30f655bd88f62990c8a19ae"
-  integrity sha512-l4HcT//w4Ubqc2PV58hJux6sf/NgMG5ahHUhC2LupJICpZPvFAp3lwSZkm/ejSElaX1LYGLW8giZqiix+ssVOQ==
+"@sentry-internal/eslint-config-sdk@7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.15.0.tgz#7f33c6c39c720132d9816364d55751cd26ab34e4"
+  integrity sha512-ttLoetchz0NkRuv8xkab/NF3u67lwWidYAIr8dV0Gc/wuefLwGr/XWdHff1hadXk528/7ZJcnNVUAE9DeeWYvA==
   dependencies:
-    "@sentry-internal/eslint-plugin-sdk" "7.13.0"
-    "@sentry-internal/typescript" "7.13.0"
+    "@sentry-internal/eslint-plugin-sdk" "7.15.0"
+    "@sentry-internal/typescript" "7.15.0"
     "@typescript-eslint/eslint-plugin" "^3.9.0"
     "@typescript-eslint/parser" "^3.9.0"
     eslint-config-prettier "^6.11.0"
@@ -115,82 +115,81 @@
     eslint-plugin-jsdoc "^30.0.3"
     eslint-plugin-simple-import-sort "^5.0.3"
 
-"@sentry-internal/eslint-plugin-sdk@7.13.0":
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.13.0.tgz#ca7d97d3bbd618ad44293490c387fc86f3db5e45"
-  integrity sha512-ZKejUx7FLiOB+cY/3YbV1/TamMFm8IOE54dTK2e148MbBvefM1mNjI5gbUcBMDCVk3CR5PO/2SkeRMBcEZfw1A==
+"@sentry-internal/eslint-plugin-sdk@7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.15.0.tgz#49dfa926033d70948aaf1f304e4d98d1f50d13b9"
+  integrity sha512-CYCf6i/kt5m49XKYNz5ocgRDGUSpQvImyT/qXvZGWnj4jKNeie4/k3abua2Dj765zZ1IpNscAuBudOG7rBTRlQ==
   dependencies:
     requireindex "~1.1.0"
 
-"@sentry-internal/typescript@7.13.0":
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.13.0.tgz#86b7014859002eb5860e560fbc9d9c20e71d98d3"
-  integrity sha512-dAyNQR7a2GTMSOkGxWXRNWUmM/u8rhM1sY+d1817IXstTiLN2PFWVnpvyup32p5H7jasW/nuIDGjWjzZoY3/9Q==
+"@sentry-internal/typescript@7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.15.0.tgz#72daf80ff94ab8ba4ae22c39dd3ab888d38b9229"
+  integrity sha512-Gjc2/w1+vxmZIwSXAZYcuT99BjjOPXhHlCscOXLlGhPx5qNhnIXZ52StlQbCfW0P6Qg6H2d4P/OYUGTcOXd7gQ==
 
-"@sentry/browser@7.13.0":
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.13.0.tgz#883b8598c8a0c33af246242e7172e39306dc564a"
-  integrity sha512-WbgClHPYe8TKsdVVbuzd6alxwh3maFQNuljMkSTnYvPx2P+NT0wHljTs37D39FGfSmAwaqn7D/1ZHAtC+6mWxA==
+"@sentry/browser@7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.15.0.tgz#1723dc8efcea9239d26072126755f61f6fb9448d"
+  integrity sha512-vZYr8L2JmniV8cns4yGOpX32moazz6tsllB1uv7XmmELW98sIuuugVFX0k6cBi89R8pyhdqULFCf9CL8CRguRg==
   dependencies:
-    "@sentry/core" "7.13.0"
-    "@sentry/types" "7.13.0"
-    "@sentry/utils" "7.13.0"
+    "@sentry/core" "7.15.0"
+    "@sentry/types" "7.15.0"
+    "@sentry/utils" "7.15.0"
     tslib "^1.9.3"
 
-"@sentry/core@7.13.0":
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.13.0.tgz#65597d71f8bfa1186f34009803e03ca9edb3adee"
-  integrity sha512-hB46fklmKrSDMEvZOF8qBHhys7PONBFyxQtbNDZUlv/kabs4gF3VEg1ftCaXnjx4lLNlsUl/ScFdM6194RvISg==
+"@sentry/core@7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.15.0.tgz#983e08326afdb8ddb10494372cd22b3886d683c9"
+  integrity sha512-W8d44g04GShBn4Z9VBTUhf1T9LTMfzUnETEx237zzUucv0kkyj3LsWQsJapWchMbmwr1V/CdnNDN+lGDm8iXQA==
   dependencies:
-    "@sentry/hub" "7.13.0"
-    "@sentry/types" "7.13.0"
-    "@sentry/utils" "7.13.0"
+    "@sentry/types" "7.15.0"
+    "@sentry/utils" "7.15.0"
     tslib "^1.9.3"
 
-"@sentry/hub@7.13.0":
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.13.0.tgz#752068e528cfb277ed154bc94e311cad50ef792e"
-  integrity sha512-88/GsD1BoyrBwRKJCmVHZtSH5rizOsImUHWEXc1AOa1aR8nanfn56JdAbd6tC55pA+nT4R4H4vN/PrUaomTbtg==
+"@sentry/hub@7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.15.0.tgz#d4da91c15ab0a1ee2d70796bf7b2fda35f06837f"
+  integrity sha512-v15sSoYuKJ9+BmDUX6qxAnCDhlClmw6TY9/rcIYbP2XSxsGrJcPy6VPOw4E21/1zGXnKiW7KvBkPeYEjIx7fWA==
   dependencies:
-    "@sentry/types" "7.13.0"
-    "@sentry/utils" "7.13.0"
+    "@sentry/core" "7.15.0"
+    "@sentry/types" "7.15.0"
+    "@sentry/utils" "7.15.0"
     tslib "^1.9.3"
 
-"@sentry/node@7.13.0":
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.13.0.tgz#0e073b75d4cce684db006d93ef18f2de2cf2f60e"
-  integrity sha512-uP3bPAIRHPilnOEiYGQQDLaQphc/c7d87wm91bZrTJ+WPnMW4D/NmT7fna5zGGDQIr/KTdQ/LEpDeZOILbkCqQ==
+"@sentry/node@7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.15.0.tgz#8784a747d9b933754b29bba954b22f0d54c3b614"
+  integrity sha512-gfyo6YTo4Sw5pdKWCzs7trqZpBm5D/ArR4vylQrQayfImiYyNY6yaOK1R7g4rM34MXUu91pfVJLUpXvjk/NsHw==
   dependencies:
-    "@sentry/core" "7.13.0"
-    "@sentry/hub" "7.13.0"
-    "@sentry/types" "7.13.0"
-    "@sentry/utils" "7.13.0"
+    "@sentry/core" "7.15.0"
+    "@sentry/types" "7.15.0"
+    "@sentry/utils" "7.15.0"
     cookie "^0.4.1"
     https-proxy-agent "^5.0.0"
     lru_map "^0.3.3"
     tslib "^1.9.3"
 
-"@sentry/tracing@7.13.0":
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.13.0.tgz#521dc021dab78e37e29b0f90b01cb444337adfc4"
-  integrity sha512-/MKSd25rGv6Pc0FPBLXJifkfvSaYVPA8XUOLzVeDN0gl07h8AXli4qG9amTh/4Wb5h4dFpbcscOvW2VC+pxkIA==
+"@sentry/tracing@7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.15.0.tgz#ea516957b2ed39f389c21132f433b6470d54b465"
+  integrity sha512-c0Y3+z6EWsc+EJsfBcRtc58ugkWYa6+6KTu3ceMkx2ZgZTCmRUuzAb7yodMt/gwezBsxzq706fnQivx1lQgzlQ==
   dependencies:
-    "@sentry/hub" "7.13.0"
-    "@sentry/types" "7.13.0"
-    "@sentry/utils" "7.13.0"
+    "@sentry/core" "7.15.0"
+    "@sentry/types" "7.15.0"
+    "@sentry/utils" "7.15.0"
     tslib "^1.9.3"
 
-"@sentry/types@7.13.0":
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.13.0.tgz#398e33e5c92ea0ce91e2c86e3ab003fe00c471a2"
-  integrity sha512-ttckM1XaeyHRLMdr79wmGA5PFbTGx2jio9DCD/mkEpSfk6OGfqfC7gpwy7BNstDH/VKyQj/lDCJPnwvWqARMoQ==
+"@sentry/types@7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.15.0.tgz#50c57c924993d4dd16b43172d310c66384d17463"
+  integrity sha512-MN9haDRh9ZOsTotoDTHu2BT3sT8Vs1F0alhizUpDyjN2YgBCqR6JV+AbAE1XNHwS2+5zbppch1PwJUVeE58URQ==
 
-"@sentry/utils@7.13.0":
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.13.0.tgz#0d47a9278806ece78ba3a83c7dbebce817462759"
-  integrity sha512-jnR85LgRLSk7IQe2OhKOPMY4fasJCNQNW0iCXsH+S2R1qnsF+N4ksNkQ+7JyyM9E7F03YpI2qd76bKY0VIn5iA==
+"@sentry/utils@7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.15.0.tgz#cda642a353a58fd6631979c1e5986788e6db6c43"
+  integrity sha512-akic22/6xa/RG5Mj7UN6pLc23VnX9zQlKM53L/q3yIr0juckSVthJiiFNdgdqrX03S1tHYlBgPeShKFFTHpkjA==
   dependencies:
-    "@sentry/types" "7.13.0"
+    "@sentry/types" "7.15.0"
     tslib "^1.9.3"
 
 "@sindresorhus/is@^0.14.0":


### PR DESCRIPTION
The only code change is due to the deprecation of `@sentry/hub`