### PR TITLE
feat: Optionally send sessions when they're created

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,18 +58,18 @@
     "e2e": "cross-env TS_NODE_PROJECT=tsconfig.json xvfb-maybe mocha --require ts-node/register/transpile-only --retries 3 ./test/e2e/*.ts"
   },
   "dependencies": {
-    "@sentry/browser": "7.60.0",
-    "@sentry/core": "7.60.0",
-    "@sentry/node": "7.60.0",
-    "@sentry/types": "7.60.0",
-    "@sentry/utils": "7.60.0",
+    "@sentry/browser": "7.61.0",
+    "@sentry/core": "7.61.0",
+    "@sentry/node": "7.61.0",
+    "@sentry/types": "7.61.0",
+    "@sentry/utils": "7.61.0",
     "deepmerge": "4.3.0",
     "lru_map": "^0.3.3",
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@sentry-internal/eslint-config-sdk": "7.60.0",
-    "@sentry-internal/typescript": "7.60.0",
+    "@sentry-internal/eslint-config-sdk": "7.61.0",
+    "@sentry-internal/typescript": "7.61.0",
     "@types/busboy": "^0.2.3",
     "@types/chai": "^4.2.10",
     "@types/chai-as-promised": "^7.1.5",

--- a/src/main/integrations/main-process-session.ts
+++ b/src/main/integrations/main-process-session.ts
@@ -5,7 +5,11 @@ import { app } from 'electron';
 import { endSession, startSession } from '../sessions';
 
 interface Options {
-  /** Whether sessions should be sent immediately on creation */
+  /**
+   * Whether sessions should be sent immediately on creation
+   *
+   * @default false
+   */
   sendOnCreate?: boolean;
 }
 

--- a/src/main/integrations/main-process-session.ts
+++ b/src/main/integrations/main-process-session.ts
@@ -4,6 +4,11 @@ import { app } from 'electron';
 
 import { endSession, startSession } from '../sessions';
 
+interface Options {
+  /** Whether sessions should be sent immediately on creation */
+  sendOnCreate?: boolean;
+}
+
 /** Tracks sessions as the main process lifetime. */
 export class MainProcessSession implements Integration {
   /** @inheritDoc */
@@ -12,9 +17,11 @@ export class MainProcessSession implements Integration {
   /** @inheritDoc */
   public name: string = MainProcessSession.id;
 
+  public constructor(private readonly _options: Options = {}) {}
+
   /** @inheritDoc */
   public setupOnce(): void {
-    void startSession();
+    void startSession(!!this._options.sendOnCreate);
 
     // We track sessions via the 'will-quit' event which is the last event emitted before close.
     //

--- a/src/main/sessions.ts
+++ b/src/main/sessions.ts
@@ -17,9 +17,15 @@ let previousSession: Promise<Partial<Session> | undefined> | undefined = session
 let persistTimer: NodeJS.Timer | undefined;
 
 /** Starts a session */
-export async function startSession(): Promise<void> {
+export async function startSession(sendOnCreate: boolean): Promise<void> {
   const hub = getCurrentHub();
-  await sessionStore.set(hub.startSession());
+  const session = hub.startSession();
+
+  if (sendOnCreate) {
+    hub.captureSession();
+  }
+
+  await sessionStore.set(session);
 
   // Every PERSIST_INTERVAL, write the session to disk
   persistTimer = setInterval(async () => {

--- a/src/renderer/sdk.ts
+++ b/src/renderer/sdk.ts
@@ -22,7 +22,7 @@ export const defaultIntegrations = [...defaultBrowserIntegrations, new ScopeToMa
 export function init<O extends BrowserOptions>(
   options: BrowserOptions & O = {} as BrowserOptions & O,
   // This parameter name ensures that TypeScript error messages contain a hint for fixing SDK version mismatches
-  originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v7_60_0: O) => void = browserInit,
+  originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v7_61_0: O) => void = browserInit,
 ): void {
   ensureProcess('renderer');
 

--- a/test/e2e/test-apps/sessions/abnormal-exit-electron-uploader/session-1.json
+++ b/test/e2e/test-apps/sessions/abnormal-exit-electron-uploader/session-1.json
@@ -4,14 +4,15 @@
   "method": "envelope",
   "data": {
     "sid": "{{id}}",
-    "init": false,
+    "did": "some_user",
+    "init": true,
     "started": 0,
     "timestamp": 0,
     "status": "ok",
-    "errors": 1,
+    "errors": 0,
     "duration": 0,
     "attrs": {
-      "release": "error-session@1.0.0"
+      "release": "session-abnormal-exit-electron-uploader@1.0.0"
     }
   }
 }

--- a/test/e2e/test-apps/sessions/abnormal-exit-electron-uploader/session-2.json
+++ b/test/e2e/test-apps/sessions/abnormal-exit-electron-uploader/session-2.json
@@ -4,14 +4,15 @@
   "method": "envelope",
   "data": {
     "sid": "{{id}}",
-    "init": true,
+    "did": "some_user",
+    "init": false,
     "started": 0,
     "timestamp": 0,
-    "status": "crashed",
+    "status": "abnormal",
     "errors": 1,
     "duration": 0,
     "attrs": {
-      "release": "session-native-crash-renderer-electron-uploader@1.0.0"
+      "release": "session-abnormal-exit-electron-uploader@1.0.0"
     }
   }
 }

--- a/test/e2e/test-apps/sessions/abnormal-exit-electron-uploader/session-3.json
+++ b/test/e2e/test-apps/sessions/abnormal-exit-electron-uploader/session-3.json
@@ -4,14 +4,15 @@
   "method": "envelope",
   "data": {
     "sid": "{{id}}",
-    "init": false,
+    "did": "some_user",
+    "init": true,
     "started": 0,
     "timestamp": 0,
     "status": "ok",
-    "errors": 1,
+    "errors": 0,
     "duration": 0,
     "attrs": {
-      "release": "error-session@1.0.0"
+      "release": "session-abnormal-exit-electron-uploader@1.0.0"
     }
   }
 }

--- a/test/e2e/test-apps/sessions/abnormal-exit-electron-uploader/session-4.json
+++ b/test/e2e/test-apps/sessions/abnormal-exit-electron-uploader/session-4.json
@@ -4,14 +4,15 @@
   "method": "envelope",
   "data": {
     "sid": "{{id}}",
+    "did": "some_user",
     "init": false,
     "started": 0,
     "timestamp": 0,
-    "status": "ok",
-    "errors": 1,
+    "status": "exited",
+    "errors": 0,
     "duration": 0,
     "attrs": {
-      "release": "error-session@1.0.0"
+      "release": "session-abnormal-exit-electron-uploader@1.0.0"
     }
   }
 }

--- a/test/e2e/test-apps/sessions/abnormal-exit-electron-uploader/src/main.js
+++ b/test/e2e/test-apps/sessions/abnormal-exit-electron-uploader/src/main.js
@@ -8,7 +8,11 @@ app.commandLine.appendSwitch('enable-crashpad');
 init({
   dsn: '__DSN__',
   debug: true,
-  integrations: (defaults) => [new Integrations.ElectronMinidump(), ...defaults],
+  integrations: (defaults) => [
+    new Integrations.ElectronMinidump(),
+    new Integrations.MainProcessSession({ sendOnCreate: true }),
+    ...defaults,
+  ],
   initialScope: { user: { username: 'some_user' } },
   onFatalError: () => {},
 });

--- a/test/e2e/test-apps/sessions/abnormal-exit/session-1.json
+++ b/test/e2e/test-apps/sessions/abnormal-exit/session-1.json
@@ -7,7 +7,7 @@
     "init": true,
     "started": 0,
     "timestamp": 0,
-    "status": "exited",
+    "status": "ok",
     "errors": 0,
     "duration": 0,
     "attrs": {

--- a/test/e2e/test-apps/sessions/abnormal-exit/session-2.json
+++ b/test/e2e/test-apps/sessions/abnormal-exit/session-2.json
@@ -4,15 +4,14 @@
   "method": "envelope",
   "data": {
     "sid": "{{id}}",
-    "did": "some_user",
-    "init": true,
+    "init": false,
     "started": 0,
     "timestamp": 0,
-    "status": "exited",
-    "errors": 0,
+    "status": "abnormal",
+    "errors": 1,
     "duration": 0,
     "attrs": {
-      "release": "session-native-crash-main-electron-uploader@1.0.0"
+      "release": "session-abnormal-exit@1.0.0"
     }
   }
 }

--- a/test/e2e/test-apps/sessions/abnormal-exit/session-3.json
+++ b/test/e2e/test-apps/sessions/abnormal-exit/session-3.json
@@ -4,15 +4,14 @@
   "method": "envelope",
   "data": {
     "sid": "{{id}}",
-    "did": "some_user",
     "init": true,
     "started": 0,
     "timestamp": 0,
-    "status": "crashed",
-    "errors": 1,
+    "status": "ok",
+    "errors": 0,
     "duration": 0,
     "attrs": {
-      "release": "session-native-crash-main-electron-uploader@1.0.0"
+      "release": "session-abnormal-exit@1.0.0"
     }
   }
 }

--- a/test/e2e/test-apps/sessions/abnormal-exit/session-4.json
+++ b/test/e2e/test-apps/sessions/abnormal-exit/session-4.json
@@ -7,11 +7,11 @@
     "init": false,
     "started": 0,
     "timestamp": 0,
-    "status": "ok",
-    "errors": 1,
+    "status": "exited",
+    "errors": 0,
     "duration": 0,
     "attrs": {
-      "release": "error-session@1.0.0"
+      "release": "session-abnormal-exit@1.0.0"
     }
   }
 }

--- a/test/e2e/test-apps/sessions/abnormal-exit/src/main.js
+++ b/test/e2e/test-apps/sessions/abnormal-exit/src/main.js
@@ -1,11 +1,12 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init } = require('@sentry/electron');
+const { init, Integrations } = require('@sentry/electron');
 
 init({
   dsn: '__DSN__',
   debug: true,
+  integrations: [new Integrations.MainProcessSession({ sendOnCreate: true })],
   onFatalError: () => {},
 });
 

