### PR TITLE
feat: Update Sentry SDKs to v7.38.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,18 +58,18 @@
     "e2e": "cross-env TS_NODE_PROJECT=tsconfig.json xvfb-maybe mocha --require ts-node/register/transpile-only --retries 3 ./test/e2e/*.ts"
   },
   "dependencies": {
-    "@sentry/browser": "7.37.1",
-    "@sentry/core": "7.37.1",
-    "@sentry/node": "7.37.1",
-    "@sentry/types": "7.37.1",
-    "@sentry/utils": "7.37.1",
+    "@sentry/browser": "7.38.0",
+    "@sentry/core": "7.38.0",
+    "@sentry/node": "7.38.0",
+    "@sentry/types": "7.38.0",
+    "@sentry/utils": "7.38.0",
     "deepmerge": "4.3.0",
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@sentry-internal/eslint-config-sdk": "7.37.1",
-    "@sentry-internal/typescript": "7.37.1",
-    "@sentry/tracing": "7.37.1",
+    "@sentry-internal/eslint-config-sdk": "7.38.0",
+    "@sentry-internal/typescript": "7.38.0",
+    "@sentry/tracing": "7.38.0",
     "@types/busboy": "^0.2.3",
     "@types/chai": "^4.2.10",
     "@types/chai-as-promised": "^7.1.5",

--- a/src/common/normalize.ts
+++ b/src/common/normalize.ts
@@ -74,7 +74,7 @@ export function normalizeEvent(event: Event, basePath: string): Event {
   }
 
   // The Node SDK includes server_name, which contains the machine name of the computer running Electron.
-  // In this case this is likely to be PII.
+  // In this case this is likely to include PII.
   const { tags = {} } = event;
   delete tags.server_name;
   delete event.server_name;

--- a/src/common/normalize.ts
+++ b/src/common/normalize.ts
@@ -42,6 +42,10 @@ export function normalizeEvent(event: Event, basePath: string): Event {
       if (frame.filename) {
         frame.filename = normalizeUrl(frame.filename, basePath);
       }
+
+      if (frame.abs_path) {
+        frame.abs_path = normalizeUrl(frame.abs_path, basePath);
+      }
     }
   }
 
@@ -69,9 +73,8 @@ export function normalizeEvent(event: Event, basePath: string): Event {
     delete request.headers['User-Agent'];
   }
 
-  // The Node SDK includes server_name, which contains
-  // the machine name of the computer running Electron. This is not useful
-  // information in this case.
+  // The Node SDK includes server_name, which contains the machine name of the computer running Electron.
+  // In this case this is likely to be PII.
   const { tags = {} } = event;
   delete tags.server_name;
   delete event.server_name;

