### PR TITLE
fix: Flakey session e2e test on Windows

### DIFF
--- a/test/e2e/test-apps/sessions/abnormal-exit-electron-uploader/src/main.js
+++ b/test/e2e/test-apps/sessions/abnormal-exit-electron-uploader/src/main.js
@@ -34,7 +34,7 @@ app.on('ready', () => {
 if (process.env.APP_FIRST_RUN) {
   setTimeout(() => {
     process.exit();
-  }, 2000);
+  }, 4000);
 } else {
   setTimeout(() => {
     app.quit();

--- a/test/e2e/test-apps/sessions/abnormal-exit/src/main.js
+++ b/test/e2e/test-apps/sessions/abnormal-exit/src/main.js
@@ -27,7 +27,7 @@ app.on('ready', () => {
 if (process.env.APP_FIRST_RUN) {
   setTimeout(() => {
     process.exit();
-  }, 2000);
+  }, 4000);
 } else {
   setTimeout(() => {
     app.quit();


### PR DESCRIPTION
Looking at the test flakes, they don't occur on my local machine and it looks like in CI the initial `ok` session is not sent from the first instance before it closes. 

This PR extends the app runtime because the Windows VMs are super slow...