--- a/test/e2e/test-apps/sessions/good/session-first.json
+++ b/test/e2e/test-apps/sessions/good/session-first.json
@@ -4,14 +4,14 @@
   "method": "envelope",
   "data": {
     "sid": "{{id}}",
-    "init": false,
+    "init": true,
     "started": 0,
     "timestamp": 0,
     "status": "ok",
-    "errors": 1,
+    "errors": 0,
     "duration": 0,
     "attrs": {
-      "release": "error-session@1.0.0"
+      "release": "good-session@1.0.0"
     }
   }
 }

--- a/test/e2e/test-apps/sessions/good/session-fourth.json
+++ b/test/e2e/test-apps/sessions/good/session-fourth.json
@@ -7,11 +7,11 @@
     "init": false,
     "started": 0,
     "timestamp": 0,
-    "status": "ok",
-    "errors": 1,
+    "status": "exited",
+    "errors": 0,
     "duration": 0,
     "attrs": {
-      "release": "error-session@1.0.0"
+      "release": "good-session@1.0.0"
     }
   }
 }

--- a/test/e2e/test-apps/sessions/good/session-second.json
+++ b/test/e2e/test-apps/sessions/good/session-second.json
@@ -7,11 +7,11 @@
     "init": false,
     "started": 0,
     "timestamp": 0,
