### PR TITLE
test: Only test ANR on newer versions of Electron

### DIFF
--- a/test/e2e/test-apps/anr/anr-main/recipe.yml
+++ b/test/e2e/test-apps/anr/anr-main/recipe.yml
@@ -1,4 +1,4 @@
 description: ANR Main Event
 category: ANR
 command: yarn
-condition: version.major >= 4
+condition: version.major >= 13

--- a/test/e2e/test-apps/anr/anr-renderer/recipe.yml
+++ b/test/e2e/test-apps/anr/anr-renderer/recipe.yml
@@ -1,4 +1,4 @@
 description: ANR Renderer Event
 category: ANR
 command: yarn
-condition: version.major >= 4
+condition: version.major >= 13


### PR DESCRIPTION
When trying to publish a release, some ANR tests are failing on very old versions of Electron. It unnecessary to test all these really old versions!