### PR TITLE
fix: Add 2 second timeout to session flushing

### DIFF
--- a/src/main/sessions.ts
+++ b/src/main/sessions.ts
@@ -54,7 +54,7 @@ export async function endSession(): Promise<void> {
 
   await sessionStore.clear();
 
-  await flush();
+  await flush(2_000);
 }
 
 /** Determines if a Date is likely to have occurred in the previous uncompleted session */

--- a/test/e2e/recipe/index.ts
+++ b/test/e2e/recipe/index.ts
@@ -7,7 +7,7 @@ import { dirname, join } from 'path';
 import { SDK_VERSION } from '../../../src/main/version';
 import { delay } from '../../helpers';
 import { TestContext } from '../context';
-import { ERROR_ID, RATE_LIMIT_ID, SERVER_PORT, TestServer, TestServerEvent } from '../server';
+import { ERROR_ID, HANG_ID, RATE_LIMIT_ID, SERVER_PORT, TestServer, TestServerEvent } from '../server';
 import { createLogger, getTestLog, walkSync } from '../utils';
 import { evaluateCondition } from './eval';
 import { eventIsSession, normalize } from './normalize';
@@ -115,7 +115,8 @@ export class RecipeRunner {
         .replace('__DSN__', `http://${SENTRY_KEY}@localhost:${SERVER_PORT}/277345`)
         .replace('__INCORRECT_DSN__', `http://${SENTRY_KEY}@localhost:9999/277345`)
         .replace('__RATE_LIMIT_DSN__', `http://${SENTRY_KEY}@localhost:${SERVER_PORT}/${RATE_LIMIT_ID}`)
-        .replace('__ERROR_DSN__', `http://${SENTRY_KEY}@localhost:${SERVER_PORT}/${ERROR_ID}`);
+        .replace('__ERROR_DSN__', `http://${SENTRY_KEY}@localhost:${SERVER_PORT}/${ERROR_ID}`)
+        .replace('__HANG_DSN__', `http://${SENTRY_KEY}@localhost:${SERVER_PORT}/${HANG_ID}`);
 
       if (file.endsWith('package.json')) {
         content = content

--- a/test/e2e/server/index.ts
+++ b/test/e2e/server/index.ts
@@ -8,6 +8,7 @@ import { Readable } from 'stream';
 import { inspect, TextDecoder, TextEncoder } from 'util';
 import { gunzipSync } from 'zlib';
 
+import { delay } from '../../helpers';
 import { eventIsSession } from '../recipe';
 import { createLogger } from '../utils';
 import { parseMultipart, sentryEventFromFormFields } from './multi-part';
@@ -17,6 +18,7 @@ const log = createLogger('Test Server');
 export const SERVER_PORT = 8123;
 export const RATE_LIMIT_ID = 666;
 export const ERROR_ID = 999;
+export const HANG_ID = 777;
 
 interface Attachment {
   filename?: string;
@@ -99,6 +101,11 @@ export class TestServer {
       if (ctx.params.id === ERROR_ID.toString()) {
         ctx.status = 500;
         ctx.body = 'Server Error';
+        return;
+      }
+
+      if (ctx.params.id === HANG_ID.toString()) {
+        await delay(10_000);
         return;
       }
 

--- a/test/e2e/test-apps/other/exit-timeout/package.json
+++ b/test/e2e/test-apps/other/exit-timeout/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "flush-on-exit-timeout",
+  "version": "1.0.0",
+  "main": "src/main.js",
+  "dependencies": {
+    "@sentry/electron": "3.0.0"
+  }
+}

--- a/test/e2e/test-apps/other/exit-timeout/recipe.yml
+++ b/test/e2e/test-apps/other/exit-timeout/recipe.yml
@@ -1,0 +1,3 @@
+description: App close flush timeout
+command: yarn
+expectedError: Some console output

--- a/test/e2e/test-apps/other/exit-timeout/src/main.js
+++ b/test/e2e/test-apps/other/exit-timeout/src/main.js
@@ -1,0 +1,15 @@
+const { app } = require('electron');
+const { init } = require('@sentry/electron');
+
+init({
+  dsn: '__HANG_DSN__',
+  debug: true,
+  onFatalError: () => {},
+});
+
+app.on('ready', () => {
+  setTimeout(() => {
+    console.log('Some console output');
+    app.quit();
+  }, 3000);
+});


### PR DESCRIPTION
Closes #643

- Adds a test server route that holds the connection open for 10 seconds
- Adds an e2e test that exits with app expected to be closed within test timeout
- Add 2 second timeout to session flush