### PR TITLE
fix: Also check crashpad `pending` directory on macOS when renderer process exits

### DIFF
--- a/src/main/integrations/sentry-minidump/minidump-loader.ts
+++ b/src/main/integrations/sentry-minidump/minidump-loader.ts
@@ -94,6 +94,7 @@ function crashpadMinidumpLoader(): MinidumpLoader {
     await deleteCrashpadMetadataFile(crashesDirectory).catch((error) => logger.error(error));
 
     const dumpDirectory = join(crashesDirectory, crashpadSubDirectory);
+    const pendingDirectory = join(crashesDirectory, 'pending');
 
     return (await readDirAsync(dumpDirectory))
       .filter((file) => file.endsWith('.dmp'))
@@ -104,7 +105,19 @@ function crashpadMinidumpLoader(): MinidumpLoader {
           path,
           load: () => readFileAsync(path),
         };
-      });
+      })
+      .concat(
+        (await readDirAsync(pendingDirectory))
+          .filter((file) => file.endsWith('.dmp'))
+          .map((file) => {
+            const path = join(pendingDirectory, file);
+
+            return {
+              path,
+              load: () => readFileAsync(path),
+            };
+          }),
+      );
   });
 }
 

--- a/src/main/integrations/sentry-minidump/minidump-loader.ts
+++ b/src/main/integrations/sentry-minidump/minidump-loader.ts
@@ -86,6 +86,14 @@ async function deleteCrashpadMetadataFile(crashesDirectory: string, waitMs: numb
   }
 }
 
