### PR TITLE
test: Don't test all Electron versions for releases

### DIFF
--- a/scripts/e2e-test-versions.js
+++ b/scripts/e2e-test-versions.js
@@ -2,10 +2,5 @@ const { readFileSync } = require('fs');
 
 const versions = JSON.parse(readFileSync('./test/e2e/versions.json', 'utf8'));
 
-if (process.env.GITHUB_REF && process.env.GITHUB_REF.includes('release/')) {
-  // For release builds we test all versions
-  console.log(JSON.stringify(versions));
-} else {
-  // Otherwise we test the oldest version and the last 10 versions
-  console.log(JSON.stringify([versions[0], ...versions.slice(-10)]));
-}
+// We test the oldest version and the last 10 versions
+console.log(JSON.stringify([versions[0], ...versions.slice(-10)]));


### PR DESCRIPTION
This PR changes it so we no longer test every version of Electron for release builds. v2 and the last 10 versions is more than enough.