### PR TITLE
fix: Ensure any scope updates do not clobber the initial async scope read

### DIFF
--- a/test/e2e/test-apps/native-sentry/main/event.json
+++ b/test/e2e/test-apps/native-sentry/main/event.json
@@ -65,7 +65,8 @@
       "event.environment": "native",
       "event.origin": "electron",
       "event.process": "browser",
-      "event_type": "native"
+      "event_type": "native",
+      "app-run": "first"
     }
   },
   "attachments": [ { "attachment_type": "event.minidump" } ]

--- a/test/e2e/test-apps/native-sentry/main/src/main.js
+++ b/test/e2e/test-apps/native-sentry/main/src/main.js
@@ -1,13 +1,17 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init } = require('@sentry/electron');
+const { init, configureScope } = require('@sentry/electron');
 
 init({
   dsn: '__DSN__',
   debug: true,
   autoSessionTracking: false,
   onFatalError: () => {},
+});
+
+configureScope((scope) => {
+  scope.setTag('app-run', process.env.APP_FIRST_RUN ? 'first' : 'second');
 });
 
 app.on('ready', () => {


### PR DESCRIPTION
Closes #585

The initial read from the `BufferedWriteStore` is async but writes (to the cached value) were synchronous. This meant that modifications to the scope immediately after calling `init` would overwrite the scope from the previous run.

This PR:
- Wraps the scope updates in `setImmediate` so that the initial read will always win the async race
- Adds a tag to the e2e test to confirm this is working and doesn't get broken again!