### PR TITLE
fix: Deprecate `EventToMain` integration

### DIFF
--- a/src/integrations.ts
+++ b/src/integrations.ts
@@ -31,6 +31,7 @@ export interface Integrations {
   Screenshots: Screenshots;
   // For renderer process
   ScopeToMain: ScopeToMain;
+  // eslint-disable-next-line deprecation/deprecation
   EventToMain: EventToMain;
 }
 

--- a/src/renderer/integrations/event-to-main.ts
+++ b/src/renderer/integrations/event-to-main.ts
@@ -4,6 +4,8 @@ import { normalize } from '@sentry/utils';
 import { getIPC } from '../ipc';
 
 /**
+ * @deprecated Events are now sent to the main process via a custom transport.
+ *
  * Passes events to the main process.
  */
 export class EventToMain implements Integration {
@@ -14,6 +16,7 @@ export class EventToMain implements Integration {
   public readonly name: string;
 
   public constructor() {
+    // eslint-disable-next-line deprecation/deprecation
     this.name = EventToMain.id;
   }
 

--- a/src/renderer/integrations/index.ts
+++ b/src/renderer/integrations/index.ts
@@ -1,2 +1,3 @@
 export { ScopeToMain } from './scope-to-main';
+// eslint-disable-next-line deprecation/deprecation
 export { EventToMain } from './event-to-main';


### PR DESCRIPTION
This integration hasn't been used since we started routing events from renderer to main via a custom transport.

It was left behind because it is exported and removing it would technically be a breaking change. It should be marked as deprecated so nobody uses it!