### PR TITLE
CI: Add CI job which can be used to block merging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,3 +84,15 @@ jobs:
       - run: yarn install
       - name: Run E2E Tests
         run: yarn e2e
+
+  required_jobs_passed:
+    name: All required jobs passed or were skipped
+    needs: [build, lint, test, e2e]
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1


### PR DESCRIPTION
This copies the Ci workflow of the Sentry JavaScript repository. 

It adds a final job that relies on all the other jobs and this can be set as a merge blocker in the GitHub Actions configuration.