### PR TITLE
feat: Update to v7.55.0 of Sentry JavaScript SDKs

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,17 +58,17 @@
     "e2e": "cross-env TS_NODE_PROJECT=tsconfig.json xvfb-maybe mocha --require ts-node/register/transpile-only --retries 3 ./test/e2e/*.ts"
   },
   "dependencies": {
-    "@sentry/browser": "7.54.0",
-    "@sentry/core": "7.54.0",
-    "@sentry/node": "7.54.0",
-    "@sentry/types": "7.54.0",
-    "@sentry/utils": "7.54.0",
+    "@sentry/browser": "7.55.0",
+    "@sentry/core": "7.55.0",
+    "@sentry/node": "7.55.0",
+    "@sentry/types": "7.55.0",
+    "@sentry/utils": "7.55.0",
     "deepmerge": "4.3.0",
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@sentry-internal/eslint-config-sdk": "7.54.0",
-    "@sentry-internal/typescript": "7.54.0",
+    "@sentry-internal/eslint-config-sdk": "7.55.0",
+    "@sentry-internal/typescript": "7.55.0",
     "@types/busboy": "^0.2.3",
     "@types/chai": "^4.2.10",
     "@types/chai-as-promised": "^7.1.5",

--- a/package.json
+++ b/package.json
@@ -58,17 +58,17 @@
     "e2e": "cross-env TS_NODE_PROJECT=tsconfig.json xvfb-maybe mocha --require ts-node/register/transpile-only --retries 3 ./test/e2e/*.ts"
   },
   "dependencies": {
-    "@sentry/browser": "7.50.0",
-    "@sentry/core": "7.50.0",
-    "@sentry/node": "7.50.0",
-    "@sentry/types": "7.50.0",
-    "@sentry/utils": "7.50.0",
+    "@sentry/browser": "7.54.0",
+    "@sentry/core": "7.54.0",
+    "@sentry/node": "7.54.0",
+    "@sentry/types": "7.54.0",
+    "@sentry/utils": "7.54.0",
     "deepmerge": "4.3.0",
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@sentry-internal/eslint-config-sdk": "7.50.0",
-    "@sentry-internal/typescript": "7.50.0",
+    "@sentry-internal/eslint-config-sdk": "7.54.0",
+    "@sentry-internal/typescript": "7.54.0",
     "@types/busboy": "^0.2.3",
     "@types/chai": "^4.2.10",
     "@types/chai-as-promised": "^7.1.5",

--- a/src/renderer/sdk.ts
+++ b/src/renderer/sdk.ts
@@ -22,7 +22,7 @@ export const defaultIntegrations = [...defaultBrowserIntegrations, new ScopeToMa
 export function init<O extends BrowserOptions>(
   options: BrowserOptions & O = {} as BrowserOptions & O,
   // This parameter name ensures that TypeScript error messages contain a hint for fixing SDK version mismatches
-  originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v7_54_0: O) => void = browserInit,
+  originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v7_55_0: O) => void = browserInit,
 ): void {
   ensureProcess('renderer');
 

--- a/src/renderer/sdk.ts
+++ b/src/renderer/sdk.ts
@@ -22,7 +22,7 @@ export const defaultIntegrations = [...defaultBrowserIntegrations, new ScopeToMa
 export function init<O extends BrowserOptions>(
   options: BrowserOptions & O = {} as BrowserOptions & O,
   // This parameter name ensures that TypeScript error messages contain a hint for fixing SDK version mismatches
-  originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v7_50_0: O) => void = browserInit,
+  originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v7_54_0: O) => void = browserInit,
 ): void {
   ensureProcess('renderer');
 

--- a/test/unit/stack-parse.test.ts
+++ b/test/unit/stack-parse.test.ts
@@ -156,14 +156,14 @@ describe('Parse mixed renderer stack traces', () => {
       {
         filename: 'http://localhost:12345/src/index.html',
         function: 'one',
-        in_app: false,
+        in_app: true,
         lineno: 24,
         colno: 9,
       },
       {
         filename: 'http://localhost:12345/src/index.html',
         function: 'two',
-        in_app: false,
+        in_app: true,
         lineno: 17,
         colno: 11,
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -128,13 +128,13 @@
     "@pnpm/network.ca-file" "^1.0.1"
     config-chain "^1.1.11"
 
-"@sentry-internal/eslint-config-sdk@7.54.0":
-  version "7.54.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.54.0.tgz#d208276b643a931089a7c4a65a265e1a4e9c0c39"
-  integrity sha512-JXvDbAnzFjoujxBZBFunxiLs0Ze0rpXglk3eQZAWRtF6rZaRDZU3R8tl8nL5+3IHxB/yguVR9xibSVtAlorHvw==
+"@sentry-internal/eslint-config-sdk@7.55.0":
+  version "7.55.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.55.0.tgz#31f306269eba5d9c93baf94d88b18eeffefb0c8a"
+  integrity sha512-NMGvnhvNIw10JvCb6ftxf2no509UQD55Z+bSOeIrz+NyOsw1Ain8WeO2M+xu/cuRALUx29fn2/tGI8gqvBRlXg==
   dependencies:
-    "@sentry-internal/eslint-plugin-sdk" "7.54.0"
-    "@sentry-internal/typescript" "7.54.0"
+    "@sentry-internal/eslint-plugin-sdk" "7.55.0"
+    "@sentry-internal/typescript" "7.55.0"
     "@typescript-eslint/eslint-plugin" "^5.48.0"
     "@typescript-eslint/parser" "^5.48.0"
     eslint-config-prettier "^6.11.0"
@@ -143,83 +143,83 @@
     eslint-plugin-jsdoc "^30.0.3"
     eslint-plugin-simple-import-sort "^5.0.3"
 
-"@sentry-internal/eslint-plugin-sdk@7.54.0":
-  version "7.54.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.54.0.tgz#e92ebf061feb6c640d099eb6f6addc9a50b12d30"
-  integrity sha512-NnVFVR6McwuVdNI5wahvWfErQmVeL6zFTq93cUhY8O98qjTEbRpxqZLZmCPJEO4A8DjmoX6AgCAK2/SmyqvHkg==
+"@sentry-internal/eslint-plugin-sdk@7.55.0":
+  version "7.55.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.55.0.tgz#f44fbaf761e9cf22c14eb81985246e080e0f5a4c"
+  integrity sha512-DeotHRe1d9JPuPqYgKJjsJdjxZibDco8L99MMiYonIfYBZgwTLc/eaM3bf5uFqRx+MWd2sFphzfFGyBN4QA11w==
   dependencies:
     requireindex "~1.1.0"
 
-"@sentry-internal/tracing@7.54.0":
-  version "7.54.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.54.0.tgz#eeb10ee72426d08669a7706faa4264f1ec02c71d"
-  integrity sha512-JsyhZ0wWZ+VqbHJg+azqRGdYJDkcI5R9+pnkO6SzbzxrRewqMAIwzkpPee3oI7vG99uhMEkOkMjHu0nQGwkOQw==
+"@sentry-internal/tracing@7.55.0":
+  version "7.55.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.55.0.tgz#4ecdc1e62590b19c51b6b0d8f4cd09d13fe4beca"
+  integrity sha512-Bm82Z2tHcz4BF8CQDfYT5LeZPpuePWNHcxTSknJImPpPlQnol++2WQtloZZOs5FxllXL08UjN3LphRKmiEQsVQ==
   dependencies:
-    "@sentry/core" "7.54.0"
-    "@sentry/types" "7.54.0"
-    "@sentry/utils" "7.54.0"
+    "@sentry/core" "7.55.0"
+    "@sentry/types" "7.55.0"
+    "@sentry/utils" "7.55.0"
     tslib "^1.9.3"
 
-"@sentry-internal/typescript@7.54.0":
-  version "7.54.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.54.0.tgz#5fa9aa3be72055159eb9ad4fc5cebf555fc5a075"
-  integrity sha512-Ohoplg119QbOuBGQdzLVWGJwym5Z59Xj+/oFCJQZTHFseqheBL1tnUx3PJYL96/4DN+0dDqSiSSDJwoSkSn3lw==
+"@sentry-internal/typescript@7.55.0":
+  version "7.55.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.55.0.tgz#7bd1dcd8f4795a410a999fd8afa0011b037c6ada"
+  integrity sha512-bbhkdEmEfZu3WZKjd+IIBwjhwDLpCE8lx/noFKp/Fq7AOHxM8xA93THY2CR9ZZCvoQgoWLzwx5GFpPdVsdspXw==
 
-"@sentry/browser@7.54.0":
-  version "7.54.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.54.0.tgz#7fe331c776d02b5c902733aa41dcbfac7bef1ae6"
-  integrity sha512-EvLAw03N9WE2m1CMl2/1YMeIs1icw9IEOVJhWmf3uJEysNJOFWXu6ZzdtHEz1E6DiJYhc1HzDya0ExZeJxNARA==
+"@sentry/browser@7.55.0":
+  version "7.55.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.55.0.tgz#b3219e03c8f4579c5f8e101fe4c285ed7bbe5f73"
+  integrity sha512-ukwj7MBkZx0IBDL5MfNcerZp8p5M85m+AZ7LFEw2aMVFSt4HEmp1CPQYpubORMcP+oq+BHGJ6khkvNQlM4D7+g==
   dependencies:
-    "@sentry-internal/tracing" "7.54.0"
-    "@sentry/core" "7.54.0"
-    "@sentry/replay" "7.54.0"
-    "@sentry/types" "7.54.0"
-    "@sentry/utils" "7.54.0"
+    "@sentry-internal/tracing" "7.55.0"
+    "@sentry/core" "7.55.0"
+    "@sentry/replay" "7.55.0"
+    "@sentry/types" "7.55.0"
+    "@sentry/utils" "7.55.0"
     tslib "^1.9.3"
 
-"@sentry/core@7.54.0":
-  version "7.54.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.54.0.tgz#8c4cb8800f8df708b3f3f6483026bb9a02820014"
-  integrity sha512-MAn0E2EwgNn1pFQn4qxhU+1kz6edullWg6VE5wCmtpXWOVw6sILBUsQpeIG5djBKMcneJCdOlz5jeqcKPrLvZQ==
+"@sentry/core@7.55.0":
+  version "7.55.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.55.0.tgz#0a02f8bf7f083a52b344e03f1fe0b8bd092765af"
+  integrity sha512-ClOcxdAlX7aS52UQQFc7zAIoqyV24wZnDamJTNtnygETGhrjsj4sUyhelF0xecn5gyYJQ0pfT55iBTGacms8Ag==
   dependencies:
-    "@sentry/types" "7.54.0"
-    "@sentry/utils" "7.54.0"
+    "@sentry/types" "7.55.0"
+    "@sentry/utils" "7.55.0"
     tslib "^1.9.3"
 
-"@sentry/node@7.54.0":
-  version "7.54.0"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.54.0.tgz#ebdc1f5d91e97bbfbbc70192bf2bf77433f5f55f"
-  integrity sha512-k8P7WD6lra3JF3H/y9GO+twBV8qQilj3X3d8PpaVPBHHwOA9AfdBVF18qgrdlZKghKtgALapZzrQQVnTOm34rw==
+"@sentry/node@7.55.0":
+  version "7.55.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.55.0.tgz#ee4df42dda1c38f27708f078daaa1f8062583c6b"
+  integrity sha512-X7v1LoZu6mlZAg7eDz+gU4V0QdfcKcZjI/4bxl6E9yKX6VH5ORuNaNujWXMfzu7Yvu8Dtp+JZ0ZDa+9nEmXbZQ==
   dependencies:
-    "@sentry-internal/tracing" "7.54.0"
-    "@sentry/core" "7.54.0"
-    "@sentry/types" "7.54.0"
-    "@sentry/utils" "7.54.0"
+    "@sentry-internal/tracing" "7.55.0"
+    "@sentry/core" "7.55.0"
+    "@sentry/types" "7.55.0"
+    "@sentry/utils" "7.55.0"
     cookie "^0.4.1"
     https-proxy-agent "^5.0.0"
     lru_map "^0.3.3"
     tslib "^1.9.3"
 
-"@sentry/replay@7.54.0":
-  version "7.54.0"
-  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.54.0.tgz#f0f44f9413ceefd1809bf1665e82315927ae08db"
-  integrity sha512-C0F0568ybphzGmKGe23duB6n5wJcgM7WLYhoeqW3o2bHeqpj1dGPSka/K3s9KzGaAgzn1zeOUYXJsOs+T/XdsA==
+"@sentry/replay@7.55.0":
+  version "7.55.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.55.0.tgz#9332bf749a01c418ebc1b392358ca4a335471f31"
+  integrity sha512-SRWYNgSTGjUBONRJk939MJTynk6fxK524J5Sa/ABHHo+Gow1O8F1q9GY4OIIGkh0Giz8rO6vePWBwuDE6F7B2Q==
   dependencies:
-    "@sentry/core" "7.54.0"
-    "@sentry/types" "7.54.0"
-    "@sentry/utils" "7.54.0"
+    "@sentry/core" "7.55.0"
+    "@sentry/types" "7.55.0"
+    "@sentry/utils" "7.55.0"
 
-"@sentry/types@7.54.0":
-  version "7.54.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.54.0.tgz#bfee18107a78e290e6c8ad41646e2b9d9dd95234"
-  integrity sha512-D+i9xogBeawvQi2r0NOrM7zYcUaPuijeME4O9eOTrDF20tj71hWtJLilK+KTGLYFtpGg1h+9bPaz7OHEIyVopg==
+"@sentry/types@7.55.0":
+  version "7.55.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.55.0.tgz#97baff0d9fc2e2946366ff2569f0a44cc0dd9d37"
+  integrity sha512-e8VLiR0NIYd1Y5SlATp3eSARTYmbpNEYsX2b3a1E0NDZj+G5eOqef7k6ab6Y30LUrqrqmkDE0VJqTtnI3pMzzg==
 
-"@sentry/utils@7.54.0":
-  version "7.54.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.54.0.tgz#a3acb5e25a1409cbca7b46d6356d7417a253ea9a"
-  integrity sha512-3Yf5KlKjIcYLddOexSt2ovu2TWlR4Fi7M+aCK8yUTzwNzf/xwFSWOstHlD/WiDy9HvfhWAOB/ukNTuAeJmtasw==
+"@sentry/utils@7.55.0":
+  version "7.55.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.55.0.tgz#cb1ab6a5534755a27611257edafe09ae1df01375"
+  integrity sha512-18YU0fLhlr/e7lUyMkh/BEE05N8DG9lzWToz6c9DOYw6pTyt2EXZrxho+BcYufd7IayU0Twb0sp8EX/wfggYxA==
   dependencies:
-    "@sentry/types" "7.54.0"
+    "@sentry/types" "7.55.0"
     tslib "^1.9.3"
 
 "@sindresorhus/is@^4.0.0":

--- a/yarn.lock
+++ b/yarn.lock
@@ -128,13 +128,13 @@
     "@pnpm/network.ca-file" "^1.0.1"
     config-chain "^1.1.11"
 
-"@sentry-internal/eslint-config-sdk@7.50.0":
-  version "7.50.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.50.0.tgz#b4210244f1bf69e035cf924f34f8cb8b0e50be31"
-  integrity sha512-jge0KvAH9kUcphiWftLqIYmKM0Wm0/cZUWPBtnc8ApNDGCOZhj0uX8zTEWSAZb2YOXv5AikCEfshPGuftlXYBg==
+"@sentry-internal/eslint-config-sdk@7.54.0":
+  version "7.54.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.54.0.tgz#d208276b643a931089a7c4a65a265e1a4e9c0c39"
+  integrity sha512-JXvDbAnzFjoujxBZBFunxiLs0Ze0rpXglk3eQZAWRtF6rZaRDZU3R8tl8nL5+3IHxB/yguVR9xibSVtAlorHvw==
   dependencies:
-    "@sentry-internal/eslint-plugin-sdk" "7.50.0"
-    "@sentry-internal/typescript" "7.50.0"
+    "@sentry-internal/eslint-plugin-sdk" "7.54.0"
+    "@sentry-internal/typescript" "7.54.0"
     "@typescript-eslint/eslint-plugin" "^5.48.0"
     "@typescript-eslint/parser" "^5.48.0"
     eslint-config-prettier "^6.11.0"
@@ -143,83 +143,83 @@
     eslint-plugin-jsdoc "^30.0.3"
     eslint-plugin-simple-import-sort "^5.0.3"
 
-"@sentry-internal/eslint-plugin-sdk@7.50.0":
-  version "7.50.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.50.0.tgz#a42a9acad3fc87af5f9d82d5c02adc8bc69c69b6"
-  integrity sha512-DFDqs43Pc6sIYHGysYO9E+Z4hkUs4cbmo9e+vWnRKlsQDfHs/+BirsX6pH07m/sbWxKwwdUbel3I+yOXJF9jxQ==
+"@sentry-internal/eslint-plugin-sdk@7.54.0":
+  version "7.54.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.54.0.tgz#e92ebf061feb6c640d099eb6f6addc9a50b12d30"
+  integrity sha512-NnVFVR6McwuVdNI5wahvWfErQmVeL6zFTq93cUhY8O98qjTEbRpxqZLZmCPJEO4A8DjmoX6AgCAK2/SmyqvHkg==
   dependencies:
     requireindex "~1.1.0"
 
-"@sentry-internal/tracing@7.50.0":
-  version "7.50.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.50.0.tgz#74454af99a03d81762993835d2687c881e14f41e"
-  integrity sha512-4TQ4vN0aMBWsUXfJWk2xbe4x7fKfwCXgXKTtHC/ocwwKM+0EefV5Iw9YFG8IrIQN4vMtuRzktqcs9q0/Sbv7tg==
+"@sentry-internal/tracing@7.54.0":
+  version "7.54.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.54.0.tgz#eeb10ee72426d08669a7706faa4264f1ec02c71d"
+  integrity sha512-JsyhZ0wWZ+VqbHJg+azqRGdYJDkcI5R9+pnkO6SzbzxrRewqMAIwzkpPee3oI7vG99uhMEkOkMjHu0nQGwkOQw==
   dependencies:
-    "@sentry/core" "7.50.0"
-    "@sentry/types" "7.50.0"
-    "@sentry/utils" "7.50.0"
+    "@sentry/core" "7.54.0"
+    "@sentry/types" "7.54.0"
+    "@sentry/utils" "7.54.0"
     tslib "^1.9.3"
 
-"@sentry-internal/typescript@7.50.0":
-  version "7.50.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.50.0.tgz#31d76a36bba025ca35edefc6d1dae6afac26d4f1"
-  integrity sha512-cCWBqAcKWByS7z9x2oqsFl6/fT4EhFgb6OYShPlsOwP5UYthIJqDDFZJiFb9qSejQeENgSyWE63dIMVMtUI5sQ==
+"@sentry-internal/typescript@7.54.0":
+  version "7.54.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.54.0.tgz#5fa9aa3be72055159eb9ad4fc5cebf555fc5a075"
+  integrity sha512-Ohoplg119QbOuBGQdzLVWGJwym5Z59Xj+/oFCJQZTHFseqheBL1tnUx3PJYL96/4DN+0dDqSiSSDJwoSkSn3lw==
 
-"@sentry/browser@7.50.0":
-  version "7.50.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.50.0.tgz#16c995c336322c8aec65570f90f50288678004ec"
-  integrity sha512-a+UYbP89+SAvW47/p9wxEi9eWlyp/SkYl52OCdZNXnplQY4kQIOVyiaIs5nnCxIxZgXKrhAX4eo1E9ykleFuNQ==
+"@sentry/browser@7.54.0":
+  version "7.54.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.54.0.tgz#7fe331c776d02b5c902733aa41dcbfac7bef1ae6"
+  integrity sha512-EvLAw03N9WE2m1CMl2/1YMeIs1icw9IEOVJhWmf3uJEysNJOFWXu6ZzdtHEz1E6DiJYhc1HzDya0ExZeJxNARA==
   dependencies:
-    "@sentry-internal/tracing" "7.50.0"
-    "@sentry/core" "7.50.0"
-    "@sentry/replay" "7.50.0"
-    "@sentry/types" "7.50.0"
-    "@sentry/utils" "7.50.0"
+    "@sentry-internal/tracing" "7.54.0"
+    "@sentry/core" "7.54.0"
+    "@sentry/replay" "7.54.0"
+    "@sentry/types" "7.54.0"
+    "@sentry/utils" "7.54.0"
     tslib "^1.9.3"
 
-"@sentry/core@7.50.0":
-  version "7.50.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.50.0.tgz#88bc9cbfc0cb429a28489ece6f0be7a7006436c4"
-  integrity sha512-6oD1a3fYs4aiNK7tuJSd88LHjYJAetd7ZK/AfJniU7zWKj4jxIYfO8nhm0qdnhEDs81RcweVDmPhWm3Kwrzzsg==
+"@sentry/core@7.54.0":
+  version "7.54.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.54.0.tgz#8c4cb8800f8df708b3f3f6483026bb9a02820014"
+  integrity sha512-MAn0E2EwgNn1pFQn4qxhU+1kz6edullWg6VE5wCmtpXWOVw6sILBUsQpeIG5djBKMcneJCdOlz5jeqcKPrLvZQ==
   dependencies:
-    "@sentry/types" "7.50.0"
-    "@sentry/utils" "7.50.0"
+    "@sentry/types" "7.54.0"
+    "@sentry/utils" "7.54.0"
     tslib "^1.9.3"
 
-"@sentry/node@7.50.0":
-  version "7.50.0"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.50.0.tgz#d6adab136d87f7dca614ea0d77944f902fa45626"
-  integrity sha512-11UJBKoQFMp7f8sbzeO2gENsKIUkVCNBTzuPRib7l2K1HMjSfacXmwwma7ZEs0mc3ofIZ1UYuyONAXmI1lK9cQ==
+"@sentry/node@7.54.0":
+  version "7.54.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.54.0.tgz#ebdc1f5d91e97bbfbbc70192bf2bf77433f5f55f"
+  integrity sha512-k8P7WD6lra3JF3H/y9GO+twBV8qQilj3X3d8PpaVPBHHwOA9AfdBVF18qgrdlZKghKtgALapZzrQQVnTOm34rw==
   dependencies:
-    "@sentry-internal/tracing" "7.50.0"
-    "@sentry/core" "7.50.0"
-    "@sentry/types" "7.50.0"
-    "@sentry/utils" "7.50.0"
+    "@sentry-internal/tracing" "7.54.0"
+    "@sentry/core" "7.54.0"
+    "@sentry/types" "7.54.0"
+    "@sentry/utils" "7.54.0"
     cookie "^0.4.1"
     https-proxy-agent "^5.0.0"
     lru_map "^0.3.3"
     tslib "^1.9.3"
 
-"@sentry/replay@7.50.0":
-  version "7.50.0"
-  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.50.0.tgz#dd29f063492d91e708629ff8dd95a59d4b7180f1"
-  integrity sha512-EYRk+DTZ5luwfkiCaDpBC3YBKIEdkReTUNZtWDVUytSVjsCnttkAipx/y6bxy3HN+rSXungMd3XKQT5RNMRUNA==
+"@sentry/replay@7.54.0":
+  version "7.54.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.54.0.tgz#f0f44f9413ceefd1809bf1665e82315927ae08db"
+  integrity sha512-C0F0568ybphzGmKGe23duB6n5wJcgM7WLYhoeqW3o2bHeqpj1dGPSka/K3s9KzGaAgzn1zeOUYXJsOs+T/XdsA==
   dependencies:
-    "@sentry/core" "7.50.0"
-    "@sentry/types" "7.50.0"
-    "@sentry/utils" "7.50.0"
+    "@sentry/core" "7.54.0"
+    "@sentry/types" "7.54.0"
+    "@sentry/utils" "7.54.0"
 
-"@sentry/types@7.50.0":
-  version "7.50.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.50.0.tgz#52a035cad83a80ca26fa53c09eb1241250c3df3e"
-  integrity sha512-Zo9vyI98QNeYT0K0y57Rb4JRWDaPEgmp+QkQ4CRQZFUTWetO5fvPZ4Gb/R7TW16LajuHZlbJBHmvmNj2pkL2kw==
+"@sentry/types@7.54.0":
+  version "7.54.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.54.0.tgz#bfee18107a78e290e6c8ad41646e2b9d9dd95234"
+  integrity sha512-D+i9xogBeawvQi2r0NOrM7zYcUaPuijeME4O9eOTrDF20tj71hWtJLilK+KTGLYFtpGg1h+9bPaz7OHEIyVopg==
 
-"@sentry/utils@7.50.0":
-  version "7.50.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.50.0.tgz#2b93a48024651436e95b7c8e2066aee7c2234d57"
-  integrity sha512-iyPwwC6fwJsiPhH27ZbIiSsY5RaccHBqADS2zEjgKYhmP4P9WGgHRDrvLEnkOjqQyKNb6c0yfmv83n0uxYnolw==
+"@sentry/utils@7.54.0":
+  version "7.54.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.54.0.tgz#a3acb5e25a1409cbca7b46d6356d7417a253ea9a"
+  integrity sha512-3Yf5KlKjIcYLddOexSt2ovu2TWlR4Fi7M+aCK8yUTzwNzf/xwFSWOstHlD/WiDy9HvfhWAOB/ukNTuAeJmtasw==
   dependencies:
-    "@sentry/types" "7.50.0"
+    "@sentry/types" "7.54.0"
     tslib "^1.9.3"
 
 "@sindresorhus/is@^4.0.0":


### PR DESCRIPTION
This required some manual changes due to `makeDsn` now returning undefined for invalid DSN 