### PR TITLE
feat: Update to v7.98.0 of JavaScript SDKs

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,19 +55,19 @@
     "e2e": "cross-env TS_NODE_PROJECT=tsconfig.test.json xvfb-maybe mocha --require ts-node/register/transpile-only --retries 3 ./test/e2e/*.ts"
   },
   "dependencies": {
-    "@sentry/browser": "7.94.1",
-    "@sentry/core": "7.94.1",
-    "@sentry/node": "7.94.1",
-    "@sentry/types": "7.94.1",
-    "@sentry/utils": "7.94.1",
+    "@sentry/browser": "7.98.0",
+    "@sentry/core": "7.98.0",
+    "@sentry/node": "7.98.0",
+    "@sentry/types": "7.98.0",
+    "@sentry/utils": "7.98.0",
     "deepmerge": "4.3.0",
     "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.2.1",
     "@rollup/plugin-typescript": "^11.1.4",
-    "@sentry-internal/eslint-config-sdk": "7.94.1",
-    "@sentry-internal/typescript": "7.94.1",
+    "@sentry-internal/eslint-config-sdk": "7.98.0",
+    "@sentry-internal/typescript": "7.98.0",
     "@types/busboy": "^0.2.3",
     "@types/chai": "^4.2.10",
     "@types/chai-as-promised": "^7.1.5",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -76,7 +76,12 @@ export {
   startInactiveSpan,
   startSpanManual,
   continueTrace,
+  parameterize,
   metrics,
+  functionToStringIntegration,
+  inboundFiltersIntegration,
+  linkedErrorsIntegration,
+  requestDataIntegration,
 } from '@sentry/core';
 export type { SpanStatusType } from '@sentry/core';
 

--- a/src/main/sdk.ts
+++ b/src/main/sdk.ts
@@ -34,6 +34,7 @@ export const defaultIntegrations: Integration[] = [
   new AdditionalContext(),
   new Screenshots(),
   new RendererProfiling(),
+  // eslint-disable-next-line deprecation/deprecation
   ...defaultNodeIntegrations.filter(
     (integration) => integration.name !== 'OnUncaughtException' && integration.name !== 'Context',
   ),

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -73,6 +73,12 @@ export {
   startInactiveSpan,
   startSpanManual,
   continueTrace,
+  // eslint-disable-next-line deprecation/deprecation
+  ModuleMetadata,
+  moduleMetadataIntegration,
+  functionToStringIntegration,
+  inboundFiltersIntegration,
+  parameterize,
 } from '@sentry/core';
 export type { SpanStatusType } from '@sentry/core';
 
@@ -94,10 +100,22 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   lastEventId,
   showReportDialog,
+  // eslint-disable-next-line deprecation/deprecation
   Replay,
+  replayIntegration,
+  replayCanvasIntegration,
+  feedbackIntegration,
+  sendFeedback,
+  breadcrumbsIntegration,
+  dedupeIntegration,
+  globalHandlersIntegration,
+  httpContextIntegration,
+  linkedErrorsIntegration,
+  browserApiErrorsIntegration,
 } from '@sentry/browser';
 // eslint-disable-next-line deprecation/deprecation
 export type { BrowserOptions, ReportDialogOptions } from '@sentry/browser';
 
+// eslint-disable-next-line deprecation/deprecation
 export const Integrations = { ...BrowserIntegrations, ...ElectronRendererIntegrations };
 export { init, defaultIntegrations } from './sdk';

--- a/src/renderer/sdk.ts
+++ b/src/renderer/sdk.ts
@@ -13,6 +13,7 @@ import { MetricsAggregator } from './integrations/metrics-aggregator';
 import { electronRendererStackParser } from './stack-parse';
 import { makeRendererTransport } from './transport';
 
+// eslint-disable-next-line deprecation/deprecation
 export const defaultIntegrations = [...defaultBrowserIntegrations, new ScopeToMain(), new MetricsAggregator()];
 
 interface ElectronRendererOptions extends BrowserOptions {
@@ -41,7 +42,7 @@ interface ElectronRendererOptions extends BrowserOptions {
 export function init<O extends ElectronRendererOptions>(
   options: ElectronRendererOptions & O = {} as ElectronRendererOptions & O,
   // This parameter name ensures that TypeScript error messages contain a hint for fixing SDK version mismatches
-  originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v7_94_1: O) => void = browserInit,
+  originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v7_98_0: O) => void = browserInit,
 ): void {
   ensureProcess('renderer');
 

--- a/test/e2e/test-apps/other/browser-replay/src/index.html
+++ b/test/e2e/test-apps/other/browser-replay/src/index.html
@@ -5,11 +5,11 @@
   </head>
   <body>
     <script>
-      const { init, Replay } = require('@sentry/electron/renderer');
+      const { init, replayIntegration } = require('@sentry/electron/renderer');
 
       init({
         debug: true,
-        integrations: [new Replay()],
+        integrations: [replayIntegration()],
         replaysSessionSampleRate: 0,
         replaysOnErrorSampleRate: 1,
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -164,13 +164,13 @@
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
 
-"@sentry-internal/eslint-config-sdk@7.94.1":
-  version "7.94.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.94.1.tgz#87af85dff9a2330101144e26db1e0d0e94a79fdf"
-  integrity sha512-SlYJEFPHeNPfl3EwE9omqIVZ8kQ+khlAMSka0YpM1dKXmzMRQN60iuzDoqf243SJt3HXyORVbghdAAYC5Svqtg==
+"@sentry-internal/eslint-config-sdk@7.98.0":
+  version "7.98.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.98.0.tgz#138327174d9f6727cd38d2da5564a45ca6a82c6c"
+  integrity sha512-dfUmTCAEqFjzFxAk8HT3q3gwgbGbG6K9gwNwFaWJnPuw1I8mvvtsN15r0+VlQWowB+BcbIVHnEH8HNP1XtnBgg==
   dependencies:
-    "@sentry-internal/eslint-plugin-sdk" "7.94.1"
-    "@sentry-internal/typescript" "7.94.1"
+    "@sentry-internal/eslint-plugin-sdk" "7.98.0"
+    "@sentry-internal/typescript" "7.98.0"
     "@typescript-eslint/eslint-plugin" "^5.48.0"
     "@typescript-eslint/parser" "^5.48.0"
     eslint-config-prettier "^6.11.0"
@@ -180,97 +180,98 @@
     eslint-plugin-jsdoc "^30.0.3"
     eslint-plugin-simple-import-sort "^5.0.3"
 
-"@sentry-internal/eslint-plugin-sdk@7.94.1":
-  version "7.94.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.94.1.tgz#f2f0ff83d2caf4e2a496a1a5ed58d9c55244eff4"
-  integrity sha512-nn8x1y47vAhINglbwBNZWmVflOHgkFcnOfKeEWSGTZ35QPuO6cD+S6Kc62S5o3wA1hgQHOII+b1Hl7w9NtrtMg==
+"@sentry-internal/eslint-plugin-sdk@7.98.0":
+  version "7.98.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.98.0.tgz#64dc7c809a50d4c1ca0a4169a8616b54398c8518"
+  integrity sha512-EGWacj/Y0z4w2dlfpRmjiKfJV3Ap+bHGPeMB0ui/rMAGwLAn97hF4wBNeSEEFBuFGisD+TztelfqZkmV3LQNbA==
   dependencies:
     requireindex "~1.1.0"
 
-"@sentry-internal/feedback@7.94.1":
-  version "7.94.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/feedback/-/feedback-7.94.1.tgz#332212255568b1b18c08814bb7f8d37187e1e6c0"
-  integrity sha512-NlJn/TEX1MOPfY4bb6FU0Equ6YuaewZ+lIAqYt3HuEoYI7nYApeRGaPuVLkkezN0cmI7oU/+pJ7v83PtYXCFZw==
+"@sentry-internal/feedback@7.98.0":
+  version "7.98.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/feedback/-/feedback-7.98.0.tgz#2dabbdc060dca49e79536ae99a9bd55f9c6f806f"
+  integrity sha512-t/mATvwkLcQLKRlx8SO5vlUjaadF6sT3lfR0PdWYyBy8qglbMTHDW4KP6JKh1gdzTVQGnwMByy+/4h9gy4AVzw==
   dependencies:
-    "@sentry/core" "7.94.1"
-    "@sentry/types" "7.94.1"
-    "@sentry/utils" "7.94.1"
+    "@sentry/core" "7.98.0"
+    "@sentry/types" "7.98.0"
+    "@sentry/utils" "7.98.0"
 
-"@sentry-internal/replay-canvas@7.94.1":
-  version "7.94.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/replay-canvas/-/replay-canvas-7.94.1.tgz#fdf9743c3051d468ae7c42ecf534beb803204154"
-  integrity sha512-kCFxdIJTbo2z8wnAQ3IqNVI8y2lSOtaSSZeBgeqiertro8Pe/DS8AXUnhXnAQkluM2i2koA+AgUo6/4bUeZXuQ==
+"@sentry-internal/replay-canvas@7.98.0":
+  version "7.98.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/replay-canvas/-/replay-canvas-7.98.0.tgz#108160c49f714a6021368fd60e08b7291fe44450"
+  integrity sha512-vAR6KIycyazaY9HwxG5UONrPTe8jeKtZr6k04svPC8OvcoI0xF+l1jMEYcarffuzKpZlPfssYb5ChHtKuXCB+Q==
   dependencies:
-    "@sentry/core" "7.94.1"
-    "@sentry/replay" "7.94.1"
-    "@sentry/types" "7.94.1"
+    "@sentry/core" "7.98.0"
+    "@sentry/replay" "7.98.0"
+    "@sentry/types" "7.98.0"
+    "@sentry/utils" "7.98.0"
 
-"@sentry-internal/tracing@7.94.1":
-  version "7.94.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.94.1.tgz#27909da03c1541a83002cab655814ec208242b9e"
-  integrity sha512-znxCdrz7tPXm9Bwoe46PW72Zr0Iv7bXT6+b2LNg5fxWiCQVBbQFrMuVvtXEmHxeRRJVEgTh/4TdulB7wrtQIUQ==
+"@sentry-internal/tracing@7.98.0":
+  version "7.98.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.98.0.tgz#812ef7fce6b64794784f3279c66bc6b5cfd29d7f"
+  integrity sha512-FnhD2uMLIAJvv4XsYPv3qsTTtxrImyLxiZacudJyaWFhxoeVQ8bKKbWJ/Ar68FAwqTtjXMeY5evnEBbRMcQlaA==
   dependencies:
-    "@sentry/core" "7.94.1"
-    "@sentry/types" "7.94.1"
-    "@sentry/utils" "7.94.1"
+    "@sentry/core" "7.98.0"
+    "@sentry/types" "7.98.0"
+    "@sentry/utils" "7.98.0"
 
-"@sentry-internal/typescript@7.94.1":
-  version "7.94.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.94.1.tgz#1dd9100c6f253a06143d1b369898e993432a1619"
-  integrity sha512-hgPK7YOmVhJXCfkDwHt3KPDS54jA/DLV4zEo9xuhDtb6YpQIfMY0F7ufsxI2i3JFWiyNmeuWaHzgOt2Jh9jRtQ==
+"@sentry-internal/typescript@7.98.0":
+  version "7.98.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.98.0.tgz#c1032a0563b26cc136a65f9131692004ae1e255d"
+  integrity sha512-7tBQTLcNAPo86Xz2DUWLqjGCo2LjXwGOUGozb7RRTUH5jIVTSzPohkZbsWUkefqHdnCVt1fz9coTig8/p3r9eQ==
 
-"@sentry/browser@7.94.1":
-  version "7.94.1"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.94.1.tgz#d9a4a1c00138bf799e8559fd1df3eff2fa12155b"
-  integrity sha512-IUR8B/AEPEzLijZ4Uo5qJsgmIBnCudBqAWd3zAiuk3TWYYOQUEvleddFxffN3n6pFhGx3ArksB+AIQBruttLGA==
+"@sentry/browser@7.98.0":
+  version "7.98.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.98.0.tgz#f249e6e38351de4cea1142f498e1169006e5dd76"
+  integrity sha512-/MzTS31N2iM6Qwyh4PSpHihgmkVD5xdfE5qi1mTlwQZz5Yz8t7MdMriX8bEDPlLB8sNxl7+D6/+KUJO8akX0nQ==
   dependencies:
-    "@sentry-internal/feedback" "7.94.1"
-    "@sentry-internal/replay-canvas" "7.94.1"
-    "@sentry-internal/tracing" "7.94.1"
-    "@sentry/core" "7.94.1"
-    "@sentry/replay" "7.94.1"
-    "@sentry/types" "7.94.1"
-    "@sentry/utils" "7.94.1"
+    "@sentry-internal/feedback" "7.98.0"
+    "@sentry-internal/replay-canvas" "7.98.0"
+    "@sentry-internal/tracing" "7.98.0"
+    "@sentry/core" "7.98.0"
+    "@sentry/replay" "7.98.0"
+    "@sentry/types" "7.98.0"
+    "@sentry/utils" "7.98.0"
 
-"@sentry/core@7.94.1":
-  version "7.94.1"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.94.1.tgz#3696cd78b2196ac27fda5bcfb2338f46241a3ff8"
-  integrity sha512-4sjiMnkbGpv9O98YHVZe7fHNwwdYl+zLoCOoEOadtrJ1EYYvnK/MSixN2HJF7g/0s22xd4xY958QyNIRVR+Iiw==
+"@sentry/core@7.98.0":
+  version "7.98.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.98.0.tgz#e4f5353bc3986e510b8dd2507355787440d6e25d"
+  integrity sha512-baRUcpCNGyk7cApQHMfqEZJkXdvAKK+z/dVWiMqWc5T5uhzMnPE8/gjP1JZsMtJSQ8g5nHimBdI5TwOyZtxPaA==
   dependencies:
-    "@sentry/types" "7.94.1"
-    "@sentry/utils" "7.94.1"
+    "@sentry/types" "7.98.0"
+    "@sentry/utils" "7.98.0"
 
-"@sentry/node@7.94.1":
-  version "7.94.1"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.94.1.tgz#3e123e546330d89e71004f9f5cad1f9ba7581598"
-  integrity sha512-30nyrfVbY1vNoWg5ptGW+soykU532VvKLuXiKty3SKEXjp5bv23JrCcVtuwp9KrW4josHOJbxZUqeNni85YplQ==
+"@sentry/node@7.98.0":
+  version "7.98.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.98.0.tgz#49d0a46e72f4e6116b4929d033322951e5a7e88b"
+  integrity sha512-9cHW217DnU9wC4iR+QxmY3q59N1Touh23hPMDtpMRmbRHSgrmLMoHTVPhK9zHsXRs0mUeidmMqY1ubAWauQByw==
   dependencies:
-    "@sentry-internal/tracing" "7.94.1"
-    "@sentry/core" "7.94.1"
-    "@sentry/types" "7.94.1"
-    "@sentry/utils" "7.94.1"
+    "@sentry-internal/tracing" "7.98.0"
+    "@sentry/core" "7.98.0"
+    "@sentry/types" "7.98.0"
+    "@sentry/utils" "7.98.0"
 
-"@sentry/replay@7.94.1":
-  version "7.94.1"
-  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.94.1.tgz#cba88d4de453c90aa21db3fd3cb7e66e0ecad0a1"
-  integrity sha512-4wf3CZ1LR2Neh9IiZD0rY8AORS5Dc5HlKfMug026f8KM2aeoDyneM2JFBnPT/ulRnbD2gNciV+kdZiRd5K5jiw==
+"@sentry/replay@7.98.0":
+  version "7.98.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.98.0.tgz#21ba96d501260c1a33bc1af445f5cfbe02d0ba30"
+  integrity sha512-CQabv/3KnpMkpc2TzIquPu5krpjeMRAaDIO0OpTj5SQeH2RqSq3fVWNZkHa8tLsADxcfLFINxqOg2jd1NxvwxA==
   dependencies:
-    "@sentry-internal/tracing" "7.94.1"
-    "@sentry/core" "7.94.1"
-    "@sentry/types" "7.94.1"
-    "@sentry/utils" "7.94.1"
+    "@sentry-internal/tracing" "7.98.0"
+    "@sentry/core" "7.98.0"
+    "@sentry/types" "7.98.0"
+    "@sentry/utils" "7.98.0"
 
-"@sentry/types@7.94.1":
-  version "7.94.1"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.94.1.tgz#97b653a6e73078fc82a2c9d2129e22c7ae1ee248"
-  integrity sha512-A7CdEXFSgGyWv2BT2p9cAvJfb+dypvOtsY8ZvZvdPLUa7kqCV7ndhURUqKjvMBzsL2GParHn3ehDTl2eVc7pvA==
+"@sentry/types@7.98.0":
+  version "7.98.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.98.0.tgz#6a88bf60679aea88ac6cba4d1517958726c2bafb"
+  integrity sha512-pc034ziM0VTETue4bfBcBqTWGy4w0okidtoZJjGVrYAfE95ObZnUGVj/XYIQ3FeCYWIa7NFN2MvdsCS0buwivQ==
 
-"@sentry/utils@7.94.1":
-  version "7.94.1"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.94.1.tgz#1164934cf6e2277fb404744b27de38a04310895d"
-  integrity sha512-gQ2EaMpUU1gGH3S+iqpog9gkXbCo8tlhGYA9a5FUtEtER3D3OAlp8dGFwClwzWDAwzjdLT1+X55zmEptU1cP/A==
+"@sentry/utils@7.98.0":
+  version "7.98.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.98.0.tgz#54355a197f7f71a6d17354a3d043022df402b502"
+  integrity sha512-0/LY+kpHxItVRY0xPDXPXVsKRb95cXsGSQf8sVMtfSjz++0bLL1U4k7PFz1c5s2/Vk0B8hS6duRrgMv6dMIZDw==
   dependencies:
-    "@sentry/types" "7.94.1"
+    "@sentry/types" "7.98.0"
 
 "@sindresorhus/is@^4.0.0":
   version "4.6.0"


### PR DESCRIPTION
This simply included adding some new exports and ignoring some new deprecations.