### PR TITLE
test: Don't run sandbox tests on Linux for Electron < 13

### DIFF
--- a/examples/electron-forge-webpack/recipe.yml
+++ b/examples/electron-forge-webpack/recipe.yml
@@ -1,4 +1,4 @@
 description: Electron Forge Webpack with contextIsolation and sandbox
 command: yarn && yarn package
-condition: supportsContextIsolation
+condition: supportsContextIsolation && supportsSandbox
 timeout: 120

--- a/examples/webpack-context-isolation-preload/recipe.yml
+++ b/examples/webpack-context-isolation-preload/recipe.yml
@@ -1,4 +1,4 @@
 description: Webpack 5 app with contextIsolation and sandbox with preload
 command: yarn && yarn build
-condition: supportsContextIsolation
+condition: supportsContextIsolation && supportsSandbox
 timeout: 120

--- a/examples/webpack-context-isolation/recipe.yml
+++ b/examples/webpack-context-isolation/recipe.yml
@@ -1,4 +1,4 @@
 description: Webpack 5 app with contextIsolation and sandbox
 command: yarn && yarn build
-condition: supportsContextIsolation
+condition: supportsContextIsolation && supportsSandbox
 timeout: 120

--- a/test/e2e/recipe/eval.ts
+++ b/test/e2e/recipe/eval.ts
@@ -15,9 +15,11 @@ function getEvalContext(electronVersion: string): Context {
     (platform === 'win32' && version.major >= 6) ||
     (platform === 'linux' && version.major >= 15);
 
+  const supportsSandbox = platform !== 'linux' || version.major >= 13;
+
   const supportsContextIsolation = version.major >= 6;
 
-  return createContext({ version, platform, usesCrashpad, supportsContextIsolation });
+  return createContext({ version, platform, usesCrashpad, supportsContextIsolation, supportsSandbox });
 }
 
 export function evaluateCondition(name: string, electronVersion: string, condition: string | undefined): boolean {

--- a/test/e2e/test-apps/other/error-iframe/recipe.yml
+++ b/test/e2e/test-apps/other/error-iframe/recipe.yml
@@ -1,4 +1,4 @@
 description: JavaScript Error from <iframe>
 command: yarn && yarn build
-condition: supportsContextIsolation
+condition: supportsContextIsolation && supportsSandbox
 timeout: 120


### PR DESCRIPTION
For release builds we test all supported Electron versions. 

It [appears](https://github.com/getsentry/sentry-electron/actions/runs/3892651247/jobs/6644902509) that tests involving sandboxed renderers no longer pass on `ubuntu-latest` for older, unsupported versions of Electron.

This PR skips those failing tests.