### PR TITLE
feat: Add callback option for more control over screenshot capture

### DIFF
--- a/src/main/integrations/screenshots.ts
+++ b/src/main/integrations/screenshots.ts
@@ -16,12 +16,18 @@ export class Screenshots implements Integration {
 
   /** @inheritDoc */
   public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void): void {
-    const attachScreenshot = !!(getCurrentHub().getClient()?.getOptions() as ElectronMainOptions).attachScreenshot;
+    const attachScreenshot = (getCurrentHub().getClient()?.getOptions() as ElectronMainOptions).attachScreenshot;
 
     if (attachScreenshot) {
       addGlobalEventProcessor(async (event: Event, hint: EventHint) => {
         // We don't capture screenshots for transactions or native crashes
         if (!event.transaction && event.platform !== 'native') {
+          if (typeof attachScreenshot === 'function') {
+            if (attachScreenshot(event, hint) === false) {
+              return event;
+            }
+          }
+
           let count = 1;
 
           for (const window of BrowserWindow.getAllWindows()) {

--- a/src/main/sdk.ts
+++ b/src/main/sdk.ts
@@ -2,7 +2,7 @@ import { ensureProcess, IPCMode } from '../common';
 ensureProcess('main');
 
 import { defaultIntegrations as defaultNodeIntegrations, init as nodeInit, NodeOptions } from '@sentry/node';
-import { Integration, Options } from '@sentry/types';
+import { Event, EventHint, Integration, Options } from '@sentry/types';
 import { Session, session, WebContents } from 'electron';
 
 import { getDefaultEnvironment, getDefaultReleaseName } from './context';
@@ -36,6 +36,8 @@ export const defaultIntegrations: Integration[] = [
     (integration) => integration.name !== 'OnUncaughtException' && integration.name !== 'Context',
   ),
 ];
+
+type ShouldEvent = (event: Event, hint: EventHint) => boolean;
 
 export interface ElectronMainOptionsInternal extends Options<ElectronOfflineTransportOptions> {
   /**
@@ -74,7 +76,7 @@ export interface ElectronMainOptionsInternal extends Options<ElectronOfflineTran
    * Screenshots are not included for native crashes since it's not possible to capture images of crashed Electron
    * renderers.
    */
-  attachScreenshot?: boolean;
+  attachScreenshot?: boolean | ShouldEvent;
 }
 
 // getSessions and ipcMode properties are optional because they have defaults


### PR DESCRIPTION
Closes #648

Extends the `attachScreenshot` option to allow a callback to be passed which when supplied is called before capturing a screenshot. The callback is passed the event and hint and returning true results in screenshot attachment.