### PR TITLE
fix: Limit `BrowserWindowSession` to Electron >= v14

### DIFF
--- a/src/main/integrations/browser-window-session.ts
+++ b/src/main/integrations/browser-window-session.ts
@@ -19,7 +19,7 @@ type SessionState = { name: 'active' } | { name: 'inactive' } | { name: 'timeout
 /**
  * Tracks sessions as BrowserWindows focused.
  *
- * Supports Electron >= v12
+ * Supports Electron >= v14
  */
 export class BrowserWindowSession implements Integration {
   /** @inheritDoc */
@@ -31,8 +31,8 @@ export class BrowserWindowSession implements Integration {
   private _state: SessionState;
 
   public constructor(private readonly _options: Options = {}) {
-    if (ELECTRON_MAJOR_VERSION < 12) {
-      throw new Error('BrowserWindowSession requires Electron >= v12');
+    if (ELECTRON_MAJOR_VERSION < 14) {
+      throw new Error('BrowserWindowSession requires Electron >= v14');
     }
 
     this.name = BrowserWindowSession.id;

--- a/test/e2e/test-apps/sessions/window-bad/recipe.yml
+++ b/test/e2e/test-apps/sessions/window-bad/recipe.yml
@@ -1,4 +1,4 @@
 description: Bad Session - Window
 category: Sessions
 command: yarn
-condition: version.major >= 12
+condition: version.major >= 14

--- a/test/e2e/test-apps/sessions/window-good/recipe.yml
+++ b/test/e2e/test-apps/sessions/window-good/recipe.yml
@@ -1,4 +1,4 @@
 description: Good Session - Window
 category: Sessions
 command: yarn
-condition: version.major >= 12
+condition: version.major >= 14


### PR DESCRIPTION
Release builds are tested on every Electron version and they seem to suggest that the current code for `BrowserWindowSession` does not correctly detect focus for Electron 12 and 13. This PR changes the minimum supported Electron version to v14.