### PR TITLE
feat: Support passing JavaScript framework specific SDK init as second init parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ import { init } from '@sentry/electron/renderer';
 ```
 
 If you are using a framework specific Sentry SDK, you can pass that `init` function as the second parameter in the
-renderer and the two SDKs functionality will be combined:
+renderer and the two SDKs functionalities will be combined:
 ```javascript
 import { init } from '@sentry/electron/renderer';
 import { init as reactInit } from '@sentry/react';

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ import { init } from '@sentry/electron/main';
 import { init } from '@sentry/electron/renderer';
 ```
 
-If you are using a framework specific Sentry SDK, you can pass that `init` function as the second parameter and the two
-SDKs functionality will be combined:
+If you are using a framework specific Sentry SDK, you can pass that `init` function as the second parameter in the
+renderer and the two SDKs functionality will be combined:
 ```javascript
 import { init } from '@sentry/electron/renderer';
 import { init as reactInit } from '@sentry/react';

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ import { init } from '@sentry/electron/main';
 import { init } from '@sentry/electron/renderer';
 ```
 
+If you are using a framework specific Sentry SDK, you can pass that `init` function as the second parameter and the two
+SDKs functionality will be combined:
+```javascript
+import { init } from '@sentry/electron/renderer';
+import { init as reactInit } from '@sentry/react';
+
+init({ /* config */ }, reactInit);
+
+```
+
 To set context information or send manual events, use the exported functions of `@sentry/electron`. Note that these
 functions will not perform any action before you have called `init()`:
 

--- a/examples/electron-react-boilerplate/package.json
+++ b/examples/electron-react-boilerplate/package.json
@@ -58,6 +58,7 @@
   },
   "dependencies": {
     "@sentry/electron": "^3.0.5",
+    "@sentry/react": "7.15.0",
     "electron-debug": "^3.2.0",
     "electron-log": "^4.4.6",
     "electron-updater": "^4.6.5",

--- a/examples/electron-react-boilerplate/src/renderer/index.tsx
+++ b/examples/electron-react-boilerplate/src/renderer/index.tsx
@@ -1,8 +1,9 @@
 import { render } from 'react-dom';
 import App from './App';
-import * as Sentry from '@sentry/electron/renderer';
+import { init } from '@sentry/electron/renderer';
+import { init as reactInit } from '@sentry/react';
 
-Sentry.init();
+init({ debug: true }, reactInit);
 
 setTimeout(() => {
   throw new Error('Some renderer error');

--- a/examples/electron-vite/index.html
+++ b/examples/electron-vite/index.html
@@ -5,8 +5,7 @@
     <title>Hello World!</title>
   </head>
   <body>
-    <h1>💖 Hello World!</h1>
-    <p>Welcome to your Electron application.</p>
-    <script type="module" src="./src/renderer/index.mjs"></script>
+    <div id="app"></div>
+    <script type="module" src="/src/renderer/index.mjs"></script>
   </body>
 </html>

--- a/examples/electron-vite/package.json
+++ b/examples/electron-vite/package.json
@@ -9,10 +9,13 @@
   },
   "dependencies": {
     "electron-squirrel-startup": "^1.0.0",
-    "@sentry/electron": "3.0.0"
+    "@sentry/electron": "3.0.0",
+    "@sentry/vue": "7.15.0",
+    "vue": "^3.2.40"
   },
   "devDependencies": {
-    "vite": "^2.7.10",
+    "@vitejs/plugin-vue": "^3.1.2",
+    "vite": "^3.1.8",
     "electron": "13.1.9"
   }
 }

--- a/examples/electron-vite/src/renderer/App.vue
+++ b/examples/electron-vite/src/renderer/App.vue
@@ -1,0 +1,10 @@
+<script setup>
+setTimeout(() => {
+  throw new Error('Some renderer error');
+}, 500);
+</script>
+
+<template>
+  <h1>💖 Hello World!</h1>
+  <p>Welcome to your Electron application.</p>
+</template>

--- a/examples/electron-vite/src/renderer/index.mjs
+++ b/examples/electron-vite/src/renderer/index.mjs
@@ -1,9 +1,14 @@
+import { createApp } from 'vue';
+import App from './App.vue';
 import { init } from '@sentry/electron';
+import { init as initVue } from '@sentry/vue';
 
-init({
-  debug: true,
-});
+init(
+  {
+    debug: true,
+  },
+  initVue,
+);
 
-setTimeout(() => {
-  throw new Error('Some renderer error');
-}, 500);
+const app = createApp(App);
+app.mount('#app');

--- a/examples/electron-vite/vite.config.renderer.js
+++ b/examples/electron-vite/vite.config.renderer.js
@@ -1,4 +1,5 @@
 import { join } from 'path';
+import vue from '@vitejs/plugin-vue';
 
 const PACKAGE_ROOT = __dirname;
 
@@ -16,6 +17,7 @@ const config = {
       strict: true,
     },
   },
+  plugins: [vue()],
   build: {
     sourcemap: true,
     target: `chrome61`,

--- a/src/renderer/sdk.ts
+++ b/src/renderer/sdk.ts
@@ -14,8 +14,14 @@ export const defaultIntegrations = [...defaultBrowserIntegrations, new ScopeToMa
 
 /**
  * Initialize Sentry in the Electron renderer process
+ * @param options SDK options
+ * @param originalInit Optional init function for a specific framework SDK
+ * @returns
  */
-export function init(options: BrowserOptions = {}): void {
+export function init<O extends BrowserOptions>(
+  options: BrowserOptions & O = {} as BrowserOptions & O,
+  originalInit: (options: O) => void = browserInit,
+): void {
   ensureProcess('renderer');
 
   // Ensure the browser SDK is only init'ed once.
@@ -53,5 +59,5 @@ If init has been called in the preload and contextIsolation is disabled, is not 
   // We only handle initialScope in the main process otherwise it can cause race conditions over IPC
   delete options.initialScope;
 
-  browserInit(options);
+  originalInit(options);
 }

--- a/test/e2e/recipe/index.ts
+++ b/test/e2e/recipe/index.ts
@@ -15,7 +15,7 @@ import { parseRecipe, TestRecipe } from './parser';
 export * from './normalize';
 
 const SENTRY_KEY = '37f8a2ee37c0409d8970bc7559c7c7e4';
-const TRACING_VERSION = require('../../../package.json').devDependencies['@sentry/tracing'];
+const JS_VERSION = require('../../../package.json').dependencies['@sentry/core'];
 
 const log = createLogger('Recipe Runner');
 
@@ -121,8 +121,10 @@ export class RecipeRunner {
             /"@sentry\/electron": ".*"/,
             `"@sentry/electron": "file:./../../../../sentry-electron-${SDK_VERSION}.tgz"`,
           )
-          // We replace the @sentry/tracing dependency version to match that of @sentry/electron
-          .replace(/"@sentry\/tracing": ".*"/, `"@sentry/tracing": "${TRACING_VERSION}"`);
+          // We replace the Sentry JavaScript dependency versions to match that of @sentry/electron
+          .replace(/"@sentry\/tracing": ".*"/, `"@sentry/tracing": "${JS_VERSION}"`)
+          .replace(/"@sentry\/react": ".*"/, `"@sentry/react": "${JS_VERSION}"`)
+          .replace(/"@sentry\/vue": ".*"/, `"@sentry/vue": "${JS_VERSION}"`);
       }
 
       writeFileSync(path, content);


### PR DESCRIPTION
This copies the approach used in [`@sentry/capacitor`](https://github.com/getsentry/sentry-capacitor/blob/6aeb492f540f468f5190c025ebd799fdb7dd3e8e/src/sdk.ts#L20-L23). 

```ts
import * as Sentry from "@sentry/capacitor";
import { init as sentryAngularInit }  from "@sentry/angular";

// Init by passing the sibling SDK's init as the second parameter.
Sentry.init({
  dsn: "__DSN__",
}, sentryAngularInit);
```

This involves minimal code changes and is not a breaking change since to the 2nd parameter has a default of the browser init!

I've extended the react and vite example apps to use this approach.

Closes #506