### PR TITLE
ci: Use `setup-node` rather than `volta`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
           node-version-file: 'package.json'
       - name: Install
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
           node-version-file: 'package.json'
       - run: yarn install
@@ -58,7 +58,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
           node-version-file: 'package.json'
       - run: yarn install
@@ -78,7 +78,7 @@ jobs:
       ELECTRON_VERSION: ${{ matrix.electron }}
     steps:
       - uses: actions/checkout@v3
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
           node-version-file: 'package.json'
       - run: yarn install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: volta-cli/action@v3
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: 'package.json'
       - name: Install
         run: yarn install
       - name: Build
@@ -38,7 +40,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: volta-cli/action@v3
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: 'package.json'
       - run: yarn install
       - name: Run Linter
         run: yarn lint
@@ -54,7 +58,9 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3
-      - uses: volta-cli/action@v3
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: 'package.json'
       - run: yarn install
       - name: Run Unit Tests
         run: yarn test
@@ -72,7 +78,9 @@ jobs:
       ELECTRON_VERSION: ${{ matrix.electron }}
     steps:
       - uses: actions/checkout@v3
-      - uses: volta-cli/action@v3
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: 'package.json'
       - run: yarn install
       - name: Run E2E Tests
         run: yarn e2e

--- a/.github/workflows/new-electron-versions-pr.yml
+++ b/.github/workflows/new-electron-versions-pr.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
           node-version-file: 'package.json'
       - run: yarn install

--- a/.github/workflows/new-electron-versions-pr.yml
+++ b/.github/workflows/new-electron-versions-pr.yml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: volta-cli/action@v3
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: 'package.json'
       - run: yarn install
       - name: Update Versions
         run: yarn update-electron-versions

--- a/.github/workflows/new-sdk-versions-pr.yml
+++ b/.github/workflows/new-sdk-versions-pr.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
           node-version-file: 'package.json'
       - run: yarn install

--- a/.github/workflows/new-sdk-versions-pr.yml
+++ b/.github/workflows/new-sdk-versions-pr.yml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: volta-cli/action@v3
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: 'package.json'
       - run: yarn install
       - name: Update Versions
         run: yarn update-sdk-versions


### PR DESCRIPTION
As per [the JavaScript monorep](https://github.com/getsentry/sentry-javascript/pull/7763), the Volta cli action is unreliable and `setup-node` now supports using the volta version in package.json.