### PR TITLE
fix: Include `sentry_key` in ping URL so it does not end up in breadcrumbs

### DIFF
--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -13,7 +13,7 @@ function getImplementation(): IPCInterface {
 
   logger.log('IPC was not configured in preload script, falling back to custom protocol and fetch');
 
-  fetch(`${PROTOCOL_SCHEME}://${IPCChannel.PING}`).catch(() =>
+  fetch(`${PROTOCOL_SCHEME}://${IPCChannel.PING}/sentry_key`).catch(() =>
     console.error(`Sentry SDK failed to establish connection with the Electron main process.
  - Ensure you have initialized the SDK in the main process
  - If your renderers use custom sessions, be sure to set 'getSessions' in the main process options


### PR DESCRIPTION
When using `fetch` to communicate with the main process, we include `sentry_key` in the URL so that it does not result in a fetch breadcrumb.

It appears this was left off of the `ping` "command" resulting in a breadcrumb!