### PR TITLE
feat: Browser profiling

### DIFF
--- a/src/common/normalize.ts
+++ b/src/common/normalize.ts
@@ -116,9 +116,9 @@ export function normalizeUrlsInReplayEnvelope(envelope: Envelope, basePath: stri
  * Normalizes all URLs in a profile
  */
 export function normaliseProfile(profile: Profile, basePath: string): void {
-  profile.profile.frames.forEach((frame) => {
+  for (const frame of profile.profile.frames) {
     if (frame.abs_path) {
       frame.abs_path = normalizeUrl(frame.abs_path, basePath);
     }
-  });
+  }
 }

--- a/src/common/normalize.ts
+++ b/src/common/normalize.ts
@@ -1,4 +1,4 @@
-import { Envelope, Event, ReplayEvent } from '@sentry/types';
+import { Envelope, Event, Profile, ReplayEvent } from '@sentry/types';
 import { addItemToEnvelope, createEnvelope, forEachEnvelopeItem } from '@sentry/utils';
 
 /**
@@ -110,4 +110,15 @@ export function normalizeUrlsInReplayEnvelope(envelope: Envelope, basePath: stri
   });
 
   return isReplay ? modifiedEnvelope : envelope;
+}
+
+/**
+ * Normalizes all URLs in a profile
+ */
+export function normaliseProfile(profile: Profile, basePath: string): void {
+  profile.profile.frames.forEach((frame) => {
+    if (frame.abs_path) {
+      frame.abs_path = normalizeUrl(frame.abs_path, basePath);
+    }
+  });
 }

--- a/src/main/integrations/index.ts
+++ b/src/main/integrations/index.ts
@@ -10,3 +10,4 @@ export { AdditionalContext } from './additional-context';
 export { Net } from './net-breadcrumbs';
 export { ChildProcess } from './child-process';
 export { Screenshots } from './screenshots';
+export { RendererProfiling } from './renderer-profiling';

--- a/src/main/integrations/renderer-profiling.ts
+++ b/src/main/integrations/renderer-profiling.ts
@@ -1,0 +1,120 @@
+import { NodeClient } from '@sentry/node';
+import { Event, Integration, Profile } from '@sentry/types';
+import { forEachEnvelopeItem, LRUMap } from '@sentry/utils';
+import { app } from 'electron';
+
+import { normaliseProfile } from '../../common';
+import { getDefaultEnvironment, getDefaultReleaseName } from '../context';
+import { ELECTRON_MAJOR_VERSION } from '../electron-normalize';
+import { ElectronMainOptionsInternal } from '../sdk';
+
+// A cache of renderer profiles which need attaching to events
+let RENDERER_PROFILES: LRUMap<string, Profile> | undefined;
+
+/**
+ * Caches a profile to later be re-attached to an event
+ */
+export function rendererProfileFromIpc(event: Event, profile: Profile): void {
+  if (!RENDERER_PROFILES) {
+    return;
+  }
+
+  const profile_id = profile.event_id;
+  RENDERER_PROFILES.set(profile_id, profile);
+
+  if (event) {
+    event.contexts = {
+      ...event.contexts,
+      // Re-add the profile context which we can later use to find the correct profile
+      profile: {
+        profile_id,
+      },
+    };
+  }
+}
+
+/**
+ * Injects 'js-profiling' document policy headers and ensures that profiles get forwarded with transactions
+ */
+export class RendererProfiling implements Integration {
+  /** @inheritDoc */
+  public static id: string = 'RendererProfiling';
+
+  /** @inheritDoc */
+  public readonly name: string;
+
+  public constructor() {
+    this.name = RendererProfiling.id;
+  }
+
+  /** @inheritDoc */
+  public setupOnce(): void {
+    //
+  }
+
+  /** @inheritDoc */
+  public setup(client: NodeClient): void {
+    const options = client.getOptions() as ElectronMainOptionsInternal;
+    if (!options.enableRendererProfiling) {
+      return;
+    }
+
+    if (ELECTRON_MAJOR_VERSION < 15) {
+      throw new Error('Renderer profiling requires Electron 15+ (Chromium 94+)');
+    }
+
+    RENDERER_PROFILES = new LRUMap(10);
+
+    app.on('ready', () => {
+      // Ensure the correct headers are set to enable the browser profiler
+      for (const sesh of options.getSessions()) {
+        sesh.webRequest.onHeadersReceived((details, callback) => {
+          callback({
+            responseHeaders: {
+              ...details.responseHeaders,
+              'Document-Policy': 'js-profiling',
+            },
+          });
+        });
+      }
+    });
+
+    // Copy the profiles back into the event envelopes
+    client.on('beforeEnvelope', (envelope) => {
+      let profile_id: string | undefined;
+
+      forEachEnvelopeItem(envelope, (item, type) => {
+        if (type !== 'transaction') {
+          return;
+        }
+
+        for (let j = 1; j < item.length; j++) {
+          const event = item[j] as Event;
+
+          if (event && event.contexts && event.contexts.profile && event.contexts.profile.profile_id) {
+            profile_id = event.contexts.profile.profile_id as string;
+            // This can be removed as it's no longer needed
+            delete event.contexts.profile;
+          }
+        }
+      });
+
+      if (!profile_id) {
+        return;
+      }
+
+      const profile = RENDERER_PROFILES?.remove(profile_id);
+
+      if (!profile) {
+        return;
+      }
+
+      normaliseProfile(profile, app.getAppPath());
+      profile.release = options.release || getDefaultReleaseName();
+      profile.environment = options.environment || getDefaultEnvironment();
+
+      // @ts-expect-error untyped envelope
+      envelope[1].push([{ type: 'profile' }, profile]);
+    });
+  }
+}

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,5 +1,5 @@
 import { captureEvent, configureScope, getCurrentHub, Scope } from '@sentry/core';
-import { Attachment, AttachmentItem, Envelope, Event, EventItem } from '@sentry/types';
+import { Attachment, AttachmentItem, Envelope, Event, EventItem, Profile } from '@sentry/types';
 import { forEachEnvelopeItem, logger, parseEnvelope, SentryError } from '@sentry/utils';
 import { app, ipcMain, protocol, WebContents, webContents } from 'electron';
 import { TextDecoder, TextEncoder } from 'util';
@@ -14,6 +14,7 @@ import {
 } from '../common';
 import { createRendererAnrStatusHandler } from './anr';
 import { registerProtocol, supportsFullProtocol, whenAppReady } from './electron-normalize';
+import { rendererProfileFromIpc } from './integrations/renderer-profiling';
 import { ElectronMainOptionsInternal } from './sdk';
 
 let KNOWN_RENDERERS: Set<number> | undefined;
@@ -88,9 +89,10 @@ function handleEvent(options: ElectronMainOptionsInternal, jsonEvent: string, co
   captureEventFromRenderer(options, event, [], contents);
 }
 
-function eventFromEnvelope(envelope: Envelope): [Event, Attachment[]] | undefined {
+function eventFromEnvelope(envelope: Envelope): [Event, Attachment[], Profile | undefined] | undefined {
   let event: Event | undefined;
   const attachments: Attachment[] = [];
+  let profile: Profile | undefined;
 
   forEachEnvelopeItem(envelope, (item, type) => {
     if (type === 'event' || type === 'transaction') {
@@ -104,10 +106,12 @@ function eventFromEnvelope(envelope: Envelope): [Event, Attachment[]] | undefine
         contentType: headers.content_type,
         data,
       });
+    } else if (type === 'profile') {
+      profile = item[1] as unknown as Profile;
     }
   });
 
-  return event ? [event, attachments] : undefined;
+  return event ? [event, attachments, profile] : undefined;
 }
 
 function handleEnvelope(options: ElectronMainOptionsInternal, env: Uint8Array | string, contents?: WebContents): void {
@@ -115,7 +119,14 @@ function handleEnvelope(options: ElectronMainOptionsInternal, env: Uint8Array | 
 
   const eventAndAttachments = eventFromEnvelope(envelope);
   if (eventAndAttachments) {
-    const [event, attachments] = eventAndAttachments;
+    const [event, attachments, profile] = eventAndAttachments;
+
+    if (profile) {
+      // We have a 'profile' item and there is no way for us to pass this through event capture
+      // so store them in a cache and reattach them via the `beforeEnvelope` hook before sending
+      rendererProfileFromIpc(event, profile);
+    }
+
     captureEventFromRenderer(options, event, attachments, contents);
   } else {
     const normalizedEnvelope = normalizeUrlsInReplayEnvelope(envelope, app.getAppPath());

--- a/src/main/sdk.ts
+++ b/src/main/sdk.ts
@@ -16,6 +16,7 @@ import {
   Net,
   OnUncaughtException,
   PreloadInjection,
+  RendererProfiling,
   Screenshots,
   SentryMinidump,
 } from './integrations';
@@ -34,6 +35,7 @@ export const defaultIntegrations: Integration[] = [
   new PreloadInjection(),
   new AdditionalContext(),
   new Screenshots(),
+  new RendererProfiling(),
   ...defaultNodeIntegrations.filter(
     (integration) => integration.name !== 'OnUncaughtException' && integration.name !== 'Context',
   ),
@@ -77,6 +79,13 @@ export interface ElectronMainOptionsInternal extends Options<ElectronOfflineTran
    * renderers.
    */
   attachScreenshot?: boolean;
+
+  /**
+   * Enables injection of 'js-profiling' document policy headers and ensure profiles are forwarded with transactions
+   *
+   * Requires Electron 15+
+   */
+  enableRendererProfiling?: boolean;
 }
 
 // getSessions and ipcMode properties are optional because they have defaults

--- a/test/e2e/recipe/index.ts
+++ b/test/e2e/recipe/index.ts
@@ -257,7 +257,7 @@ export class RecipeRunner {
     }
 
     for (const event of testServer.events) {
-      event.data = normalize(event.data);
+      normalize(event);
     }
 
     for (const [i, expectedEvent] of expectedEvents.entries()) {

--- a/test/e2e/test-apps/other/browser-profiling/event.json
+++ b/test/e2e/test-apps/other/browser-profiling/event.json
@@ -1,0 +1,141 @@
+{
+  "method": "envelope",
+  "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
+  "appId": "277345",
+  "data": {
+    "sdk": {
+      "name": "sentry.javascript.electron",
+      "packages": [
+        {
+          "name": "npm:@sentry/electron",
+          "version": "{{version}}"
+        }
+      ],
+      "version": "{{version}}"
+    },
+    "contexts": {
+      "app": {
+        "app_name": "browser-profiling",
+        "app_version": "1.0.0",
+        "app_start_time": "{{time}}"
+      },
+      "browser": {
+        "name": "Chrome"
+      },
+      "chrome": {
+        "name": "Chrome",
+        "type": "runtime",
+        "version": "{{version}}"
+      },
+      "device": {
+        "arch": "{{arch}}",
+        "family": "Desktop",
+        "memory_size": 0,
+        "free_memory": 0,
+        "processor_count": 0,
+        "processor_frequency": 0,
+        "cpu_description": "{{cpu}}",
+        "screen_resolution": "{{screen}}",
+        "screen_density": 1,
+        "language": "{{language}}"
+      },
+      "node": {
+        "name": "Node",
+        "type": "runtime",
+        "version": "{{version}}"
+      },
+      "os": {
+        "name": "{{platform}}",
+        "version": "{{version}}"
+      },
+      "runtime": {
+        "name": "Electron",
+        "version": "{{version}}"
+      }
+    },
+    "spans": [
+      {
+        "description": "PBKDF2",
+        "origin": "manual",
+        "parent_span_id": "{{id}}",
+        "span_id": "{{id}}",
+        "start_timestamp": 0,
+        "timestamp": 0,
+        "trace_id": "{{id}}"
+      },
+      {
+        "description": "PBKDF2",
+        "origin": "manual",
+        "parent_span_id": "{{id}}",
+        "span_id": "{{id}}",
+        "start_timestamp": 0,
+        "timestamp": 0,
+        "trace_id": "{{id}}"
+      },
+      {
+        "description": "PBKDF2",
+        "origin": "manual",
+        "parent_span_id": "{{id}}",
+        "span_id": "{{id}}",
+        "start_timestamp": 0,
+        "timestamp": 0,
+        "trace_id": "{{id}}"
+      },
+      {
+        "description": "PBKDF2",
+        "origin": "manual",
+        "parent_span_id": "{{id}}",
+        "span_id": "{{id}}",
+        "start_timestamp": 0,
+        "timestamp": 0,
+        "trace_id": "{{id}}"
+      }
+    ],
+    "release": "some-release",
+    "environment": "development",
+    "user": {
+      "ip_address": "{{auto}}"
+    },
+    "event_id": "{{id}}",
+    "platform": "javascript",
+    "start_timestamp": 0,
+    "timestamp": 0,
+    "breadcrumbs": [],
+    "request": {
+      "url": "app:///src/index.html"
+    },
+    "tags": {
+      "event.environment": "javascript",
+      "event.origin": "electron",
+      "event_type": "javascript"
+    }
+  },
+  "profile": {
+    "event_id": "{{id}}",
+    "timestamp": "{{time}}",
+    "release": "some-release",
+    "environment": "development",
+    "profile": {
+      "samples": [
+        {
+          "stack_id": 0,
+          "thread_id": "0"
+        },
+        {
+          "stack_id": 0,
+          "thread_id": "0"
+        },
+        {
+          "stack_id": 0,
+          "thread_id": "0"
+        }
+      ],
+      "thread_metadata": { "0": { "name": "main" } }
+    },
+    "transactions": [
+      {
+        "name": "Long work"
+      }
+    ]
+  }
+}

--- a/test/e2e/test-apps/other/browser-profiling/package.json
+++ b/test/e2e/test-apps/other/browser-profiling/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "browser-profiling",
+  "version": "1.0.0",
+  "main": "src/main.js",
+  "dependencies": {
+    "@sentry/electron": "3.0.0"
+  }
+}

--- a/test/e2e/test-apps/other/browser-profiling/recipe.yml
+++ b/test/e2e/test-apps/other/browser-profiling/recipe.yml
@@ -1,0 +1,4 @@
+description: Browser Profiling
+command: yarn
+# Browser Tracing fails on Electron v24
+condition: version.major >= 15

--- a/test/e2e/test-apps/other/browser-profiling/src/index.html
+++ b/test/e2e/test-apps/other/browser-profiling/src/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <script>
+      const crypto = require('crypto');
+      const {
+        addTracingExtensions,
+        init,
+        BrowserProfilingIntegration,
+        startSpan,
+      } = require('@sentry/electron/renderer');
+
+      addTracingExtensions();
+
+      init({
+        debug: true,
+        integrations: [new BrowserProfilingIntegration()],
+        tracesSampleRate: 1,
+        profilesSampleRate: 1,
+      });
+
+      function pbkdf2() {
+        return new Promise((resolve) => {
+          const salt = crypto.randomBytes(128).toString('base64');
+          crypto.pbkdf2('myPassword', salt, 10000, 512, 'sha512', resolve);
+        });
+      }
+
+      async function longWork() {
+        for (let i = 0; i < 10; i++) {
+          await startSpan({ name: 'PBKDF2' }, async () => {
+            await pbkdf2();
+          });
+        }
+      }
+
+      setTimeout(() => {
+        startSpan({ name: 'Long work' }, async () => {
+          await longWork();
+        });
+      }, 500);
+    </script>
+  </body>
+</html>

--- a/test/e2e/test-apps/other/browser-profiling/src/main.js
+++ b/test/e2e/test-apps/other/browser-profiling/src/main.js
@@ -1,0 +1,25 @@
+const path = require('path');
+
+const { app, BrowserWindow } = require('electron');
+const { init } = require('@sentry/electron');
+
+init({
+  dsn: '__DSN__',
+  debug: true,
+  release: 'some-release',
+  autoSessionTracking: false,
+  enableRendererProfiling: true,
+  onFatalError: () => {},
+});
+
+app.on('ready', () => {
+  const mainWindow = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+
+  mainWindow.loadFile(path.join(__dirname, 'index.html'));
+});


### PR DESCRIPTION
Closes #792

Adds a new `RendererProfiling` integration:
- Requires Electron >= v15 (For Chrome 94)
- Enabled via the new `enableRendererProfiling` option
- It adds `'Document-Policy': 'js-profiling'` headers to all renderer requests
- Caches profile envelope items as they arrive in the main process from renderers
- Hooks `beforeEnvelope` to re-add the profiles to the correct envelopes

This PR also adds a test to ensure a profile is sent with the transaction.

## Enabling Browser Profiling

From a users perspective, to enable profiling in the renderers, you'll need to pass `enableRendererProfiling: true` in the main process:

```ts
const { init } = require('@sentry/electron/main');

init({
  dsn: '__DSN__',
  enableRendererProfiling: true,
});
```

Then in the renderer follow the regular browser profiling instructions:
```ts
import { addTracingExtensions, init, BrowserProfilingIntegration } from '@sentry/electron/renderer';

addTracingExtensions();

init({
  integrations: [new BrowserProfilingIntegration()],
  tracesSampleRate: 1,
  profilesSampleRate: 1,
});
```

