### PR TITLE
test: Ensure correct scope for main process native crashes

### DIFF
--- a/test/e2e/test-apps/native-sentry/main/event.json
+++ b/test/e2e/test-apps/native-sentry/main/event.json
@@ -60,7 +60,23 @@
     },
     "event_id": "{{id}}",
     "timestamp": 0,
-    "breadcrumbs": [],
+    "breadcrumbs": [
+      {
+        "category": "console",
+        "level": "log",
+        "message": "main process breadcrumb from first crashing run"
+      },
+      {
+        "category": "console",
+        "level": "log",
+        "message": "renderer process breadcrumb from first crashing run"
+      },
+      {
+        "category": "console",
+        "level": "log",
+        "message": "main process breadcrumb from second run"
+      }
+    ],
     "tags": {
       "event.environment": "native",
       "event.origin": "electron",

--- a/test/e2e/test-apps/native-sentry/main/src/index.html
+++ b/test/e2e/test-apps/native-sentry/main/src/index.html
@@ -10,6 +10,10 @@
       init({
         debug: true,
       });
+
+      if (process.env.APP_FIRST_RUN) {
+        console.log('renderer process breadcrumb from first crashing run');
+      }
     </script>
   </body>
 </html>

--- a/test/e2e/test-apps/native-sentry/main/src/main.js
+++ b/test/e2e/test-apps/native-sentry/main/src/main.js
@@ -28,8 +28,12 @@ app.on('ready', () => {
   // We only crash on the first run
   // The second run is where the crash is uploaded
   if (process.env.APP_FIRST_RUN) {
+    console.log('main process breadcrumb from first crashing run');
+
     setTimeout(() => {
       process.crash();
-    }, 1000);
+    }, 2000);
+  } else {
+    console.log('main process breadcrumb from second run');
   }
 });


### PR DESCRIPTION
Closes #802

This PR adds some console breadcrumbs to a test to ensure we include scope/breadcrumbs from previous run where the main process crashed.