### PR TITLE
fix: Replay should be re-exported

### DIFF
--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -45,7 +45,7 @@ export {
   InboundFilters,
 } from '@sentry/core';
 
-export { BrowserClient, lastEventId, showReportDialog } from '@sentry/browser';
+export { BrowserClient, lastEventId, showReportDialog, Replay } from '@sentry/browser';
 export type { BrowserOptions, ReportDialogOptions } from '@sentry/browser';
 
 export const Integrations = { ...ElectronRendererIntegrations, ...BrowserIntegrations };

--- a/test/e2e/test-apps/other/browser-replay/package.json
+++ b/test/e2e/test-apps/other/browser-replay/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "main": "src/main.js",
   "dependencies": {
-    "@sentry/electron": "3.0.0",
-    "@sentry/replay": "7.0.0"
+    "@sentry/electron": "3.0.0"
   }
 }

--- a/test/e2e/test-apps/other/browser-replay/src/index.html
+++ b/test/e2e/test-apps/other/browser-replay/src/index.html
@@ -5,8 +5,7 @@
   </head>
   <body>
     <script>
-      const { init } = require('@sentry/electron');
-      const { Replay } = require('@sentry/replay');
+      const { init, Replay } = require('@sentry/electron/renderer');
 
       init({
         debug: true,


### PR DESCRIPTION
While writing the docs I realised Replay should be re-exported for simpler consumption...