### PR TITLE
feat: Update JavaScript SDKs to 7.76.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,20 +55,19 @@
     "e2e": "cross-env TS_NODE_PROJECT=tsconfig.test.json xvfb-maybe mocha --require ts-node/register/transpile-only --retries 3 ./test/e2e/*.ts"
   },
   "dependencies": {
-    "@sentry/browser": "7.74.1",
-    "@sentry/core": "7.74.1",
-    "@sentry/node": "7.74.1",
-    "@sentry/types": "7.74.1",
-    "@sentry/utils": "7.74.1",
+    "@sentry/browser": "7.76.0",
+    "@sentry/core": "7.76.0",
+    "@sentry/node": "7.76.0",
+    "@sentry/types": "7.76.0",
+    "@sentry/utils": "7.76.0",
     "deepmerge": "4.3.0",
-    "lru_map": "^0.3.3",
     "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.2.1",
     "@rollup/plugin-typescript": "^11.1.4",
-    "@sentry-internal/eslint-config-sdk": "7.74.1",
-    "@sentry-internal/typescript": "7.74.1",
+    "@sentry-internal/eslint-config-sdk": "7.76.0",
+    "@sentry-internal/typescript": "7.76.0",
     "@types/busboy": "^0.2.3",
     "@types/chai": "^4.2.10",
     "@types/chai-as-promised": "^7.1.5",

--- a/package.json
+++ b/package.json
@@ -55,11 +55,11 @@
     "e2e": "cross-env TS_NODE_PROJECT=tsconfig.test.json xvfb-maybe mocha --require ts-node/register/transpile-only --retries 3 ./test/e2e/*.ts"
   },
   "dependencies": {
-    "@sentry/browser": "7.74.0",
-    "@sentry/core": "7.74.0",
-    "@sentry/node": "7.74.0",
-    "@sentry/types": "7.74.0",
-    "@sentry/utils": "7.74.0",
+    "@sentry/browser": "7.74.1",
+    "@sentry/core": "7.74.1",
+    "@sentry/node": "7.74.1",
+    "@sentry/types": "7.74.1",
+    "@sentry/utils": "7.74.1",
     "deepmerge": "4.3.0",
     "lru_map": "^0.3.3",
     "tslib": "^2.5.0"
@@ -67,8 +67,8 @@
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.2.1",
     "@rollup/plugin-typescript": "^11.1.4",
-    "@sentry-internal/eslint-config-sdk": "7.74.0",
-    "@sentry-internal/typescript": "7.74.0",
+    "@sentry-internal/eslint-config-sdk": "7.74.1",
+    "@sentry-internal/typescript": "7.74.1",
     "@types/busboy": "^0.2.3",
     "@types/chai": "^4.2.10",
     "@types/chai-as-promised": "^7.1.5",

--- a/src/main/anr.ts
+++ b/src/main/anr.ts
@@ -12,6 +12,7 @@ import { app, WebContents } from 'electron';
 import { RendererStatus } from '../common';
 import { ELECTRON_MAJOR_VERSION } from './electron-normalize';
 import { ElectronMainOptions } from './sdk';
+import { sessionAnr } from './sessions';
 
 function getRendererName(contents: WebContents): string | undefined {
   const options = getCurrentHub().getClient()?.getOptions() as ElectronMainOptions | undefined;
@@ -19,6 +20,8 @@ function getRendererName(contents: WebContents): string | undefined {
 }
 
 function sendRendererAnrEvent(contents: WebContents, blockedMs: number, frames?: StackFrame[]): void {
+  sessionAnr();
+
   const rendererName = getRendererName(contents) || 'renderer';
 
   const event: Event = {
@@ -79,6 +82,11 @@ function createHrTimer(): { getTimeMs: () => number; reset: () => void } {
       lastPoll = process.hrtime();
     },
   };
+}
+
+/** Are we currently running in the ANR child process */
+export function isAnrChildProcess(): boolean {
+  return !!process.env.SENTRY_ANR_CHILD_PROCESS;
 }
 
 /** Creates a renderer ANR status hook */

--- a/src/main/integrations/net-breadcrumbs.ts
+++ b/src/main/integrations/net-breadcrumbs.ts
@@ -7,10 +7,10 @@ import {
   fill,
   generateSentryTraceHeader,
   logger,
+  LRUMap,
   stringMatchesSomePattern,
 } from '@sentry/utils';
 import { ClientRequest, ClientRequestConstructorOptions, IncomingMessage, net } from 'electron';
-import { LRUMap } from 'lru_map';
 import * as urlModule from 'url';
 
 type ShouldTraceFn = (method: string, url: string) => boolean;

--- a/src/main/sdk.ts
+++ b/src/main/sdk.ts
@@ -5,6 +5,7 @@ import { defaultIntegrations as defaultNodeIntegrations, init as nodeInit, NodeO
 import { Integration, Options } from '@sentry/types';
 import { app, Session, session, WebContents } from 'electron';
 
+import { isAnrChildProcess } from './anr';
 import { getDefaultEnvironment, getDefaultReleaseName } from './context';
 import {
   AdditionalContext,
@@ -96,7 +97,7 @@ export function init(userOptions: ElectronMainOptions): void {
   const options: ElectronMainOptionsInternal = Object.assign(defaultOptions, userOptions);
   const defaults = defaultIntegrations;
 
-  if (process.env.SENTRY_ANR_CHILD_PROCESS) {
+  if (isAnrChildProcess()) {
     app.dock?.hide();
     options.autoSessionTracking = false;
     options.tracesSampleRate = 0;

--- a/src/renderer/sdk.ts
+++ b/src/renderer/sdk.ts
@@ -40,7 +40,7 @@ interface ElectronRendererOptions extends BrowserOptions {
 export function init<O extends ElectronRendererOptions>(
   options: ElectronRendererOptions & O = {} as ElectronRendererOptions & O,
   // This parameter name ensures that TypeScript error messages contain a hint for fixing SDK version mismatches
-  originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v7_74_1: O) => void = browserInit,
+  originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v7_76_0: O) => void = browserInit,
 ): void {
   ensureProcess('renderer');
 

--- a/src/renderer/sdk.ts
+++ b/src/renderer/sdk.ts
@@ -40,7 +40,7 @@ interface ElectronRendererOptions extends BrowserOptions {
 export function init<O extends ElectronRendererOptions>(
   options: ElectronRendererOptions & O = {} as ElectronRendererOptions & O,
   // This parameter name ensures that TypeScript error messages contain a hint for fixing SDK version mismatches
-  originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v7_74_0: O) => void = browserInit,
+  originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v7_74_1: O) => void = browserInit,
 ): void {
   ensureProcess('renderer');
 

--- a/test/e2e/test-apps/anr/anr-main/session.json
+++ b/test/e2e/test-apps/anr/anr-main/session.json
@@ -1,0 +1,18 @@
+{
+  "appId": "277345",
+  "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
+  "method": "envelope",
+  "data": {
+    "sid": "{{id}}",
+    "init": true,
+    "started": 0,
+    "timestamp": 0,
+    "status": "abnormal",
+    "abnormal_mechanism": "anr_foreground",
+    "errors": 0,
+    "duration": 0,
+    "attrs": {
+      "release": "anr-main@1.0.0"
+    }
+  }
+}

--- a/test/e2e/test-apps/anr/anr-main/src/main.js
+++ b/test/e2e/test-apps/anr/anr-main/src/main.js
@@ -6,7 +6,6 @@ const { init, enableMainProcessAnrDetection } = require('@sentry/electron/main')
 init({
   dsn: '__DSN__',
   debug: true,
-  autoSessionTracking: false,
   onFatalError: () => {},
 });
 

--- a/test/e2e/test-apps/anr/anr-renderer/session.json
+++ b/test/e2e/test-apps/anr/anr-renderer/session.json
@@ -1,0 +1,18 @@
+{
+  "appId": "277345",
+  "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
+  "method": "envelope",
+  "data": {
+    "sid": "{{id}}",
+    "init": true,
+    "started": 0,
+    "timestamp": 0,
+    "status": "abnormal",
+    "abnormal_mechanism": "anr_foreground",
+    "errors": 0,
+    "duration": 0,
+    "attrs": {
+      "release": "anr-renderer@1.0.0"
+    }
+  }
+}

--- a/test/e2e/test-apps/anr/anr-renderer/src/main.js
+++ b/test/e2e/test-apps/anr/anr-renderer/src/main.js
@@ -6,7 +6,6 @@ const { init } = require('@sentry/electron/main');
 init({
   dsn: '__DSN__',
   debug: true,
-  autoSessionTracking: false,
   onFatalError: () => {},
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -164,13 +164,13 @@
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
 
-"@sentry-internal/eslint-config-sdk@7.74.0":
-  version "7.74.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.74.0.tgz#dade78c180cad8aaeb1e239bc5451b15b8a3a7c0"
-  integrity sha512-ornnUt2BOD/5R5nzKgoExACrLFPfp04cyC2hcGa6U3DPvYb4aQsO2A3xeftsGZRiQ0OfAACvtajIKNkn61nppQ==
+"@sentry-internal/eslint-config-sdk@7.74.1":
+  version "7.74.1"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.74.1.tgz#a0085872c99a52a95b6d3986474ccd72c15c32f1"
+  integrity sha512-zUIKv8pnwbGy0UiAh20QameYdWZwd7NaIAMrGybc2UpVDwBvQb3qv+oZFfKHOYf98wq3OMwGlkw363TkrNrnCA==
   dependencies:
-    "@sentry-internal/eslint-plugin-sdk" "7.74.0"
-    "@sentry-internal/typescript" "7.74.0"
+    "@sentry-internal/eslint-plugin-sdk" "7.74.1"
+    "@sentry-internal/typescript" "7.74.1"
     "@typescript-eslint/eslint-plugin" "^5.48.0"
     "@typescript-eslint/parser" "^5.48.0"
     eslint-config-prettier "^6.11.0"
@@ -180,83 +180,83 @@
     eslint-plugin-jsdoc "^30.0.3"
     eslint-plugin-simple-import-sort "^5.0.3"
 
-"@sentry-internal/eslint-plugin-sdk@7.74.0":
-  version "7.74.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.74.0.tgz#4ceecc6e84ed2a8e07c41d5f52b15188ce251908"
-  integrity sha512-j0rTZKn4Mj0ywOIco8SxfI2f0xXo0O7dWlw8jfuPrYtn3BBtJc0/7lilz1ZwYTYKDAbDuhxKITaVP1V1R0ADDg==
+"@sentry-internal/eslint-plugin-sdk@7.74.1":
+  version "7.74.1"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.74.1.tgz#05a905d4a05b976b4d97b4f5ae40d5680a45c17f"
+  integrity sha512-NGtD2n6VpUwxbakqvaUC/3rH3Y/GQW21eZ8poXSPyOxl/Mq9BkYnS7QvcX+wU4yuIvgMpXLwmZX8PNBMiT6lLw==
   dependencies:
     requireindex "~1.1.0"
 
-"@sentry-internal/tracing@7.74.0":
-  version "7.74.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.74.0.tgz#11b0762d0b18b01cc18dfb1e40bbaa41c6f97452"
-  integrity sha512-JK6IRGgdtZjswGfaGIHNWIThffhOHzVIIaGmglui+VFIzOsOqePjoxaDV0MEvzafxXZD7eWqGE5RGuZ0n6HFVg==
+"@sentry-internal/tracing@7.74.1":
+  version "7.74.1"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.74.1.tgz#55ff387e61d2c9533a9a0d099d376332426c8e08"
+  integrity sha512-nNaiZreQxCitG2PzYPaC7XtyA9OMsETGYMKAtiK4p62/uTmeYbsBva9BoNx1XeiHRwbrVQYRMKQ9nV5e2jS4/A==
   dependencies:
-    "@sentry/core" "7.74.0"
-    "@sentry/types" "7.74.0"
-    "@sentry/utils" "7.74.0"
+    "@sentry/core" "7.74.1"
+    "@sentry/types" "7.74.1"
+    "@sentry/utils" "7.74.1"
     tslib "^2.4.1 || ^1.9.3"
 
-"@sentry-internal/typescript@7.74.0":
-  version "7.74.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.74.0.tgz#2dec70a1eec2684c8fc7abdc6b3ba03944c059c3"
-  integrity sha512-Xq71bUhZ2GIT76VfhNyJb9k5lmSDVFuaj9uy8PZ0W1DkY0fE4FEx2xWQUXuYy7M5+2QAHesGjCzHxZO2cx1HAQ==
+"@sentry-internal/typescript@7.74.1":
+  version "7.74.1"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.74.1.tgz#1635bf13b97ff53c7eca149222dede778f798965"
+  integrity sha512-6598R51owTJyfZcDRlh0gTYAh6n9d9FKCWvy3zNHjQsGl8hK1Co2bm9iznN5MWeD19mspapMS4X+SFfl4BNWIg==
 
-"@sentry/browser@7.74.0":
-  version "7.74.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.74.0.tgz#4a01bccb34059894007b9a22a89892f2c4dff130"
-  integrity sha512-Njr8216Z1dFUcl6NqBOk20dssK9SjoVddY74Xq+Q4p3NfXBG3lkMcACXor7SFoJRZXq8CZWGS13Cc5KwViRw4g==
+"@sentry/browser@7.74.1":
+  version "7.74.1"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.74.1.tgz#9302d440bbdcb018abd5fee5959dab4b2fe97383"
+  integrity sha512-OYWNne/KO60lOvkIpIlJUyiJt/9j8DGI57thSDFEYSmmbNqMitczUTBOaEStouvHKyfchqLZm1CZfWKt+z0VOA==
   dependencies:
-    "@sentry-internal/tracing" "7.74.0"
-    "@sentry/core" "7.74.0"
-    "@sentry/replay" "7.74.0"
-    "@sentry/types" "7.74.0"
-    "@sentry/utils" "7.74.0"
+    "@sentry-internal/tracing" "7.74.1"
+    "@sentry/core" "7.74.1"
+    "@sentry/replay" "7.74.1"
+    "@sentry/types" "7.74.1"
+    "@sentry/utils" "7.74.1"
     tslib "^2.4.1 || ^1.9.3"
 
-"@sentry/core@7.74.0":
-  version "7.74.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.74.0.tgz#2cfcb5133a4a3f82fbac09d3573ea9f508fb7c67"
-  integrity sha512-83NRuqn7nDZkSVBN5yJQqcpXDG4yMYiB7TkYUKrGTzBpRy6KUOrkCdybuKk0oraTIGiGSe5WEwCFySiNgR9FzA==
+"@sentry/core@7.74.1":
+  version "7.74.1"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.74.1.tgz#9e33cf59b754a994e4054c47c74df1d3fbd30d3c"
+  integrity sha512-LvEhOSfdIvwkr+PdlrT/aA/iOLhkXrSkvjqAQyogE4ddCWeYfS0NoirxNt1EaxMBAWKhYZRqzkA7WA4LDLbzlA==
   dependencies:
-    "@sentry/types" "7.74.0"
-    "@sentry/utils" "7.74.0"
+    "@sentry/types" "7.74.1"
+    "@sentry/utils" "7.74.1"
     tslib "^2.4.1 || ^1.9.3"
 
-"@sentry/node@7.74.0":
-  version "7.74.0"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.74.0.tgz#c6b6704a3a238155f047972fd4c6944004347aba"
-  integrity sha512-uBmW2/z0cz/WFIG74ZF7lSipO0XNzMf9yrdqnZXnGDYsUZE4I4QiqDN0hNi6fkTgf9MYRC8uFem2OkAvyPJ74Q==
+"@sentry/node@7.74.1":
+  version "7.74.1"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.74.1.tgz#6d3b2e3483eb3b379d8d51759a079934eabb2bef"
+  integrity sha512-aMUQ2LFZF64FBr+cgjAqjT4OkpYBIC9lyWI8QqjEHqNho5+LGu18/iVrJPD4fgs4UhGdCuAiQjpC36MbmnIDZA==
   dependencies:
-    "@sentry-internal/tracing" "7.74.0"
-    "@sentry/core" "7.74.0"
-    "@sentry/types" "7.74.0"
-    "@sentry/utils" "7.74.0"
+    "@sentry-internal/tracing" "7.74.1"
+    "@sentry/core" "7.74.1"
+    "@sentry/types" "7.74.1"
+    "@sentry/utils" "7.74.1"
     cookie "^0.5.0"
     https-proxy-agent "^5.0.0"
     lru_map "^0.3.3"
     tslib "^2.4.1 || ^1.9.3"
 
-"@sentry/replay@7.74.0":
-  version "7.74.0"
-  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.74.0.tgz#618d40f7c9ecc7589dd14df0c560b20a24839d3f"
-  integrity sha512-GoYa3cHTTFVI/J1cnZ0i4X128mf/JljaswO3PWNTe2k3lSHq/LM5aV0keClRvwM0W8hlix8oOTT06nnenOUmmw==
+"@sentry/replay@7.74.1":
+  version "7.74.1"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.74.1.tgz#dcb5040a3b0a9bda160b70cde5368ecbb4f0e782"
+  integrity sha512-qmbOl+jYdyhoHFbPp9WemKx8UojID5hVmuVLxNIP0ANqAwmE9OQEK9YFg2cf7L/TpKb1tqz0qLgi5MYIdcdpgQ==
   dependencies:
-    "@sentry/core" "7.74.0"
-    "@sentry/types" "7.74.0"
-    "@sentry/utils" "7.74.0"
+    "@sentry/core" "7.74.1"
+    "@sentry/types" "7.74.1"
+    "@sentry/utils" "7.74.1"
 
-"@sentry/types@7.74.0":
-  version "7.74.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.74.0.tgz#810a62cd28db21c5f15f131da6525d7ddf7a29db"
-  integrity sha512-rI5eIRbUycWjn6s6o3yAjjWtIvYSxZDdnKv5je2EZINfLKcMPj1dkl6wQd2F4y7gLfD/N6Y0wZYIXC3DUdJQQg==
+"@sentry/types@7.74.1":
+  version "7.74.1"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.74.1.tgz#b6f9b1bd266254f1f8b55fbcc92fa649ba2100ed"
+  integrity sha512-2jIuPc+YKvXqZETwr2E8VYnsH1zsSUR/wkIvg1uTVeVNyoowJv+YsOtCdeGyL2AwiotUBSPKu7O1Lz0kq5rMOQ==
 
-"@sentry/utils@7.74.0":
-  version "7.74.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.74.0.tgz#e0a16d345b2af6f8b09d157c8c8a3145d7a2070a"
-  integrity sha512-k3np8nuTPtx5KDODPtULfFln4UXdE56MZCcF19Jv6Ljxf+YN/Ady1+0Oi3e0XoSvFpWNyWnglauT7M65qCE6kg==
+"@sentry/utils@7.74.1":
+  version "7.74.1"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.74.1.tgz#e9a8453c954d02ebed2fd3dbe7588483d8f6d3cb"
+  integrity sha512-qUsqufuHYcy5gFhLZslLxA5kcEOkkODITXW3c7D+x+8iP/AJqa8v8CeUCVNS7RetHCuIeWAbbTClC4c411EwQg==
   dependencies:
-    "@sentry/types" "7.74.0"
+    "@sentry/types" "7.74.1"
     tslib "^2.4.1 || ^1.9.3"
 
 "@sindresorhus/is@^4.0.0":

--- a/yarn.lock
+++ b/yarn.lock
@@ -164,13 +164,13 @@
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
 
-"@sentry-internal/eslint-config-sdk@7.74.1":
-  version "7.74.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.74.1.tgz#a0085872c99a52a95b6d3986474ccd72c15c32f1"
-  integrity sha512-zUIKv8pnwbGy0UiAh20QameYdWZwd7NaIAMrGybc2UpVDwBvQb3qv+oZFfKHOYf98wq3OMwGlkw363TkrNrnCA==
+"@sentry-internal/eslint-config-sdk@7.76.0":
+  version "7.76.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.76.0.tgz#40888c53176c95fd46ff805a5c88207b1e554e8e"
+  integrity sha512-kUiJhUx2/OgMAiKZ2pfKI9HHmgIdj6DGWSF3Uyzcd+IGix+Gk/Or84D6whyq0+bwvDfi+VcVW/zDxG63lvAYZw==
   dependencies:
-    "@sentry-internal/eslint-plugin-sdk" "7.74.1"
-    "@sentry-internal/typescript" "7.74.1"
+    "@sentry-internal/eslint-plugin-sdk" "7.76.0"
+    "@sentry-internal/typescript" "7.76.0"
     "@typescript-eslint/eslint-plugin" "^5.48.0"
     "@typescript-eslint/parser" "^5.48.0"
     eslint-config-prettier "^6.11.0"
@@ -180,84 +180,78 @@
     eslint-plugin-jsdoc "^30.0.3"
     eslint-plugin-simple-import-sort "^5.0.3"
 
-"@sentry-internal/eslint-plugin-sdk@7.74.1":
-  version "7.74.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.74.1.tgz#05a905d4a05b976b4d97b4f5ae40d5680a45c17f"
-  integrity sha512-NGtD2n6VpUwxbakqvaUC/3rH3Y/GQW21eZ8poXSPyOxl/Mq9BkYnS7QvcX+wU4yuIvgMpXLwmZX8PNBMiT6lLw==
+"@sentry-internal/eslint-plugin-sdk@7.76.0":
+  version "7.76.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.76.0.tgz#a0cca6254fd1e3e9cefdd40b9e3a9f4257b5bf44"
+  integrity sha512-/F7LcVpiPUfgz2roC3TwoLrQ9y2/lihRNy6xUUGlWlKs41qOvG2LFJCRa0gKpYCodWbWsRsZ2C8kI32vpCOnpw==
   dependencies:
     requireindex "~1.1.0"
 
-"@sentry-internal/tracing@7.74.1":
-  version "7.74.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.74.1.tgz#55ff387e61d2c9533a9a0d099d376332426c8e08"
-  integrity sha512-nNaiZreQxCitG2PzYPaC7XtyA9OMsETGYMKAtiK4p62/uTmeYbsBva9BoNx1XeiHRwbrVQYRMKQ9nV5e2jS4/A==
+"@sentry-internal/tracing@7.76.0":
+  version "7.76.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.76.0.tgz#36c54425bc20c08e569e6da52e13d325611cad66"
+  integrity sha512-QQVIv+LS2sbGf/e5P2dRisHzXpy02dAcLqENLPG4sZ9otRaFNjdFYEqnlJ4qko+ORpJGQEQp/BX7Q/qzZQHlAg==
   dependencies:
-    "@sentry/core" "7.74.1"
-    "@sentry/types" "7.74.1"
-    "@sentry/utils" "7.74.1"
-    tslib "^2.4.1 || ^1.9.3"
+    "@sentry/core" "7.76.0"
+    "@sentry/types" "7.76.0"
+    "@sentry/utils" "7.76.0"
 
-"@sentry-internal/typescript@7.74.1":
-  version "7.74.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.74.1.tgz#1635bf13b97ff53c7eca149222dede778f798965"
-  integrity sha512-6598R51owTJyfZcDRlh0gTYAh6n9d9FKCWvy3zNHjQsGl8hK1Co2bm9iznN5MWeD19mspapMS4X+SFfl4BNWIg==
+"@sentry-internal/typescript@7.76.0":
+  version "7.76.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.76.0.tgz#0a9845859d6a05a372a3c1bd869ecc9b3085fb84"
+  integrity sha512-zQUX7ptLml27Qze+BVWtpiujVhRXLaCjI85d7EbySbVXAM3oz1Dp9IEPKXryrqlxD+41O/qcLNG21F01u6866g==
 
-"@sentry/browser@7.74.1":
-  version "7.74.1"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.74.1.tgz#9302d440bbdcb018abd5fee5959dab4b2fe97383"
-  integrity sha512-OYWNne/KO60lOvkIpIlJUyiJt/9j8DGI57thSDFEYSmmbNqMitczUTBOaEStouvHKyfchqLZm1CZfWKt+z0VOA==
+"@sentry/browser@7.76.0":
+  version "7.76.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.76.0.tgz#7d73573790023523f7d9c3757b8424b7ad60d664"
+  integrity sha512-83xA+cWrBhhkNuMllW5ucFsEO2NlUh2iBYtmg07lp3fyVW+6+b1yMKRnc4RFArJ+Wcq6UO+qk2ZEvrSAts1wEw==
   dependencies:
-    "@sentry-internal/tracing" "7.74.1"
-    "@sentry/core" "7.74.1"
-    "@sentry/replay" "7.74.1"
-    "@sentry/types" "7.74.1"
-    "@sentry/utils" "7.74.1"
-    tslib "^2.4.1 || ^1.9.3"
+    "@sentry-internal/tracing" "7.76.0"
+    "@sentry/core" "7.76.0"
+    "@sentry/replay" "7.76.0"
+    "@sentry/types" "7.76.0"
+    "@sentry/utils" "7.76.0"
 
-"@sentry/core@7.74.1":
-  version "7.74.1"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.74.1.tgz#9e33cf59b754a994e4054c47c74df1d3fbd30d3c"
-  integrity sha512-LvEhOSfdIvwkr+PdlrT/aA/iOLhkXrSkvjqAQyogE4ddCWeYfS0NoirxNt1EaxMBAWKhYZRqzkA7WA4LDLbzlA==
+"@sentry/core@7.76.0":
+  version "7.76.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.76.0.tgz#b0d1dc399a862ea8a1c8a1c60a409e92eaf8e9e1"
+  integrity sha512-M+ptkCTeCNf6fn7p2MmEb1Wd9/JXUWxIT/0QEc+t11DNR4FYy1ZP2O9Zb3Zp2XacO7ORrlL3Yc+VIfl5JTgjfw==
   dependencies:
-    "@sentry/types" "7.74.1"
-    "@sentry/utils" "7.74.1"
-    tslib "^2.4.1 || ^1.9.3"
+    "@sentry/types" "7.76.0"
+    "@sentry/utils" "7.76.0"
 
-"@sentry/node@7.74.1":
-  version "7.74.1"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.74.1.tgz#6d3b2e3483eb3b379d8d51759a079934eabb2bef"
-  integrity sha512-aMUQ2LFZF64FBr+cgjAqjT4OkpYBIC9lyWI8QqjEHqNho5+LGu18/iVrJPD4fgs4UhGdCuAiQjpC36MbmnIDZA==
+"@sentry/node@7.76.0":
+  version "7.76.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.76.0.tgz#9efc8bbe4825b4a5a4f853210364d21980dd790e"
+  integrity sha512-C+YZ5S5W9oTphdWTBgV+3nDdcV1ldnupIHylHzf2Co+xNtJ76V06N5NjdJ/l9+qvQjMn0DdSp7Uu7KCEeNBT/g==
   dependencies:
-    "@sentry-internal/tracing" "7.74.1"
-    "@sentry/core" "7.74.1"
-    "@sentry/types" "7.74.1"
-    "@sentry/utils" "7.74.1"
-    cookie "^0.5.0"
+    "@sentry-internal/tracing" "7.76.0"
+    "@sentry/core" "7.76.0"
+    "@sentry/types" "7.76.0"
+    "@sentry/utils" "7.76.0"
     https-proxy-agent "^5.0.0"
-    lru_map "^0.3.3"
-    tslib "^2.4.1 || ^1.9.3"
 
-"@sentry/replay@7.74.1":
-  version "7.74.1"
-  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.74.1.tgz#dcb5040a3b0a9bda160b70cde5368ecbb4f0e782"
-  integrity sha512-qmbOl+jYdyhoHFbPp9WemKx8UojID5hVmuVLxNIP0ANqAwmE9OQEK9YFg2cf7L/TpKb1tqz0qLgi5MYIdcdpgQ==
+"@sentry/replay@7.76.0":
+  version "7.76.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.76.0.tgz#bccf9ea4a6efc332a79d6a78f923697b9b283371"
+  integrity sha512-OACT7MfMHC/YGKnKST8SF1d6znr3Yu8fpUpfVVh2t9TNeh3+cQJVTOliHDqLy+k9Ljd5FtitgSn4IHtseCHDLQ==
   dependencies:
-    "@sentry/core" "7.74.1"
-    "@sentry/types" "7.74.1"
-    "@sentry/utils" "7.74.1"
+    "@sentry-internal/tracing" "7.76.0"
+    "@sentry/core" "7.76.0"
+    "@sentry/types" "7.76.0"
+    "@sentry/utils" "7.76.0"
 
-"@sentry/types@7.74.1":
-  version "7.74.1"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.74.1.tgz#b6f9b1bd266254f1f8b55fbcc92fa649ba2100ed"
-  integrity sha512-2jIuPc+YKvXqZETwr2E8VYnsH1zsSUR/wkIvg1uTVeVNyoowJv+YsOtCdeGyL2AwiotUBSPKu7O1Lz0kq5rMOQ==
+"@sentry/types@7.76.0":
+  version "7.76.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.76.0.tgz#628c9899bfa82ea762708314c50fd82f2138587d"
+  integrity sha512-vj6z+EAbVrKAXmJPxSv/clpwS9QjPqzkraMFk2hIdE/kii8s8kwnkBwTSpIrNc8GnzV3qYC4r3qD+BXDxAGPaw==
 
-"@sentry/utils@7.74.1":
-  version "7.74.1"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.74.1.tgz#e9a8453c954d02ebed2fd3dbe7588483d8f6d3cb"
-  integrity sha512-qUsqufuHYcy5gFhLZslLxA5kcEOkkODITXW3c7D+x+8iP/AJqa8v8CeUCVNS7RetHCuIeWAbbTClC4c411EwQg==
+"@sentry/utils@7.76.0":
+  version "7.76.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.76.0.tgz#6b540b387d3ac539abd20978f4d3ae235114f6ab"
+  integrity sha512-40jFD+yfQaKpFYINghdhovzec4IEpB7aAuyH/GtE7E0gLpcqnC72r55krEIVILfqIR2Mlr5OKUzyeoCyWAU/yw==
   dependencies:
-    "@sentry/types" "7.74.1"
-    tslib "^2.4.1 || ^1.9.3"
+    "@sentry/types" "7.76.0"
 
 "@sindresorhus/is@^4.0.0":
   version "4.6.0"
@@ -1177,11 +1171,6 @@ content-type@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
   integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
-
-cookie@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
-  integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
 
 cookies@~0.8.0:
   version "0.8.0"
@@ -2680,11 +2669,6 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lru_map@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
-  integrity sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==
-
 make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
@@ -3635,11 +3619,6 @@ tslib@^2.3.1, tslib@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
-
-"tslib@^2.4.1 || ^1.9.3":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.0.tgz#b295854684dbda164e181d259a22cd779dcd7bc3"
-  integrity sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==
 
 tsscmp@1.0.6:
   version "1.0.6"


### PR DESCRIPTION
This PR:
- Updates to the latest js SDKs which had breaking changes around the `watchdogTimer`
- Removes the `lru_map` dependency as there is now an alternative in `@sentry/utils`
- Adds ANR session support for renderer ANR
- Adds tests for both main and renderer ANR sessions

Closes #774 

When adding the tests I found a bug where the ANR child process was picking up the session persistence file and sending it as a previously abnormal session but this file was created by the main process!