### PR TITLE
fix: Use `POST` for main process ping so it does not result in fetch breadcrumb

### DIFF
--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -42,7 +42,7 @@ let cachedInterface: IPCInterface | undefined;
  * Renderer IPC interface
  *
  * Favours IPC if its been exposed via a preload script but will
- * fallback to custom protocol and fetch is IPC is not available
+ * fallback to custom protocol and fetch if IPC is not available
  */
 export function getIPC(): IPCInterface {
   if (!cachedInterface) {

--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -13,7 +13,7 @@ function getImplementation(): IPCInterface {
 
   logger.log('IPC was not configured in preload script, falling back to custom protocol and fetch');
 
-  fetch(`${PROTOCOL_SCHEME}://${IPCChannel.PING}/sentry_key`).catch(() =>
+  fetch(`${PROTOCOL_SCHEME}://${IPCChannel.PING}/sentry_key`, { method: 'POST', body: '' }).catch(() =>
     console.error(`Sentry SDK failed to establish connection with the Electron main process.
  - Ensure you have initialized the SDK in the main process
  - If your renderers use custom sessions, be sure to set 'getSessions' in the main process options


### PR DESCRIPTION
While debugging e2e tests I noticed we still capture a breadcrumb for the ping IPC command.

```ts
      {
        timestamp: 1671415619.64,
        category: 'fetch',
        data: {
          method: 'GET',
          url: 'sentry-ipc://sentry-electron.ping/sentry_key',
          status_code: 200
        },
        type: 'http'
      }
```
This is because the `@sentry/browser` code that ignores urls with `sentry_key` in them only matches for `POST` requests.