### PR TITLE
feat: Identify `webContents` of renderers via custom protocol 

### DIFF
--- a/src/common/ipc.ts
+++ b/src/common/ipc.ts
@@ -2,7 +2,7 @@ export const PROTOCOL_SCHEME = 'sentry-ipc';
 
 export enum IPCChannel {
   /** IPC to check main process is listening */
-  PING = 'sentry-electron.ping',
+  RENDERER_START = 'sentry-electron.renderer-start',
   /** IPC to send a captured event to Sentry. */
   EVENT = 'sentry-electron.event',
   /** IPC to pass scope changes to main process. */
@@ -12,10 +12,13 @@ export enum IPCChannel {
 }
 
 export interface IPCInterface {
+  sendRendererStart: () => void;
   sendScope: (scope: string) => void;
   sendEvent: (event: string) => void;
   sendEnvelope: (evn: Uint8Array | string) => void;
 }
+
+export const RENDERER_ID_HEADER = 'sentry-electron-renderer-id';
 
 /**
  * We store the IPC interface on window so it's the same for both regular and isolated contexts
@@ -24,5 +27,6 @@ declare global {
   interface Window {
     __SENTRY_IPC__?: IPCInterface;
     __SENTRY__RENDERER_INIT__?: boolean;
+    __SENTRY_RENDERER_ID__?: string;
   }
 }

--- a/src/main/electron-normalize.ts
+++ b/src/main/electron-normalize.ts
@@ -2,6 +2,7 @@ import { parseSemver } from '@sentry/utils';
 import { app, BrowserWindow, crashReporter, NativeImage, WebContents } from 'electron';
 import { basename } from 'path';
 
+import { RENDERER_ID_HEADER } from '../common/ipc';
 import { Optional } from '../common/types';
 
 const parsed = parseSemver(process.versions.electron);
@@ -215,6 +216,7 @@ function supportsProtocolHandle(): boolean {
 }
 
 interface InternalRequest {
+  windowId?: string;
   url: string;
   body?: Buffer;
 }
@@ -232,6 +234,7 @@ export function registerProtocol(
   if (supportsProtocolHandle()) {
     protocol.handle(scheme, async (request) => {
       callback({
+        windowId: request.headers.get(RENDERER_ID_HEADER) || undefined,
         url: request.url,
         body: Buffer.from(await request.arrayBuffer()),
       });
@@ -242,6 +245,7 @@ export function registerProtocol(
     // eslint-disable-next-line deprecation/deprecation
     protocol.registerStringProtocol(scheme, (request, complete) => {
       callback({
+        windowId: request.headers[RENDERER_ID_HEADER],
         url: request.url,
         body: request.uploadData?.[0]?.bytes,
       });

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,12 +1,38 @@
 import { captureEvent, configureScope, getCurrentHub, Scope } from '@sentry/core';
 import { Attachment, AttachmentItem, Envelope, Event, EventItem } from '@sentry/types';
 import { forEachEnvelopeItem, logger, parseEnvelope, SentryError } from '@sentry/utils';
-import { app, ipcMain, protocol, WebContents } from 'electron';
+import { app, ipcMain, protocol, WebContents, webContents } from 'electron';
 import { TextDecoder, TextEncoder } from 'util';
 
 import { IPCChannel, IPCMode, mergeEvents, normalizeUrlsInReplayEnvelope, PROTOCOL_SCHEME } from '../common';
 import { registerProtocol, supportsFullProtocol, whenAppReady } from './electron-normalize';
 import { ElectronMainOptionsInternal } from './sdk';
+
+let KNOWN_RENDERERS: Set<number> | undefined;
+let WINDOW_ID_TO_WEB_CONTENTS: Map<string, number> | undefined;
+
+async function newProtocolRenderer(): Promise<void> {
+  KNOWN_RENDERERS = KNOWN_RENDERERS || new Set();
+  WINDOW_ID_TO_WEB_CONTENTS = WINDOW_ID_TO_WEB_CONTENTS || new Map();
+
+  for (const wc of webContents.getAllWebContents()) {
+    if (KNOWN_RENDERERS.has(wc.id)) {
+      continue;
+    }
+
+    const windowId: string | undefined = await wc.executeJavaScript('window.__SENTRY_RENDERER_ID__');
+
+    if (windowId) {
+      KNOWN_RENDERERS.add(wc.id);
+      WINDOW_ID_TO_WEB_CONTENTS.set(windowId, wc.id);
+
+      wc.once('destroyed', () => {
+        KNOWN_RENDERERS?.delete(wc.id);
+        WINDOW_ID_TO_WEB_CONTENTS?.delete(windowId);
+      });
+    }
+  }
+}
 
 function captureEventFromRenderer(
   options: ElectronMainOptionsInternal,
@@ -139,14 +165,20 @@ function configureProtocol(options: ElectronMainOptionsInternal): void {
     .then(() => {
       for (const sesh of options.getSessions()) {
         registerProtocol(sesh.protocol, PROTOCOL_SCHEME, (request) => {
-          const data = request.body;
+          const getWebContents = (): WebContents | undefined => {
+            const webContentsId = request.windowId ? WINDOW_ID_TO_WEB_CONTENTS?.get(request.windowId) : undefined;
+            return webContentsId ? webContents.fromId(webContentsId) : undefined;
+          };
 
-          if (request.url.startsWith(`${PROTOCOL_SCHEME}://${IPCChannel.EVENT}`) && data) {
-            handleEvent(options, data.toString());
+          const data = request.body;
+          if (request.url.startsWith(`${PROTOCOL_SCHEME}://${IPCChannel.RENDERER_START}`)) {
+            void newProtocolRenderer();
+          } else if (request.url.startsWith(`${PROTOCOL_SCHEME}://${IPCChannel.EVENT}`) && data) {
+            handleEvent(options, data.toString(), getWebContents());
           } else if (request.url.startsWith(`${PROTOCOL_SCHEME}://${IPCChannel.SCOPE}`) && data) {
             handleScope(options, data.toString());
           } else if (request.url.startsWith(`${PROTOCOL_SCHEME}://${IPCChannel.ENVELOPE}`) && data) {
-            handleEnvelope(options, data);
+            handleEnvelope(options, data, getWebContents());
           }
         });
       }
@@ -158,6 +190,15 @@ function configureProtocol(options: ElectronMainOptionsInternal): void {
  * Hooks IPC for communication with the renderer processes
  */
 function configureClassic(options: ElectronMainOptionsInternal): void {
+  ipcMain.on(IPCChannel.RENDERER_START, ({ sender }) => {
+    // Keep track of renderers that are using IPC
+    KNOWN_RENDERERS = KNOWN_RENDERERS || new Set();
+    KNOWN_RENDERERS.add(sender.id);
+
+    sender.once('destroyed', () => {
+      KNOWN_RENDERERS?.delete(sender.id);
+    });
+  });
   ipcMain.on(IPCChannel.EVENT, ({ sender }, jsonEvent: string) => handleEvent(options, jsonEvent, sender));
   ipcMain.on(IPCChannel.SCOPE, (_, jsonScope: string) => handleScope(options, jsonScope));
   ipcMain.on(IPCChannel.ENVELOPE, ({ sender }, env: Uint8Array | string) => handleEnvelope(options, env, sender));

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -22,16 +22,20 @@ async function newProtocolRenderer(): Promise<void> {
     }
 
     if (!wc.isDestroyed()) {
-      const windowId: string | undefined = await wc.executeJavaScript('window.__SENTRY_RENDERER_ID__');
+      try {
+        const windowId: string | undefined = await wc.executeJavaScript('window.__SENTRY_RENDERER_ID__');
 
-      if (windowId) {
-        KNOWN_RENDERERS.add(wcId);
-        WINDOW_ID_TO_WEB_CONTENTS.set(windowId, wcId);
+        if (windowId) {
+          KNOWN_RENDERERS.add(wcId);
+          WINDOW_ID_TO_WEB_CONTENTS.set(windowId, wcId);
 
-        wc.once('destroyed', () => {
-          KNOWN_RENDERERS?.delete(wcId);
-          WINDOW_ID_TO_WEB_CONTENTS?.delete(windowId);
-        });
+          wc.once('destroyed', () => {
+            KNOWN_RENDERERS?.delete(wcId);
+            WINDOW_ID_TO_WEB_CONTENTS?.delete(windowId);
+          });
+        }
+      } catch (_) {
+        // ignore
       }
     }
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -14,6 +14,7 @@ if (window.__SENTRY_IPC__) {
   console.log('Sentry Electron preload has already been run');
 } else {
   const ipcObject = {
+    sendRendererStart: () => ipcRenderer.send(IPCChannel.RENDERER_START),
     sendScope: (scopeJson: string) => ipcRenderer.send(IPCChannel.SCOPE, scopeJson),
     sendEvent: (eventJson: string) => ipcRenderer.send(IPCChannel.EVENT, eventJson),
     sendEnvelope: (envelope: Uint8Array | string) => ipcRenderer.send(IPCChannel.ENVELOPE, envelope),

--- a/src/preload/legacy.ts
+++ b/src/preload/legacy.ts
@@ -25,6 +25,7 @@ if (window.__SENTRY_IPC__) {
   });
 
   const ipcObject = {
+    sendRendererStart: () => ipcRenderer.send(IPCChannel.RENDERER_START),
     sendScope: (scopeJson: string) => ipcRenderer.send(IPCChannel.SCOPE, scopeJson),
     sendEvent: (eventJson: string) => ipcRenderer.send(IPCChannel.EVENT, eventJson),
     sendEnvelope: (envelope: Uint8Array | string) => ipcRenderer.send(IPCChannel.ENVELOPE, envelope),

--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -1,44 +1,54 @@
 /* eslint-disable no-restricted-globals */
 /* eslint-disable no-console */
-import { logger } from '@sentry/utils';
+import { logger, uuid4 } from '@sentry/utils';
 
-import { IPCChannel, IPCInterface, PROTOCOL_SCHEME } from '../common';
+import { IPCChannel, IPCInterface, PROTOCOL_SCHEME, RENDERER_ID_HEADER } from '../common/ipc';
+
+function buildUrl(channel: IPCChannel): string {
+  // We include sentry_key in the URL so these don't end up in fetch breadcrumbs
+  // https://github.com/getsentry/sentry-javascript/blob/a3f70d8869121183bec037571a3ee78efaf26b0b/packages/browser/src/integrations/breadcrumbs.ts#L240
+  return `${PROTOCOL_SCHEME}://${channel}/sentry_key`;
+}
 
 /** Gets the available IPC implementation */
 function getImplementation(): IPCInterface {
   // Favour IPC if it's been exposed by a preload script
   if (window.__SENTRY_IPC__) {
     return window.__SENTRY_IPC__;
+  } else {
+    logger.log('IPC was not configured in preload script, falling back to custom protocol and fetch');
+
+    // A unique ID used to identify this renderer and is send in the headers of every request
+    // Because it added as a global, this can be fetched from the main process via executeJavaScript
+    const id = (window.__SENTRY_RENDERER_ID__ = uuid4());
+    const headers: Record<string, string> = { [RENDERER_ID_HEADER]: id };
+
+    return {
+      sendRendererStart: () => {
+        fetch(buildUrl(IPCChannel.RENDERER_START), { method: 'POST', body: '', headers }).catch(() => {
+          console.error(`Sentry SDK failed to establish connection with the Electron main process.
+  - Ensure you have initialized the SDK in the main process
+  - If your renderers use custom sessions, be sure to set 'getSessions' in the main process options
+  - If you are bundling your main process code and using Electron < v5, you'll need to manually configure a preload script`);
+        });
+      },
+      sendScope: (body: string) => {
+        fetch(buildUrl(IPCChannel.SCOPE), { method: 'POST', body, headers }).catch(() => {
+          // ignore
+        });
+      },
+      sendEvent: (body: string) => {
+        fetch(buildUrl(IPCChannel.EVENT), { method: 'POST', body, headers }).catch(() => {
+          // ignore
+        });
+      },
+      sendEnvelope: (body: string | Uint8Array) => {
+        fetch(buildUrl(IPCChannel.ENVELOPE), { method: 'POST', body, headers }).catch(() => {
+          // ignore
+        });
+      },
+    };
   }
-
-  logger.log('IPC was not configured in preload script, falling back to custom protocol and fetch');
-
-  fetch(`${PROTOCOL_SCHEME}://${IPCChannel.PING}/sentry_key`, { method: 'POST', body: '' }).catch(() =>
-    console.error(`Sentry SDK failed to establish connection with the Electron main process.
- - Ensure you have initialized the SDK in the main process
- - If your renderers use custom sessions, be sure to set 'getSessions' in the main process options
- - If you are bundling your main process code and using Electron < v5, you'll need to manually configure a preload script`),
-  );
-
-  // We include sentry_key in the URL so these dont end up in fetch breadcrumbs
-  // https://github.com/getsentry/sentry-javascript/blob/a3f70d8869121183bec037571a3ee78efaf26b0b/packages/browser/src/integrations/breadcrumbs.ts#L240
-  return {
-    sendScope: (body) => {
-      fetch(`${PROTOCOL_SCHEME}://${IPCChannel.SCOPE}/sentry_key`, { method: 'POST', body }).catch(() => {
-        // ignore
-      });
-    },
-    sendEvent: (body) => {
-      fetch(`${PROTOCOL_SCHEME}://${IPCChannel.EVENT}/sentry_key`, { method: 'POST', body }).catch(() => {
-        // ignore
-      });
-    },
-    sendEnvelope: (body) => {
-      fetch(`${PROTOCOL_SCHEME}://${IPCChannel.ENVELOPE}/sentry_key`, { method: 'POST', body }).catch(() => {
-        // ignore
-      });
-    },
-  };
 }
 
 let cachedInterface: IPCInterface | undefined;
@@ -52,6 +62,7 @@ let cachedInterface: IPCInterface | undefined;
 export function getIPC(): IPCInterface {
   if (!cachedInterface) {
     cachedInterface = getImplementation();
+    cachedInterface.sendRendererStart();
   }
 
   return cachedInterface;

--- a/test/e2e/test-apps/other/custom-renderer-name-protocol/event.json
+++ b/test/e2e/test-apps/other/custom-renderer-name-protocol/event.json
@@ -1,0 +1,106 @@
+{
+  "method": "envelope",
+  "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
+  "appId": "277345",
+  "data": {
+    "sdk": {
+      "name": "sentry.javascript.electron",
+      "packages": [
+        {
+          "name": "npm:@sentry/electron",
+          "version": "{{version}}"
+        }
+      ],
+      "version": "{{version}}"
+    },
+    "contexts": {
+      "app": {
+        "app_name": "custom-renderer-name-protocol",
+        "app_version": "1.0.0",
+        "app_start_time": "{{time}}"
+      },
+      "browser": {
+        "name": "Chrome"
+      },
+      "chrome": {
+        "name": "Chrome",
+        "type": "runtime",
+        "version": "{{version}}"
+      },
+      "device": {
+        "arch": "{{arch}}",
+        "family": "Desktop",
+        "memory_size": 0,
+        "free_memory": 0,
+        "processor_count": 0,
+        "processor_frequency": 0,
+        "cpu_description": "{{cpu}}",
+        "screen_resolution":"{{screen}}",
+        "screen_density": 1,
+        "language": "{{language}}"
+      },
+      "node": {
+        "name": "Node",
+        "type": "runtime",
+        "version": "{{version}}"
+      },
+      "os": {
+        "name": "{{platform}}",
+        "version": "{{version}}"
+      },
+      "runtime": {
+        "name": "Electron",
+        "version": "{{version}}"
+      }
+    },
+    "release": "custom-renderer-name-protocol@1.0.0",
+    "environment": "development",
+    "user": {
+      "ip_address": "{{auto}}"
+    },
+    "exception": {
+      "values": [
+        {
+          "type": "Error",
+          "value": "Some renderer error",
+          "stacktrace": {
+            "frames": [
+              {
+                "colno": 0,
+                "filename": "app:///src/index.html",
+                "function": "{{function}}",
+                "in_app": true,
+                "lineno": 0
+              }
+            ]
+          },
+          "mechanism": {
+            "handled": false,
+            "type": "instrument"
+          }
+        }
+      ]
+    },
+    "level": "error",
+    "event_id": "{{id}}",
+    "platform": "javascript",
+    "timestamp": 0,
+    "breadcrumbs": [
+      {
+        "timestamp": 0,
+        "category": "electron",
+        "message": "SomeWindow.dom-ready",
+        "type": "ui"
+      }
+    ],
+    "request": {
+      "url": "app:///src/index.html"
+    },
+    "tags": {
+      "event.environment": "javascript",
+      "event.origin": "electron",
+      "event.process": "SomeWindow",
+      "event_type": "javascript"
+    }
+  }
+}

--- a/test/e2e/test-apps/other/custom-renderer-name-protocol/package.json
+++ b/test/e2e/test-apps/other/custom-renderer-name-protocol/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "custom-renderer-name-protocol",
+  "version": "1.0.0",
+  "main": "src/main.js",
+  "dependencies": {
+    "@sentry/electron": "3.0.0"
+  }
+}

--- a/test/e2e/test-apps/other/custom-renderer-name-protocol/recipe.yml
+++ b/test/e2e/test-apps/other/custom-renderer-name-protocol/recipe.yml
@@ -1,0 +1,3 @@
+description: Custom Renderer Name via Protocol
+command: yarn
+condition: version.major >= 5

--- a/test/e2e/test-apps/other/custom-renderer-name-protocol/src/index.html
+++ b/test/e2e/test-apps/other/custom-renderer-name-protocol/src/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <script>
+      const { init } = require('@sentry/electron');
+
+      init({
+        debug: true,
+      });
+
+      setTimeout(() => {
+        throw new Error('Some renderer error');
+      }, 500);
+    </script>
+  </body>
+</html>

--- a/test/e2e/test-apps/other/custom-renderer-name-protocol/src/main.js
+++ b/test/e2e/test-apps/other/custom-renderer-name-protocol/src/main.js
@@ -1,0 +1,27 @@
+const path = require('path');
+
+const { app, BrowserWindow } = require('electron');
+const { init, IPCMode } = require('@sentry/electron');
+
+init({
+  dsn: '__DSN__',
+  debug: true,
+  autoSessionTracking: false,
+  ipcMode: IPCMode.Protocol,
+  onFatalError: () => {},
+  getRendererName(_) {
+    return 'SomeWindow';
+  },
+});
+
+app.on('ready', () => {
+  const mainWindow = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+
+  mainWindow.loadFile(path.join(__dirname, 'index.html'));
+});


### PR DESCRIPTION
The Electron SDK supports two ways for the renderers to send envelopes and scope to the main process.

- Electron IPC - Preferred but requires a preload script which we attempt to inject automatically but this fails when bundling the main process code
- Custom protocol + fetch - No setup required but Electron does not give us a way to determine which renderer the event came from (https://github.com/electron/electron/issues/31718)

This has meant custom protocol has not supported all the same context as Electron IPC because we're missing the reference to the `webContents`.

This is a problem for renderer ANR detection. We should be able to use the Electron [debugger](https://www.electronjs.org/docs/latest/api/debugger#debuggerattachprotocolversion) API to capture stack traces but once a renderer stops sending us mesages, we need to know which `webContents` to attach to! 

This PR adds a means for us to identify renderers over a custom protocol:
- In protocol mode, `window.__SENTRY_RENDERER_ID__` is set to a uuid
- When a renderer starts up and pings the main proces via the custom protocol, we use `executeJavaScript` to fetch the id and save the mapping between id and `webContents`
- When the renderer sends events/envelopes/scope and later ANR messages, the id is included in the headers
- In the main process, we can use the id in the headers to determine which `webContents` the message came from