### PR TITLE
test: Test less old Electron versions

### DIFF
--- a/scripts/e2e-test-versions.js
+++ b/scripts/e2e-test-versions.js
@@ -6,6 +6,7 @@ if (process.env.GITHUB_REF && process.env.GITHUB_REF.includes('release/')) {
   // For release builds we test all versions
   console.log(JSON.stringify(versions));
 } else {
+  const versionCount = process.platform === 'darwin' ? -3 : -7;
   // Otherwise we test the oldest version and the last 10 versions
-  console.log(JSON.stringify([versions[0], ...versions.slice(-10)]));
+  console.log(JSON.stringify([versions[0], ...versions.slice(versionCount)]));
 }


### PR DESCRIPTION
For PRs, tested versions are reduced to:
- macOS - Last 3 versions + min supported version 
- Win/Linux - Last 7 versions + min supported version 

This takes us from 33 tested version/platform combinations down to 20.

Release builds still result in all version/platform combinations being tested since there are still a lot of additions and variations in Electron APIs across all these historic versions.