### PR TITLE
fix: Change ANR minimum Electron version to v22

### DIFF
--- a/src/main/integrations/anr.ts
+++ b/src/main/integrations/anr.ts
@@ -48,8 +48,8 @@ interface Options {
  */
 export class Anr extends Integrations.Anr {
   public constructor(options: Partial<Options> = {}) {
-    if (ELECTRON_MAJOR_VERSION < 15) {
-      throw new Error('Main process ANR detection requires Electron >= v15');
+    if (ELECTRON_MAJOR_VERSION < 22) {
+      throw new Error('Main process ANR detection requires Electron v22+');
     }
 
     super({

--- a/test/e2e/test-apps/anr/anr-main/recipe.yml
+++ b/test/e2e/test-apps/anr/anr-main/recipe.yml
@@ -1,4 +1,4 @@
 description: ANR Main Event
 category: ANR
 command: yarn
-condition: version.major >= 15
+condition: version.major >= 22

--- a/test/e2e/test-apps/native-electron/renderer/event-no-crashpad.json
+++ b/test/e2e/test-apps/native-electron/renderer/event-no-crashpad.json
@@ -3,9 +3,6 @@
   "method": "minidump",
   "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
   "appId": "277345",
-  "data": {
-    "event_id": "{{id}}",
-    "timestamp": 0
-  },
+  "data": {},
   "attachments": [ { "attachment_type": "event.minidump" } ]
 }


### PR DESCRIPTION
Release builds test all supported Electron versions and it looks like the minimum supported Node version for ANR is not v16+, is it in fact v16.17.0+.

This brings the minimum supported Electron version up to v22+ which was released 14 months ago. 