--- a/src/renderer/sdk.ts
+++ b/src/renderer/sdk.ts
@@ -22,7 +22,7 @@ export const defaultIntegrations = [...defaultBrowserIntegrations, new ScopeToMa
 export function init<O extends BrowserOptions>(
   options: BrowserOptions & O = {} as BrowserOptions & O,
   // This parameter name ensures that TypeScript error messages contain a hint for fixing SDK version mismatches
-  originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v7_37_1: O) => void = browserInit,
+  originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v7_38_0: O) => void = browserInit,
 ): void {
   ensureProcess('renderer');
 

--- a/test/unit/stack-parse.test.ts
+++ b/test/unit/stack-parse.test.ts
@@ -22,6 +22,8 @@ describe('Parse mixed renderer stack traces', () => {
 
     expect(frames).to.eql([
       {
+        abs_path:
+          'file:///Users/tim/Documents/Repositories/sentry-electron/test/e2e/dist/javascript-renderer/src/index.html',
         filename:
           'file:///Users/tim/Documents/Repositories/sentry-electron/test/e2e/dist/javascript-renderer/src/index.html',
         function: 'global.setTimeout',
@@ -30,6 +32,8 @@ describe('Parse mixed renderer stack traces', () => {
         colno: 9,
       },
       {
+        abs_path:
+          'file:///Users/tim/Documents/Repositories/sentry-electron/test/e2e/dist/javascript-renderer/src/index.html',
         filename:
           'file:///Users/tim/Documents/Repositories/sentry-electron/test/e2e/dist/javascript-renderer/src/index.html',
         function: 'one',
@@ -38,6 +42,8 @@ describe('Parse mixed renderer stack traces', () => {
         colno: 9,
       },
       {
+        abs_path:
+          'file:///Users/tim/Documents/Repositories/sentry-electron/test/e2e/dist/javascript-renderer/src/index.html',
         filename:
           'file:///Users/tim/Documents/Repositories/sentry-electron/test/e2e/dist/javascript-renderer/src/index.html',
         function: 'two',
@@ -91,6 +97,8 @@ describe('Parse mixed renderer stack traces', () => {
 
     expect(frames).to.eql([
       {
+        abs_path:
+          'file:///Users/tim/Documents/Repositories/sentry-electron/test/e2e/dist/javascript-renderer/src/index.html',
         filename:
           'file:///Users/tim/Documents/Repositories/sentry-electron/test/e2e/dist/javascript-renderer/src/index.html',
         function: '?',
@@ -99,6 +107,8 @@ describe('Parse mixed renderer stack traces', () => {
         colno: 9,
       },
       {
+        abs_path:
+          'file:///Users/tim/Documents/Repositories/sentry-electron/test/e2e/dist/javascript-renderer/src/index.html',
         filename:
           'file:///Users/tim/Documents/Repositories/sentry-electron/test/e2e/dist/javascript-renderer/src/index.html',
         function: 'one',
@@ -107,6 +117,8 @@ describe('Parse mixed renderer stack traces', () => {
         colno: 9,
       },
       {
+        abs_path:
+          'file:///Users/tim/Documents/Repositories/sentry-electron/test/e2e/dist/javascript-renderer/src/index.html',
         filename:
           'file:///Users/tim/Documents/Repositories/sentry-electron/test/e2e/dist/javascript-renderer/src/index.html',
         function: 'two',

--- a/yarn.lock
+++ b/yarn.lock
@@ -128,13 +128,13 @@
     "@pnpm/network.ca-file" "^1.0.1"
     config-chain "^1.1.11"
 
-"@sentry-internal/eslint-config-sdk@7.37.1":
-  version "7.37.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.37.1.tgz#1dafb9edbe7df94fb791c95aff80b6437f60a36a"
-  integrity sha512-jdkt6DG0+IwctiH8J1be8ZyQlgDyzkeJvhEZv8D/ZdCM5tqjvUqkbqS1yVTfwV+5OfjIMnQ4I9D/5Fnt8V14Rg==
+"@sentry-internal/eslint-config-sdk@7.38.0":
+  version "7.38.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.38.0.tgz#a7c0c59e13d9b04895c2b5d1ac4d675fd692b449"
+  integrity sha512-qKw2Vcs+K7s16tgHlHzbaM821e34p+PsNtxndRiOFq3o+f9aCZYO1vAVTV9Qx7o/yB2dIBapI0ua8bWm8fHcMw==
   dependencies:
-    "@sentry-internal/eslint-plugin-sdk" "7.37.1"
-    "@sentry-internal/typescript" "7.37.1"
+    "@sentry-internal/eslint-plugin-sdk" "7.38.0"
+    "@sentry-internal/typescript" "7.38.0"
     "@typescript-eslint/eslint-plugin" "^5.48.0"
     "@typescript-eslint/parser" "^5.48.0"
     eslint-config-prettier "^6.11.0"
@@ -143,81 +143,81 @@
     eslint-plugin-jsdoc "^30.0.3"
     eslint-plugin-simple-import-sort "^5.0.3"
 
-"@sentry-internal/eslint-plugin-sdk@7.37.1":
-  version "7.37.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.37.1.tgz#9f6da2b0c711edeca628cb76eedf5f4776863dd2"
-  integrity sha512-SENuFIWVzb7xDEOdQTV8/i4EUb+s9ro6QWM/etXALQGE/Cvdors4YzTzfm3dJzV0Uk5DF3IPwdwQvimEeOsXHA==
+"@sentry-internal/eslint-plugin-sdk@7.38.0":
+  version "7.38.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.38.0.tgz#c149722c148ee69aed363da41bd6de7301447263"
+  integrity sha512-kBql/7x8jveC6bgOL5664odpKcVLnLcW5khKQV453C8vvyBwzBpbk4mWYS4xDI/o64XJCdI866Sh8bN47QiN7Q==
   dependencies:
     requireindex "~1.1.0"
 
-"@sentry-internal/typescript@7.37.1":
-  version "7.37.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.37.1.tgz#69ab51dc699eef56478da115789999dedb762e07"
-  integrity sha512-DEgaC5noRaY7WHM2XKEDRKbO01LtI4TVYxdbEgZQUmQX7FV1Ql27otHtEGiMBKe8JqoRHYm+Q3J9ZRtblMDERQ==
+"@sentry-internal/typescript@7.38.0":
+  version "7.38.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.38.0.tgz#0016c9f9e26ee662d764597969ec8b29d84669a2"
+  integrity sha512-RdT121kNtsfcWE2pm4ONr9OAVSSsNSojIj9IpGFk8qk9tpMS0pWmzow9btnohqjCu6ClD1ppd4AhV4DnzwRThA==
 
-"@sentry/browser@7.37.1":
-  version "7.37.1"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.37.1.tgz#d452ebed7f974f20872d34744e67d856ab54a41b"
-  integrity sha512-MfVbKzEVHKVH6ZyMCKLtPXvMtRCvxqQzrnK735sYW6EyMpcMYhukBU0pq7ws1E/KaCZjAJi1wDx2nqf2yPIVdQ==
+"@sentry/browser@7.38.0":
+  version "7.38.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.38.0.tgz#cdb39da23f9ee2ce47395b2c12542acb4969efa7"
+  integrity sha512-rPJr+2jRYL29PeMYA2JgzYKTZQx6bc3T9evbAdIh0n+popSjpVyOpOMV/3l6A7KZeeix3dpp6eUZUxTJukqriQ==
   dependencies:
-    "@sentry/core" "7.37.1"
-    "@sentry/replay" "7.37.1"
-    "@sentry/types" "7.37.1"
-    "@sentry/utils" "7.37.1"
+    "@sentry/core" "7.38.0"
+    "@sentry/replay" "7.38.0"
+    "@sentry/types" "7.38.0"
+    "@sentry/utils" "7.38.0"
     tslib "^1.9.3"
 
-"@sentry/core@7.37.1":
-  version "7.37.1"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.37.1.tgz#6d8d151b3d6ae0d6f81c7f4da92cd2e7cb5bf1fa"
-  integrity sha512-eS5hoFDjAOl7POZg6K77J0oiypiqR1782oVSB49UkjK+D8tCZzZ5PxPMv0b/O0310p7x4oZ3WGRJaWEN3vY4KQ==
+"@sentry/core@7.38.0":
+  version "7.38.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.38.0.tgz#52f1f1f2ba5e88ab7b33c3abb0ea9730c78d953d"
+  integrity sha512-+hXh/SO3Ie6WC2b+wi01xLhyVREdkRXS5QBmCiv3z2ks2HvYXp7PoKSXJvNKiwCP+pBD+enOnM1YEzM2yEy5yw==
   dependencies:
-    "@sentry/types" "7.37.1"
-    "@sentry/utils" "7.37.1"
+    "@sentry/types" "7.38.0"
+    "@sentry/utils" "7.38.0"
     tslib "^1.9.3"
 
-"@sentry/node@7.37.1":
-  version "7.37.1"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.37.1.tgz#c234e8711090b7532358bb1d6ab3fcca75356e98"
-  integrity sha512-nGerngIo5JwinJgl7m0SaL/xI+YRBlhb53gbkuLSAAcnoitBFzbp7LjywsqYFTWuWDIyk7O2t124GNxtolBAgA==
+"@sentry/node@7.38.0":
+  version "7.38.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.38.0.tgz#957524fa4764dc19ef970ccdffb802d62e0db3ae"
+  integrity sha512-jNIN6NZvgzn/oms8RQzffjX8Z0LQDTN6N28nnhzqGCvnfmS1QtTt0FlU+pTuFXZNNSjfGy4XMXMYvLlbvhm2bg==
   dependencies:
-    "@sentry/core" "7.37.1"
-    "@sentry/types" "7.37.1"
-    "@sentry/utils" "7.37.1"
+    "@sentry/core" "7.38.0"
+    "@sentry/types" "7.38.0"
+    "@sentry/utils" "7.38.0"
     cookie "^0.4.1"
     https-proxy-agent "^5.0.0"
     lru_map "^0.3.3"
     tslib "^1.9.3"
 
-"@sentry/replay@7.37.1":
-  version "7.37.1"
-  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.37.1.tgz#8ab4588b28baa07e35c417d3ffc6aaf934c58c45"
-  integrity sha512-3sHOE/oPirdvJbOn0IA/wpds12Sm2WaEtiAeC0+5Gg5mxQzFBLRrsA1Mz/ifzPGwr+ETn3sCyPCnd9b3PWaWMQ==
+"@sentry/replay@7.38.0":
+  version "7.38.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.38.0.tgz#48d240b67de6b4ab41c951d19abeceb0d3f7706d"
+  integrity sha512-Ai78/OIYedny605x8uS0n/a5uj7qnuevogGD6agLat9lGc8DFvC07m2iS+EFyGOwtQzyDlRYJvYkHL8peR3crQ==
   dependencies:
-    "@sentry/core" "7.37.1"
-    "@sentry/types" "7.37.1"
-    "@sentry/utils" "7.37.1"
+    "@sentry/core" "7.38.0"
+    "@sentry/types" "7.38.0"
+    "@sentry/utils" "7.38.0"
 
-"@sentry/tracing@7.37.1":
-  version "7.37.1"
-  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.37.1.tgz#f5db7990f09be8d3c6b621b3718c268fff163ba0"
-  integrity sha512-3mQG2XtMCGqDkgfzhKpRJAIfRaokNAOF8WafgAmFmZQwEDsRAFjZ3pLoO+KiBUeQE5E5et7HyWBOl9rqHCkWnQ==
+"@sentry/tracing@7.38.0":
+  version "7.38.0"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.38.0.tgz#ba28f15f526e87df167de206fd4fb0a39277dac6"
+  integrity sha512-ejXJp8oOT64MVtBzqdECUUaNzKbpu25St8Klub1i4Sm7xO+ZjDQDI4TIHvWojZvtkwQ3F4jcsCclc8KuyJunyQ==
   dependencies:
-    "@sentry/core" "7.37.1"
-    "@sentry/types" "7.37.1"
-    "@sentry/utils" "7.37.1"
+    "@sentry/core" "7.38.0"
+    "@sentry/types" "7.38.0"
+    "@sentry/utils" "7.38.0"
     tslib "^1.9.3"
 
-"@sentry/types@7.37.1":
-  version "7.37.1"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.37.1.tgz#269da7da39c1a5243bf5f9a35370291b5cc205bb"
-  integrity sha512-c2HWyWSgVA0V4+DSW2qVb0yjftrb1X/q2CzCom+ayjGHO72qyWC+9Tc+7ZfotU1mapRjqUWBgkXkbGmao8N8Ug==
+"@sentry/types@7.38.0":
+  version "7.38.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.38.0.tgz#6e2611544446271ed237440b12de782805aefe25"
+  integrity sha512-NKOALR6pNUMzUrsk2m+dkPrO8uGNvNh1LD0BCPswKNjC2qHo1h1mDGCgBmF9+EWyii8ZoACTIsxvsda+MBf97Q==
 
-"@sentry/utils@7.37.1":
-  version "7.37.1"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.37.1.tgz#7695d6e30d6178723f3fa446a9553893bca85e96"
-  integrity sha512-/4mJOyDsfysx+5TXyJgSI+Ihw2/0EVJbrHjCyXPDXW5ADwbtU8VdBZ0unOmF0hk4QfftqwM9cyEu3BN4iBJsEA==
+"@sentry/utils@7.38.0":
+  version "7.38.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.38.0.tgz#d10716e730108301f58766970493e9c5da0ba502"
+  integrity sha512-MgbI3YmYuyyhUtvcXkgGBqjOW+nuLLNGUdWCK+C4kObf8VbLt3dSE/7SEMT6TSHLYQmxs2BxFgx5Agn97m68kQ==
   dependencies:
-    "@sentry/types" "7.37.1"
+    "@sentry/types" "7.38.0"
     tslib "^1.9.3"
 
 "@sindresorhus/is@^4.0.0":


### PR DESCRIPTION
Replaces #641 because some manual changes were required.

Includes changes due to the addition of `abs_path` to stack trace frames.