### PR TITLE
ref(ci): fix set-output / set-state deprecation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
           path: |
             ${{ github.workspace }}/*.tgz
       - id: set-matrix
-        run: echo "::set-output name=matrix::$(node ./scripts/e2e-test-versions.js)"
+        run: echo "matrix=$(node ./scripts/e2e-test-versions.js)" >> "$GITHUB_OUTPUT"
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Committed via https://github.com/asottile/all-repos