### PR TITLE
fix: Patch `registerSchemesAsPrivileged` so sentry scheme isn't overwritten

### DIFF
--- a/src/main/anr.ts
+++ b/src/main/anr.ts
@@ -90,7 +90,7 @@ export function isAnrChildProcess(): boolean {
 }
 
 /** Creates a renderer ANR status hook */
-export function createRendererAnrStatusHook(): (status: RendererStatus, contents: WebContents) => void {
+export function createRendererAnrStatusHandler(): (status: RendererStatus, contents: WebContents) => void {
   function log(message: string, ...args: unknown[]): void {
     logger.log(`[Renderer ANR] ${message}`, ...args);
   }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -176,12 +176,13 @@ function configureProtocol(options: ElectronMainOptionsInternal): void {
 
   protocol.registerSchemesAsPrivileged([SENTRY_CUSTOM_SCHEME]);
 
-  // We override this function so that later user calls to registerSchemesAsPrivileged don't overwrite our custom scheme
+  // We Proxy this function so that later user calls to registerSchemesAsPrivileged don't overwrite our custom scheme
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const originalFn = protocol.registerSchemesAsPrivileged;
-  protocol.registerSchemesAsPrivileged = function (schemes) {
-    originalFn.call(this, [...schemes, SENTRY_CUSTOM_SCHEME]);
-  };
+  protocol.registerSchemesAsPrivileged = new Proxy(protocol.registerSchemesAsPrivileged, {
+    apply: (target, __, args: Parameters<typeof protocol.registerSchemesAsPrivileged>) => {
+      target([...args[0], SENTRY_CUSTOM_SCHEME]);
+    },
+  });
 
   const rendererStatusChanged = createRendererAnrStatusHandler();
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -12,12 +12,17 @@ import {
   PROTOCOL_SCHEME,
   RendererStatus,
 } from '../common';
-import { createRendererAnrStatusHook } from './anr';
+import { createRendererAnrStatusHandler } from './anr';
 import { registerProtocol, supportsFullProtocol, whenAppReady } from './electron-normalize';
 import { ElectronMainOptionsInternal } from './sdk';
 
 let KNOWN_RENDERERS: Set<number> | undefined;
 let WINDOW_ID_TO_WEB_CONTENTS: Map<string, number> | undefined;
+
+const SENTRY_CUSTOM_SCHEME = {
+  scheme: PROTOCOL_SCHEME,
+  privileges: { bypassCSP: true, corsEnabled: true, supportFetchAPI: true, secure: true },
+};
 
 async function newProtocolRenderer(): Promise<void> {
   KNOWN_RENDERERS = KNOWN_RENDERERS || new Set();
@@ -169,14 +174,16 @@ function configureProtocol(options: ElectronMainOptionsInternal): void {
     throw new SentryError("Sentry SDK should be initialized before the Electron app 'ready' event is fired");
   }
 
-  protocol.registerSchemesAsPrivileged([
-    {
-      scheme: PROTOCOL_SCHEME,
-      privileges: { bypassCSP: true, corsEnabled: true, supportFetchAPI: true, secure: true },
-    },
-  ]);
+  protocol.registerSchemesAsPrivileged([SENTRY_CUSTOM_SCHEME]);
 
-  const rendererStatusChanged = createRendererAnrStatusHook();
+  // We override this function so that later user calls to registerSchemesAsPrivileged don't overwrite our custom scheme
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const originalFn = protocol.registerSchemesAsPrivileged;
+  protocol.registerSchemesAsPrivileged = function (schemes) {
+    originalFn.call(this, [...schemes, SENTRY_CUSTOM_SCHEME]);
+  };
+
+  const rendererStatusChanged = createRendererAnrStatusHandler();
 
   whenAppReady
     .then(() => {
@@ -231,7 +238,7 @@ function configureClassic(options: ElectronMainOptionsInternal): void {
   ipcMain.on(IPCChannel.SCOPE, (_, jsonScope: string) => handleScope(options, jsonScope));
   ipcMain.on(IPCChannel.ENVELOPE, ({ sender }, env: Uint8Array | string) => handleEnvelope(options, env, sender));
 
-  const rendererStatusChanged = createRendererAnrStatusHook();
+  const rendererStatusChanged = createRendererAnrStatusHandler();
   ipcMain.on(IPCChannel.STATUS, ({ sender }, status: RendererStatus) => rendererStatusChanged(status, sender));
 }
 

--- a/test/e2e/test-apps/javascript/renderer-error-protocol/src/main.js
+++ b/test/e2e/test-apps/javascript/renderer-error-protocol/src/main.js
@@ -1,6 +1,6 @@
 const path = require('path');
 
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, protocol } = require('electron');
 const { init, IPCMode } = require('@sentry/electron');
 
 init({
@@ -10,6 +10,18 @@ init({
   autoSessionTracking: false,
   onFatalError: () => {},
 });
+
+// Since we patch registerSchemesAsPrivileged, this should not overwrite the sentry scheme
+protocol.registerSchemesAsPrivileged([
+  {
+    scheme: 'custom1',
+    privileges: {
+      standard: true,
+      secure: true,
+      supportFetchAPI: true,
+    },
+  },
+]);
 
 app.on('ready', () => {
   const mainWindow = new BrowserWindow({


### PR DESCRIPTION
Closes #661

This fix patches the Electron `registerSchemesAsPrivileged` function so that subsequent calls by user code don't overwrite the Sentry scheme.

Unfortunately this Electron API only respects the last schemes passed before app ready and doesn't warn if called multiple times. 