-    "status": "ok",
-    "errors": 1,
+    "status": "exited",
+    "errors": 0,
     "duration": 0,
     "attrs": {
-      "release": "error-session@1.0.0"
+      "release": "good-session@1.0.0"
     }
   }
 }

--- a/test/e2e/test-apps/sessions/good/session-third.json
+++ b/test/e2e/test-apps/sessions/good/session-third.json
@@ -4,14 +4,14 @@
   "method": "envelope",
   "data": {
     "sid": "{{id}}",
-    "init": false,
+    "init": true,
     "started": 0,
     "timestamp": 0,
     "status": "ok",
-    "errors": 1,
+    "errors": 0,
     "duration": 0,
     "attrs": {
-      "release": "error-session@1.0.0"
+      "release": "good-session@1.0.0"
     }
   }
 }

--- a/test/e2e/test-apps/sessions/good/src/main.js
+++ b/test/e2e/test-apps/sessions/good/src/main.js
@@ -1,11 +1,12 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init } = require('@sentry/electron');
+const { init, Integrations } = require('@sentry/electron');
 
 init({
   dsn: '__DSN__',
   debug: true,
+  integrations: [new Integrations.MainProcessSession({ sendOnCreate: true })],
   onFatalError: () => {},
 });
 

--- a/test/e2e/test-apps/sessions/javascript-error/session-start.json
+++ b/test/e2e/test-apps/sessions/javascript-error/session-start.json
@@ -7,11 +7,11 @@
     "init": true,
     "started": 0,
     "timestamp": 0,