+async function readDirAsyncIfExists(path: string): Promise<string[]> {
+  try {
+    return await readDirAsync(path);
+  } catch (_) {
+    return [];
+  }
+}
+
 function crashpadMinidumpLoader(): MinidumpLoader {
   const crashesDirectory: string = getCrashesDirectory();
   const crashpadSubDirectory = process.platform === 'win32' ? 'reports' : 'completed';
@@ -96,7 +104,7 @@ function crashpadMinidumpLoader(): MinidumpLoader {
     const dumpDirectory = join(crashesDirectory, crashpadSubDirectory);
     const pendingDirectory = join(crashesDirectory, 'pending');
 
-    return (await readDirAsync(dumpDirectory))
+    return (await readDirAsyncIfExists(dumpDirectory))
       .filter((file) => file.endsWith('.dmp'))
       .map((file) => {
         const path = join(dumpDirectory, file);
@@ -107,7 +115,7 @@ function crashpadMinidumpLoader(): MinidumpLoader {
         };
       })
       .concat(
-        (await readDirAsync(pendingDirectory))
+        (await readDirAsyncIfExists(pendingDirectory))
           .filter((file) => file.endsWith('.dmp'))
           .map((file) => {
             const path = join(pendingDirectory, file);

--- a/src/main/integrations/sentry-minidump/minidump-loader.ts
+++ b/src/main/integrations/sentry-minidump/minidump-loader.ts
@@ -112,7 +112,8 @@ function crashpadMinidumpLoader(): MinidumpLoader {
   return createMinidumpLoader(async () => {
     await deleteCrashpadMetadataFile(crashesDirectory).catch((error) => logger.error(error));
 
-    return (await readDirsAsync(dumpDirectories))
+    const files = await readDirsAsync(dumpDirectories);
+    return files
       .filter((file) => file.endsWith('.dmp'))
       .map((path) => {
         return {

--- a/test/e2e/test-apps/native-sentry/renderer-force-crash/event.json
+++ b/test/e2e/test-apps/native-sentry/renderer-force-crash/event.json
@@ -1,0 +1,83 @@
+{
+  "method": "envelope",
+  "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
+  "appId": "277345",
+  "data": {
+    "sdk": {
+      "name": "sentry.javascript.electron",
+      "packages": [
+        {
+          "name": "npm:@sentry/electron",
+          "version": "{{version}}"
+        }
+      ],
+      "version": "{{version}}"
+    },
+    "contexts": {
+      "app": {
+        "app_name": "native-sentry-renderer-force-crash",
+        "app_version": "1.0.0",
+        "app_start_time": "{{time}}"
+      },
+      "browser": {
+        "name": "Chrome"
+      },
+      "chrome": {
+        "name": "Chrome",
+        "type": "runtime",
+        "version": "{{version}}"
+      },
+      "device": {
+        "arch": "{{arch}}",
+        "family": "Desktop",
+        "memory_size": 0,
+        "free_memory": 0,
+        "processor_count": 0,
+        "processor_frequency": 0,
+        "cpu_description": "{{cpu}}",
+        "screen_resolution": "{{screen}}",
+        "screen_density": 1,
+        "language": "{{language}}"
+      },
+      "node": {
+        "name": "Node",
+        "type": "runtime",
+        "version": "{{version}}"
+      },
+      "os": {
+        "name": "{{platform}}",
+        "version": "{{version}}"
+      },
+      "runtime": {
+        "name": "Electron",
+        "version": "{{version}}"
+      },
+      "electron": {
+        "crashed_url": "unknown",
+        "details": {
+          "reason": "killed"
+        }
+      }
+    },
+    "release": "native-sentry-renderer-force-crash@1.0.0",
+    "environment": "development",
+    "user": {
+      "ip_address": "{{auto}}"
+    },
+    "event_id": "{{id}}",
+    "timestamp": 0,
+    "breadcrumbs": [],
+    "tags": {
+      "event.environment": "native",
+      "event.origin": "electron",
+      "event.process": "renderer",
+      "event_type": "native",
+      "exit.reason": "killed"
+    }
+  },
+  "attachments": [
+    {
+      "attachment_type": "event.minidump"
+    }
+  ]
+}

--- a/test/e2e/test-apps/native-sentry/renderer-force-crash/event.json
+++ b/test/e2e/test-apps/native-sentry/renderer-force-crash/event.json
@@ -51,12 +51,6 @@
       "runtime": {
         "name": "Electron",
         "version": "{{version}}"
-      },
-      "electron": {
-        "crashed_url": "unknown",
-        "details": {
-          "reason": "killed"
-        }
       }
     },
     "release": "native-sentry-renderer-force-crash@1.0.0",
@@ -71,8 +65,7 @@
       "event.environment": "native",
       "event.origin": "electron",
       "event.process": "renderer",
-      "event_type": "native",
-      "exit.reason": "killed"
+      "event_type": "native"
     }
   },
   "attachments": [

--- a/test/e2e/test-apps/native-sentry/renderer-force-crash/package.json
+++ b/test/e2e/test-apps/native-sentry/renderer-force-crash/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "native-sentry-renderer-force-crash",
+  "version": "1.0.0",
+  "main": "src/main.js",
+  "dependencies": {
+    "@sentry/electron": "3.0.0"
+  }
+}

--- a/test/e2e/test-apps/native-sentry/renderer-force-crash/recipe.yml
+++ b/test/e2e/test-apps/native-sentry/renderer-force-crash/recipe.yml
@@ -1,3 +1,4 @@
 description: Native Renderer forcefullyCrashRenderer
 category: Native (Sentry Uploader)
 command: yarn
+condition: usesCrashpad && version.major >= 12

--- a/test/e2e/test-apps/native-sentry/renderer-force-crash/recipe.yml
+++ b/test/e2e/test-apps/native-sentry/renderer-force-crash/recipe.yml
@@ -1,0 +1,3 @@
+description: Native Renderer forcefullyCrashRenderer
+category: Native (Sentry Uploader)
+command: yarn

--- a/test/e2e/test-apps/native-sentry/renderer-force-crash/src/index.html
+++ b/test/e2e/test-apps/native-sentry/renderer-force-crash/src/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <script>
+      const { init } = require('@sentry/electron');
+
+      init({
+        debug: true,
+      });
+    </script>
+  </body>
+</html>

--- a/test/e2e/test-apps/native-sentry/renderer-force-crash/src/main.js
+++ b/test/e2e/test-apps/native-sentry/renderer-force-crash/src/main.js
@@ -3,6 +3,8 @@ const path = require('path');
 const { app, BrowserWindow } = require('electron');
 const { init } = require('@sentry/electron');
 
+app.commandLine.appendSwitch('enable-crashpad');
+
 init({
   dsn: '__DSN__',
   debug: true,

--- a/test/e2e/test-apps/native-sentry/renderer-force-crash/src/main.js
+++ b/test/e2e/test-apps/native-sentry/renderer-force-crash/src/main.js
@@ -1,0 +1,27 @@
+const path = require('path');
+
+const { app, BrowserWindow } = require('electron');
+const { init } = require('@sentry/electron');
+
+init({
+  dsn: '__DSN__',
+  debug: true,
+  autoSessionTracking: false,
+  onFatalError: () => {},
+});
+
+app.on('ready', () => {
+  const mainWindow = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+
+  mainWindow.loadFile(path.join(__dirname, 'index.html'));
+
+  setTimeout(() => {
+    mainWindow.webContents.forcefullyCrashRenderer();
+  }, 1000);
+});


### PR DESCRIPTION
Closes #591

On macOS, if you call `webContents.forcefullyCrashRenderer()` the resulting minidump ends up in the `pending` subdirectory and doesn't get copied to completed until the app restarts. This causes it to be classed as a main process crash.

This PR means we now check the `pending` directory for minidumps on macOS and adds a test that ensures minidumps are correctly handled when caused by `webContents.forcefullyCrashRenderer()`.