### PR TITLE
test: Add test to ensure window titles don't end up in breadcrumbs when disabled

### DIFF
--- a/src/main/integrations/electron-breadcrumbs.ts
+++ b/src/main/integrations/electron-breadcrumbs.ts
@@ -183,10 +183,14 @@ export class ElectronBreadcrumbs implements Integration {
         };
 
         if (id) {
-          breadcrumb.data = { ...getRendererProperties(id) };
+          const state = getRendererProperties(id);
 
-          if (!this._options.captureWindowTitles && breadcrumb.data?.title) {
-            delete breadcrumb.data?.title;
+          if (!this._options.captureWindowTitles && state?.title) {
+            delete state.title;
+          }
+
+          if (state) {
+            breadcrumb.data = state;
           }
         }
 

--- a/src/main/integrations/electron-breadcrumbs.ts
+++ b/src/main/integrations/electron-breadcrumbs.ts
@@ -183,14 +183,10 @@ export class ElectronBreadcrumbs implements Integration {
         };
 
         if (id) {
-          const state = getRendererProperties(id);
+          breadcrumb.data = { ...getRendererProperties(id) };
 
-          if (!this._options.captureWindowTitles && state?.title) {
-            delete state.title;
-          }
-
-          if (state) {
-            breadcrumb.data = state;
+          if (!this._options.captureWindowTitles && breadcrumb.data?.title) {
+            delete breadcrumb.data?.title;
           }
         }
 

--- a/test/e2e/test-apps/other/window-titles/events.ts
+++ b/test/e2e/test-apps/other/window-titles/events.ts
@@ -1,0 +1,16 @@
+import { Event } from '@sentry/types';
+import { expect } from 'chai';
+
+import { TestServerEvent } from '../../../server';
+
+export async function execute(events: TestServerEvent<Event>[]): Promise<void> {
+  expect(events).to.have.lengthOf(1);
+
+  const event = events[0];
+
+  expect(event.data.breadcrumbs?.length).to.be.greaterThan(7);
+
+  for (const breadcrumb of event.data.breadcrumbs || []) {
+    expect(breadcrumb?.data?.title).to.be.undefined;
+  }
+}

--- a/test/e2e/test-apps/other/window-titles/events.ts
+++ b/test/e2e/test-apps/other/window-titles/events.ts
@@ -10,7 +10,15 @@ export async function execute(events: TestServerEvent<Event>[]): Promise<void> {
 
   expect(event.data.breadcrumbs?.length).to.be.greaterThan(5);
 
+  let withData = 0;
+
   for (const breadcrumb of event.data.breadcrumbs || []) {
+    if (breadcrumb?.data?.id) {
+      withData += 1;
+    }
+
     expect(breadcrumb?.data?.title).to.be.undefined;
   }
+
+  expect(withData).to.be.greaterThanOrEqual(2);
 }

--- a/test/e2e/test-apps/other/window-titles/events.ts
+++ b/test/e2e/test-apps/other/window-titles/events.ts
@@ -8,7 +8,7 @@ export async function execute(events: TestServerEvent<Event>[]): Promise<void> {
 
   const event = events[0];
 
-  expect(event.data.breadcrumbs?.length).to.be.greaterThan(7);
+  expect(event.data.breadcrumbs?.length).to.be.greaterThan(5);
 
   for (const breadcrumb of event.data.breadcrumbs || []) {
     expect(breadcrumb?.data?.title).to.be.undefined;

--- a/test/e2e/test-apps/other/window-titles/package.json
+++ b/test/e2e/test-apps/other/window-titles/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "window-titles",
+  "version": "1.0.0",
+  "main": "src/main.js",
+  "dependencies": {
+    "@sentry/electron": "3.0.0"
+  }
+}

--- a/test/e2e/test-apps/other/window-titles/package.json
+++ b/test/e2e/test-apps/other/window-titles/package.json
@@ -2,6 +2,7 @@
   "name": "window-titles",
   "version": "1.0.0",
   "main": "src/main.js",
+  "homepage": "https://github.com/getsentry/sentry-electron/pull/551",
   "dependencies": {
     "@sentry/electron": "3.0.0"
   }

--- a/test/e2e/test-apps/other/window-titles/recipe.yml
+++ b/test/e2e/test-apps/other/window-titles/recipe.yml
@@ -1,0 +1,2 @@
+description: Window titles are empty when disabled
+command: yarn

--- a/test/e2e/test-apps/other/window-titles/src/index.html
+++ b/test/e2e/test-apps/other/window-titles/src/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <script>
+      const { init } = require('@sentry/electron');
+
+      init({
+        debug: true,
+      });
+
+      setInterval(() => {
+        document.title = `This is the new page title: ${Math.random()}`;
+      }, 10);
+    </script>
+  </body>
+</html>

--- a/test/e2e/test-apps/other/window-titles/src/main.js
+++ b/test/e2e/test-apps/other/window-titles/src/main.js
@@ -1,0 +1,33 @@
+const path = require('path');
+
+const { app, BrowserWindow } = require('electron');
+const { init } = require('@sentry/electron');
+
+init({
+  dsn: '__DSN__',
+  debug: true,
+  autoSessionTracking: false,
+  onFatalError: () => {},
+});
+
+app.on('ready', () => {
+  const mainWindow = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+
+  mainWindow.webContents.on('dom-ready', () => {
+    setTimeout(() => {
+      mainWindow.minimize();
+
+      setTimeout(() => {
+        throw new Error('enough');
+      }, 500);
+    }, 500);
+  });
+
+  mainWindow.loadFile(path.join(__dirname, 'index.html'));
+});


### PR DESCRIPTION
This PR adds a test to ensure that window titles do not end up in breadcrumbs when this feature is disabled. This is to ensure there is no regression in the behaviour fixed by #551.

The first commit in this PR actually reverses the change in #551 to demonstrate the failing test.

A subsequent commit will reapply #551.