-    "status": "abnormal",
-    "errors": 1,
+    "status": "ok",
+    "errors": 0,
     "duration": 0,
     "attrs": {
-      "release": "session-abnormal-exit@1.0.0"
+      "release": "error-session@1.0.0"
     }
   }
 }

--- a/test/e2e/test-apps/sessions/javascript-error/src/main.js
+++ b/test/e2e/test-apps/sessions/javascript-error/src/main.js
@@ -1,11 +1,12 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init } = require('@sentry/electron');
+const { init, Integrations } = require('@sentry/electron');
 
 init({
   dsn: '__DSN__',
   debug: true,
+  integrations: [new Integrations.MainProcessSession({ sendOnCreate: true })],
   onFatalError: () => {},
 });
 

--- a/test/e2e/test-apps/sessions/native-crash-main-electron-uploader/session-1.json
+++ b/test/e2e/test-apps/sessions/native-crash-main-electron-uploader/session-1.json
@@ -4,14 +4,15 @@
   "method": "envelope",
   "data": {
     "sid": "{{id}}",
+    "did": "some_user",
     "init": true,
     "started": 0,
     "timestamp": 0,
-    "status": "exited",
+    "status": "ok",
     "errors": 0,
     "duration": 0,
     "attrs": {
-      "release": "good-session@1.0.0"
+      "release": "session-native-crash-main-electron-uploader@1.0.0"
     }
   }
 }

--- a/test/e2e/test-apps/sessions/native-crash-main-electron-uploader/session-2.json
+++ b/test/e2e/test-apps/sessions/native-crash-main-electron-uploader/session-2.json
@@ -5,14 +5,14 @@
   "data": {
     "sid": "{{id}}",
     "did": "some_user",
-    "init": true,
+    "init": false,
     "started": 0,
     "timestamp": 0,
-    "status": "abnormal",
+    "status": "crashed",
     "errors": 1,
     "duration": 0,
     "attrs": {
-      "release": "session-abnormal-exit-electron-uploader@1.0.0"
+      "release": "session-native-crash-main-electron-uploader@1.0.0"
     }
   }
 }

--- a/test/e2e/test-apps/sessions/native-crash-main-electron-uploader/session-3.json
+++ b/test/e2e/test-apps/sessions/native-crash-main-electron-uploader/session-3.json
@@ -4,14 +4,15 @@
   "method": "envelope",
   "data": {
     "sid": "{{id}}",
+    "did": "some_user",
     "init": true,
     "started": 0,
     "timestamp": 0,
-    "status": "exited",
+    "status": "ok",
     "errors": 0,
     "duration": 0,
     "attrs": {
-      "release": "good-session@1.0.0"
+      "release": "session-native-crash-main-electron-uploader@1.0.0"
     }
   }
 }

--- a/test/e2e/test-apps/sessions/native-crash-main-electron-uploader/session-4.json
+++ b/test/e2e/test-apps/sessions/native-crash-main-electron-uploader/session-4.json
@@ -4,14 +4,15 @@
   "method": "envelope",
   "data": {
     "sid": "{{id}}",
+    "did": "some_user",
     "init": false,
     "started": 0,
     "timestamp": 0,
-    "status": "ok",
-    "errors": 1,
+    "status": "exited",
+    "errors": 0,
     "duration": 0,
     "attrs": {
-      "release": "error-session@1.0.0"
+      "release": "session-native-crash-main-electron-uploader@1.0.0"
     }
   }
 }

--- a/test/e2e/test-apps/sessions/native-crash-main-electron-uploader/src/main.js
+++ b/test/e2e/test-apps/sessions/native-crash-main-electron-uploader/src/main.js
@@ -8,7 +8,11 @@ app.commandLine.appendSwitch('enable-crashpad');
 init({
   dsn: '__DSN__',
   debug: true,
-  integrations: (defaults) => [new Integrations.ElectronMinidump(), ...defaults],
+  integrations: (defaults) => [
+    new Integrations.ElectronMinidump(),
+    new Integrations.MainProcessSession({ sendOnCreate: true }),
+    ...defaults,
+  ],
   initialScope: { user: { username: 'some_user' } },
   onFatalError: () => {},
 });

