### PR TITLE
test: Disable sandbox for Linux e2e tests

### DIFF
--- a/test/e2e/context.ts
+++ b/test/e2e/context.ts
@@ -66,7 +66,14 @@ export class TestContext {
       this._clearAppUserData();
     }
 
-    const childProcess = spawn(this._electronPath, [this._appPath], { env });
+    const args = [this._appPath];
+
+    // Older versions of Electron no longer work correctly on 'ubuntu-latest' with sandbox
+    if (process.platform === 'linux') {
+      args.push('--no-sandbox');
+    }
+
+    const childProcess = spawn(this._electronPath, args, { env });
 
     function logLinesWithoutEmpty(input: string): void {
       input

--- a/test/e2e/context.ts
+++ b/test/e2e/context.ts
@@ -1,3 +1,4 @@
+import { parseSemver } from '@sentry/utils';
 import { ChildProcess, spawn, spawnSync } from 'child_process';
 import { rmSync } from 'fs';
 import { homedir } from 'os';
@@ -47,6 +48,7 @@ export class TestContext {
    */
   public constructor(
     private readonly _electronPath: string,
+    private readonly _electronVersion: string,
     private readonly _appPath: string,
     private readonly _appName: string,
   ) {}
@@ -66,10 +68,11 @@ export class TestContext {
       this._clearAppUserData();
     }
 
-    const args = [this._appPath];
+    const version = parseSemver(this._electronVersion);
 
+    const args = [this._appPath];
     // Older versions of Electron no longer work correctly on 'ubuntu-latest' with sandbox
-    if (process.platform === 'linux') {
+    if (process.platform === 'linux' && (version.major || 0) < 13) {
       args.push('--no-sandbox');
     }
 

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -61,7 +61,7 @@ describe('E2E Tests', () => {
                 }
 
                 const [appPath, appName] = await recipe.prepare(this, distDir);
-                testContext = new TestContext(await electronPath, appPath, appName);
+                testContext = new TestContext(await electronPath, electronVersion, appPath, appName);
                 await recipe.runTests(testContext, testServer);
               });
             }
@@ -79,7 +79,7 @@ describe('E2E Tests', () => {
             }
 
             const [appPath, appName] = await recipe.prepare(this, distDir);
-            testContext = new TestContext(await electronPath, appPath, appName);
+            testContext = new TestContext(await electronPath, electronVersion, appPath, appName);
             await recipe.runTests(testContext, testServer);
           });
         }


### PR DESCRIPTION
Many older versions of Electron no longer work correctly on `ubuntu-latest` failing with dbus errors and GPU crashes.

Disabling sandbox on Linux gets the tests passing without any obvious risk.