### PR TITLE
fix: Change parameter name to give more useful TypeScript error on SDK version mismatch

### DIFF
--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -1,6 +1,16 @@
 const { join } = require('path');
-const { writeFileSync } = require('fs');
+const { readFileSync, writeFileSync } = require('fs');
 
-const path = join(__dirname, '../src/main/version.ts');
-const version = require('../package.json').version;
-writeFileSync(path, `export const SDK_VERSION = '${version}';\n`);
+const packageJson = require('../package.json');
+
+// SDK_VERSION to 'src/main/version.ts'
+const versionPath = join(__dirname, '../src/main/version.ts');
+writeFileSync(versionPath, `export const SDK_VERSION = '${packageJson.version}';\n`);
+
+// Write @sentry/core version into options variable name so TypeScript error includes useful hint
+const coreVersion = packageJson.dependencies['@sentry/core'];
+const coreVersionVar = coreVersion.replace(/\./g, '_');
+const rendererSdkPath = join(__dirname, '../src/renderer/sdk.ts');
+let rendererSdk = readFileSync(rendererSdkPath, { encoding: 'utf8' });
+rendererSdk = rendererSdk.replace(/version_v\d+_\d+_\d+/, `version_v${coreVersionVar}`);
+writeFileSync(rendererSdkPath, rendererSdk);

--- a/src/renderer/sdk.ts
+++ b/src/renderer/sdk.ts
@@ -20,6 +20,7 @@ export const defaultIntegrations = [...defaultBrowserIntegrations, new ScopeToMa
  */
 export function init<O extends BrowserOptions>(
   options: BrowserOptions & O = {} as BrowserOptions & O,
+  // This parameter name ensures that TypeScript error messages contain a hint for fixing SDK version mismatches
   originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v7_16_0: O) => void = browserInit,
 ): void {
   ensureProcess('renderer');

--- a/src/renderer/sdk.ts
+++ b/src/renderer/sdk.ts
@@ -20,7 +20,7 @@ export const defaultIntegrations = [...defaultBrowserIntegrations, new ScopeToMa
  */
 export function init<O extends BrowserOptions>(
   options: BrowserOptions & O = {} as BrowserOptions & O,
-  originalInit: (options: O) => void = browserInit,
+  originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v7_16_0: O) => void = browserInit,
 ): void {
   ensureProcess('renderer');
 


### PR DESCRIPTION
Closes #583 

The error reported in the above issue would now read:
```
Argument of type '(if_you_get_a_typescript_error_ensure_sdks_use_version_v7_16_0: import("d:/dev/projects/glint/angular/node_modules/@sentry/browser/types/client").BrowserOptions) => void' is not assignable to parameter of type '(options: import("d:/dev/projects/glint/angular/node_modules/@sentry/electron/node_modules/@sentry/browser/types/client").BrowserOptions) => void'.
  Types of parameters 'if_you_get_a_typescript_error_ensure_sdks_use_version_v7_16_0' and 'options' are incompatible.
    Type 'import("d:/dev/projects/glint/angular/node_modules/@sentry/electron/node_modules/@sentry/browser/types/client").BrowserOptions' is not assignable to type 'import("d:/dev/projects/glint/angular/node_modules/@sentry/browser/types/client").BrowserOptions'.
      Types of property 'defaultIntegrations' are incompatible.
        Type 'false | import("d:/dev/projects/glint/angular/node_modules/@sentry/electron/node_modules/@sentry/types/types/integration").Integration[] | undefined' is not assignable to type 'false | import("d:/dev/projects/glint/angular/node_modules/@sentry/types/types/integration").Integration[] | undefined'.

```