--- a/test/e2e/test-apps/sessions/native-crash-main/session-0.json
+++ b/test/e2e/test-apps/sessions/native-crash-main/session-0.json
@@ -4,14 +4,14 @@
   "method": "envelope",
   "data": {
     "sid": "{{id}}",
-    "init": false,
+    "init": true,
     "started": 0,
     "timestamp": 0,
     "status": "ok",
-    "errors": 1,
+    "errors": 0,
     "duration": 0,
     "attrs": {
-      "release": "error-session@1.0.0"
+      "release": "session-native-crash-main@1.0.0"
     }
   }
 }

--- a/test/e2e/test-apps/sessions/native-crash-main/session-1.json
+++ b/test/e2e/test-apps/sessions/native-crash-main/session-1.json
@@ -4,7 +4,7 @@
   "method": "envelope",
   "data": {
     "sid": "{{id}}",
-    "init": true,
+    "init": false,
     "started": 0,
     "timestamp": 0,
     "status": "crashed",

--- a/test/e2e/test-apps/sessions/native-crash-main/session-3.json
+++ b/test/e2e/test-apps/sessions/native-crash-main/session-3.json
@@ -7,7 +7,7 @@
     "init": false,
     "started": 0,
     "timestamp": 0,
-    "status": "exited",
+    "status": "ok",
     "errors": 0,
     "duration": 0,
     "attrs": {

--- a/test/e2e/test-apps/sessions/native-crash-main/session-4.json
+++ b/test/e2e/test-apps/sessions/native-crash-main/session-4.json
@@ -7,11 +7,11 @@
     "init": false,
     "started": 0,
     "timestamp": 0,
-    "status": "ok",
-    "errors": 1,
+    "status": "exited",
+    "errors": 0,
     "duration": 0,
     "attrs": {
-      "release": "error-session@1.0.0"
+      "release": "session-native-crash-main@1.0.0"
     }
   }
 }

--- a/test/e2e/test-apps/sessions/native-crash-main/src/main.js
+++ b/test/e2e/test-apps/sessions/native-crash-main/src/main.js
@@ -1,11 +1,12 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init } = require('@sentry/electron');
+const { init, Integrations } = require('@sentry/electron');
 
 init({
   dsn: '__DSN__',
   debug: true,
+  integrations: [new Integrations.MainProcessSession({ sendOnCreate: true })],
   onFatalError: () => {},
 });
 

--- a/test/e2e/test-apps/sessions/native-crash-renderer-electron-uploader/session-crash.json
+++ b/test/e2e/test-apps/sessions/native-crash-renderer-electron-uploader/session-crash.json
@@ -4,14 +4,14 @@
   "method": "envelope",
   "data": {
     "sid": "{{id}}",
-    "init": true,
+    "init": false,
     "started": 0,
     "timestamp": 0,
     "status": "crashed",
     "errors": 1,
     "duration": 0,
     "attrs": {
-      "release": "session-native-crash-renderer@1.0.0"
+      "release": "session-native-crash-renderer-electron-uploader@1.0.0"
     }
   }
 }

--- a/test/e2e/test-apps/sessions/native-crash-renderer-electron-uploader/session-start.json
+++ b/test/e2e/test-apps/sessions/native-crash-renderer-electron-uploader/session-start.json
@@ -4,14 +4,14 @@
   "method": "envelope",
   "data": {
     "sid": "{{id}}",
-    "init": false,
+    "init": true,
     "started": 0,
     "timestamp": 0,
     "status": "ok",
-    "errors": 1,
+    "errors": 0,
     "duration": 0,
     "attrs": {
-      "release": "error-session@1.0.0"
+      "release": "session-native-crash-renderer-electron-uploader@1.0.0"
     }
   }
 }

--- a/test/e2e/test-apps/sessions/native-crash-renderer-electron-uploader/src/main.js
+++ b/test/e2e/test-apps/sessions/native-crash-renderer-electron-uploader/src/main.js
@@ -8,7 +8,11 @@ app.commandLine.appendSwitch('enable-crashpad');
 init({
   dsn: '__DSN__',
   debug: true,
-  integrations: (defaults) => [new Integrations.ElectronMinidump(), ...defaults],
+  integrations: (defaults) => [
+    new Integrations.ElectronMinidump(),
+    new Integrations.MainProcessSession({ sendOnCreate: true }),
+    ...defaults,
+  ],
   initialScope: { user: { username: 'some_user' } },
   onFatalError: () => {},
 });

--- a/test/e2e/test-apps/sessions/native-crash-renderer/session-crash.json
+++ b/test/e2e/test-apps/sessions/native-crash-renderer/session-crash.json
@@ -7,11 +7,11 @@
     "init": false,
     "started": 0,
     "timestamp": 0,
-    "status": "ok",
+    "status": "crashed",
     "errors": 1,
     "duration": 0,
     "attrs": {
-      "release": "error-session@1.0.0"
+      "release": "session-native-crash-renderer@1.0.0"
     }
   }
 }

--- a/test/e2e/test-apps/sessions/native-crash-renderer/session-start.json
+++ b/test/e2e/test-apps/sessions/native-crash-renderer/session-start.json
@@ -4,15 +4,14 @@
   "method": "envelope",
   "data": {
     "sid": "{{id}}",
-    "did": "some_user",
     "init": true,
     "started": 0,
     "timestamp": 0,
-    "status": "exited",
+    "status": "ok",
     "errors": 0,
     "duration": 0,
     "attrs": {
-      "release": "session-abnormal-exit-electron-uploader@1.0.0"
+      "release": "session-native-crash-renderer@1.0.0"
     }
   }
 }

--- a/test/e2e/test-apps/sessions/native-crash-renderer/src/main.js
+++ b/test/e2e/test-apps/sessions/native-crash-renderer/src/main.js
@@ -1,11 +1,12 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init } = require('@sentry/electron');
+const { init, Integrations } = require('@sentry/electron');
 
 init({
   dsn: '__DSN__',
   debug: true,
+  integrations: [new Integrations.MainProcessSession({ sendOnCreate: true })],
   onFatalError: () => {},
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -135,13 +135,13 @@
     "@pnpm/network.ca-file" "^1.0.1"
     config-chain "^1.1.11"
 
-"@sentry-internal/eslint-config-sdk@7.60.0":
-  version "7.60.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.60.0.tgz#11ba3c4991807a4e203e0cee83465e465e168087"
-  integrity sha512-Zj6OxzBRllZYGoZL6Qassmrv1a+RIKWAolfG+2z26lx6A9+GHjZq66m4uKUJyHDlJ+p+iOj5xsHHwKYkki3e9g==
+"@sentry-internal/eslint-config-sdk@7.61.0":
+  version "7.61.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.61.0.tgz#ca4f48f2d441aa37d43304cce60ce0f2b4a4b0e7"
+  integrity sha512-ILhnFmHg/g6hRLs90kS27Gh5N1s8JVEgPGcWhotIew18NfGrdD+8KI1ZPExM8XKatwZxNHy3cOKYyxsFr4/Ydg==
   dependencies:
-    "@sentry-internal/eslint-plugin-sdk" "7.60.0"
-    "@sentry-internal/typescript" "7.60.0"
+    "@sentry-internal/eslint-plugin-sdk" "7.61.0"
+    "@sentry-internal/typescript" "7.61.0"
     "@typescript-eslint/eslint-plugin" "^5.48.0"
     "@typescript-eslint/parser" "^5.48.0"
     eslint-config-prettier "^6.11.0"
@@ -151,83 +151,83 @@
     eslint-plugin-jsdoc "^30.0.3"
     eslint-plugin-simple-import-sort "^5.0.3"
 
-"@sentry-internal/eslint-plugin-sdk@7.60.0":
-  version "7.60.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.60.0.tgz#bcf71a08ca2f0b785eb9f06b3ff1cffa593588a5"
-  integrity sha512-cOVTWuxG6mPZ+rv+NWre3b7PcEl0PqKGKecsp8hF9dsKH3lTFGSD1tccs7LWaM+COqCZBtFY53tB2/cXQxL90A==
+"@sentry-internal/eslint-plugin-sdk@7.61.0":
+  version "7.61.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.61.0.tgz#969f36b817b008c59892a4435969e16c167a1d4f"
+  integrity sha512-xc1V1vEEBQbox2S8VQDXHA0mNdNXeZ0lmSEYWfLd0z6VapQnvGuixNR+W+R4B0dfMr0lTAwV5UM3qTqGqKlDCQ==
   dependencies:
     requireindex "~1.1.0"
 
-"@sentry-internal/tracing@7.60.0":
-  version "7.60.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.60.0.tgz#4f101d936a45965b086e042a3fba7ec7683cc034"
-  integrity sha512-2qvxmR954H+K7u4o92sS2u+hntzshem9XwfHAqDvBe51arNbFVy8LfJTJ5fffgZq/6jXlozCO0/6aR5yLR5mBg==
+"@sentry-internal/tracing@7.61.0":
+  version "7.61.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.61.0.tgz#5a0dd4a9a0b41f2e22904430f3fe0216f36ee086"
+  integrity sha512-zTr+MXEG4SxNxif42LIgm2RQn+JRXL2NuGhRaKSD2i4lXKFqHVGlVdoWqY5UfqnnJPokiTWIj9ejR8I5HV8Ogw==
   dependencies:
-    "@sentry/core" "7.60.0"
-    "@sentry/types" "7.60.0"
-    "@sentry/utils" "7.60.0"
+    "@sentry/core" "7.61.0"
+    "@sentry/types" "7.61.0"
+    "@sentry/utils" "7.61.0"
     tslib "^2.4.1 || ^1.9.3"
 
-"@sentry-internal/typescript@7.60.0":
-  version "7.60.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.60.0.tgz#546e2ffe259d08e9855e9cb7ddc13b1f737ce539"
-  integrity sha512-KbZlYgwBK0FXknjNGAklohAJDlJ17Sjrj6rseUOmePaR58emUpf/6SvKQXENGdr4yYS9QM5nvdj3Jp2Nk3+Xag==
+"@sentry-internal/typescript@7.61.0":
+  version "7.61.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.61.0.tgz#44cea2d1cabc491549abcdce06ead7053abc08b6"
+  integrity sha512-Al5uvH/LTbGB2PJraO4kDKw5TyksOTOQHcvUgaWXXTB4Eb2df3op+8lTjARgwoSF/0eUpt428qKcPtfJL8n90w==
 
-"@sentry/browser@7.60.0":
-  version "7.60.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.60.0.tgz#feb49746c9b650a968cfa58fa8e6ae43448d7821"
-  integrity sha512-WznY6zrJxCUHZns8jTvDsZw3aaHriSP+jqD+wkXZG3ceooQwFn0RkAstUuoG7YyP4Foinznn3+caeQD4ZjWaXQ==
+"@sentry/browser@7.61.0":
+  version "7.61.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.61.0.tgz#04f4122e444d8b5ffefed97af3cde2bc1c71bb80"
+  integrity sha512-IGEkJZRP16Oe5CkXkmhU3QdV5RugW6Vds16yJFFYsgp87NprWtRZgqzldFDYkINStfBHVdctj/Rh/ZrLf8QlkQ==
   dependencies:
-    "@sentry-internal/tracing" "7.60.0"
-    "@sentry/core" "7.60.0"
-    "@sentry/replay" "7.60.0"
-    "@sentry/types" "7.60.0"
-    "@sentry/utils" "7.60.0"
+    "@sentry-internal/tracing" "7.61.0"
+    "@sentry/core" "7.61.0"
+    "@sentry/replay" "7.61.0"
+    "@sentry/types" "7.61.0"
+    "@sentry/utils" "7.61.0"
     tslib "^2.4.1 || ^1.9.3"
 
-"@sentry/core@7.60.0":
-  version "7.60.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.60.0.tgz#c256d1305b52210d608e71de8d8f365ca9377f15"
-  integrity sha512-B02OlFMoqdkfDZlbQfmk7tL2vObShofk7ySd/7mp+oRdUuCvX0tyrGlwI87YJvd8YWSZOCKINs3aVYivw/b6gg==
+"@sentry/core@7.61.0":
+  version "7.61.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.61.0.tgz#0de4f73055bd156c5c0cbac50bb814b272567188"
+  integrity sha512-zl0ZKRjIoYJQWYTd3K/U6zZfS4GDY9yGd2EH4vuYO4kfYtEp/nJ8A+tfAeDo0c9FGxZ0Q+5t5F4/SfwbgyyQzg==
   dependencies:
-    "@sentry/types" "7.60.0"
-    "@sentry/utils" "7.60.0"
+    "@sentry/types" "7.61.0"
+    "@sentry/utils" "7.61.0"
     tslib "^2.4.1 || ^1.9.3"
 
-"@sentry/node@7.60.0":
-  version "7.60.0"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.60.0.tgz#9db8fa0e71a4365b2a93a3504f2e48a38eeaae1b"
-  integrity sha512-I27gr7BSkdT1uwDPcbdPm7+w2yke5tojVGgothtvKfql1en4/cJZmk2bkvO2Di41+EF0UrTlUgLQff5X/q24WQ==
+"@sentry/node@7.61.0":
+  version "7.61.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.61.0.tgz#1309330f2ad136af532ad2a03b2a312e885705de"
+  integrity sha512-oTCqD/h92uvbRCrtCdiAqN6Mfe3vF7ywVHZ8Nq3hHmJp6XadUT+fCBwNQ7rjMyqJAOYAnx/vp6iN9n8C5qcYZQ==
   dependencies:
-    "@sentry-internal/tracing" "7.60.0"
-    "@sentry/core" "7.60.0"
-    "@sentry/types" "7.60.0"
-    "@sentry/utils" "7.60.0"
+    "@sentry-internal/tracing" "7.61.0"
+    "@sentry/core" "7.61.0"
+    "@sentry/types" "7.61.0"
+    "@sentry/utils" "7.61.0"
     cookie "^0.4.1"
     https-proxy-agent "^5.0.0"
     lru_map "^0.3.3"
     tslib "^2.4.1 || ^1.9.3"
 
-"@sentry/replay@7.60.0":
-  version "7.60.0"
-  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.60.0.tgz#9f59dfb8e7acff5b269ed8752a13c7b1d0f2bb75"
-  integrity sha512-iVSs+mhgjeK0qqLdCqbCa1P4I6hETHCUq14pTYp0bwGrI1D/a1Ho/6wLkwXv47Gnrwaba/7JFM+IxZcN4FzfmQ==
+"@sentry/replay@7.61.0":
+  version "7.61.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.61.0.tgz#f816d6a2fc7511877efee2e328681d659433d147"
+  integrity sha512-1ugk0yZssOPkSg6uTVcysjxlBydycXiOgV0PCU7DsXCFOV1ua5YpyPZFReTz9iFTtwD0LwGFM1LW9wJeQ67Fzg==
   dependencies:
-    "@sentry/core" "7.60.0"
-    "@sentry/types" "7.60.0"
-    "@sentry/utils" "7.60.0"
+    "@sentry/core" "7.61.0"
+    "@sentry/types" "7.61.0"
+    "@sentry/utils" "7.61.0"
 
-"@sentry/types@7.60.0":
-  version "7.60.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.60.0.tgz#e3e5f16436feff802b1b126a16dba537000cef55"
-  integrity sha512-MSEuF9YjE0j+UKdqee2AzcNlMnShVNTkCB2Wnng6Bc5hHhn4fyYeTLbuFpNxL0ffN65lxblaWx6doDsMcvRxcA==
+"@sentry/types@7.61.0":
+  version "7.61.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.61.0.tgz#4243b5ef4658f6b0673bc4372c90e6ec920f78d8"
+  integrity sha512-/GLlIBNR35NKPE/SfWi9W10dK9hE8qTShzsuPVn5wAJxpT3Lb4+dkwmKCTLUYxdkmvRDEudkfOxgalsfQGTAWA==
 
-"@sentry/utils@7.60.0":
-  version "7.60.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.60.0.tgz#a96d772dcc2d007f73a5bcf67dcc66f6a7085736"
-  integrity sha512-Oc/PQqzeNDOSy4ZzVj6h9U+GEGRkg2PEVn9PC2V9/v3HDD20mndFqR/S2B5OOgDb/6pNGyz8XiZYI5rb29WFHA==
+"@sentry/utils@7.61.0":
+  version "7.61.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.61.0.tgz#16944afb2b851af045fb528c0c35b7dea3e1cd3b"
+  integrity sha512-jfj14d0XBFiCU0G6dZZ12SizATiF5Mt4stBGzkM5iS9nXFj8rh1oTT7/p+aZoYzP2JTF+sDzkNjWxyKZkcTo0Q==
   dependencies:
-    "@sentry/types" "7.60.0"
+    "@sentry/types" "7.61.0"
     tslib "^2.4.1 || ^1.9.3"
 
 "@sindresorhus/is@^4.0.0":


### PR DESCRIPTION
Closes #713

This PR adds an option to the `MainProcessSession` integration that forces sessions to be send immediatly on creation. Apart from a few lines to add this option and call `hub.captureSession()` when enabled, the rest of the changes are to add all the additional session envelopes to the session e2e tests.

In the Electron main process:
```ts
import { init, Integrations } from '@sentry/electron';

init({
  dsn: '__DSN__',
  integrations: [new Integrations.MainProcessSession({ sendOnCreate: true })]
});
```