### PR TITLE
feat: Deprecate class based integrations

### DIFF
--- a/src/integrations.ts
+++ b/src/integrations.ts
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import { Integration } from '@sentry/types';
 import { dynamicRequire } from '@sentry/utils';
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -85,6 +85,20 @@ export {
 } from '@sentry/core';
 export type { SpanStatusType } from '@sentry/core';
 
+export { electronBreadcrumbsIntegration } from './integrations/electron-breadcrumbs';
+export { onUncaughtExceptionIntegration } from './integrations/onuncaughtexception';
+export { mainContextIntegration } from './integrations/main-context';
+export { sentryMinidumpIntegration } from './integrations/sentry-minidump';
+export { electronMinidumpIntegration } from './integrations/electron-minidump';
+export { preloadInjectionIntegration } from './integrations/preload-injection';
+export { mainProcessSessionIntegration } from './integrations/main-process-session';
+export { browserWindowSessionIntegration } from './integrations/browser-window-session';
+export { additionalContextIntegration } from './integrations/additional-context';
+export { electronNetIntegration } from './integrations/net-breadcrumbs';
+export { childProcessIntegration } from './integrations/child-process';
+export { screenshotsIntegration } from './integrations/screenshots';
+export { rendererProfileFromIpc } from './integrations/renderer-profiling';
+
 export type { NodeOptions } from '@sentry/node';
 // eslint-disable-next-line deprecation/deprecation
 export { flush, close, NodeClient, lastEventId } from '@sentry/node';

--- a/src/main/integrations/additional-context.ts
+++ b/src/main/integrations/additional-context.ts
@@ -1,5 +1,5 @@
-import { convertIntegrationFnToClass } from '@sentry/core';
-import { DeviceContext, IntegrationFn } from '@sentry/types';
+import { convertIntegrationFnToClass, defineIntegration } from '@sentry/core';
+import { DeviceContext } from '@sentry/types';
 import { app, screen as electronScreen } from 'electron';
 import { CpuInfo, cpus } from 'os';
 
@@ -22,7 +22,10 @@ const DEFAULT_OPTIONS: AdditionalContextOptions = {
 
 const INTEGRATION_NAME = 'AdditionalContext';
 
-const additionalContext: IntegrationFn = (userOptions: Partial<AdditionalContextOptions> = {}) => {
+/**
+ * Adds additional Electron context to events
+ */
+export const additionalContextIntegration = defineIntegration((userOptions: Partial<AdditionalContextOptions> = {}) => {
   const _lazyDeviceContext: DeviceContext = {};
 
   const options = {
@@ -95,8 +98,12 @@ const additionalContext: IntegrationFn = (userOptions: Partial<AdditionalContext
       return mergeEvents(event, { contexts: { device } });
     },
   };
-};
+});
 
-/** Adds Electron context to events and normalises paths. */
+/**
+ * Adds additional Electron context to events
+ *
+ * @deprecated Use `additionalContextIntegration()z instead
+ */
 // eslint-disable-next-line deprecation/deprecation
-export const AdditionalContext = convertIntegrationFnToClass(INTEGRATION_NAME, additionalContext);
+export const AdditionalContext = convertIntegrationFnToClass(INTEGRATION_NAME, additionalContextIntegration);

--- a/src/main/integrations/browser-window-session.ts
+++ b/src/main/integrations/browser-window-session.ts
@@ -1,5 +1,4 @@
-import { convertIntegrationFnToClass } from '@sentry/core';
-import { IntegrationFn } from '@sentry/types';
+import { convertIntegrationFnToClass, defineIntegration } from '@sentry/core';
 import { app, BrowserWindow } from 'electron';
 
 import { ELECTRON_MAJOR_VERSION } from '../electron-normalize';
@@ -18,7 +17,7 @@ function focusedWindow(): boolean {
   return false;
 }
 
-interface Options {
+export interface Options {
   /**
    * Number of seconds to wait before ending a session after the app loses focus.
    *
@@ -32,7 +31,12 @@ type SessionState = { name: 'active' } | { name: 'inactive' } | { name: 'timeout
 
 const INTEGRATION_NAME = 'BrowserWindowSession';
 
-const browserWindowSession: IntegrationFn = (options: Options = {}) => {
+/**
+ * Tracks sessions as BrowserWindows focus.
+ *
+ * Supports Electron >= v12
+ */
+export const browserWindowSessionIntegration = defineIntegration((options: Options = {}) => {
   if (ELECTRON_MAJOR_VERSION < 12) {
     throw new Error('BrowserWindowSession requires Electron >= v12');
   }
@@ -100,12 +104,14 @@ const browserWindowSession: IntegrationFn = (options: Options = {}) => {
       endSessionOnExit();
     },
   };
-};
+});
 
 /**
- * Tracks sessions as BrowserWindows focused.
+ * Tracks sessions as BrowserWindows focus.
  *
  * Supports Electron >= v12
+ *
+ * @deprecated Use `browserWindowSessionIntegration()` instead
  */
 // eslint-disable-next-line deprecation/deprecation
-export const BrowserWindowSession = convertIntegrationFnToClass(INTEGRATION_NAME, browserWindowSession);
+export const BrowserWindowSession = convertIntegrationFnToClass(INTEGRATION_NAME, browserWindowSessionIntegration);

--- a/src/main/integrations/child-process.ts
+++ b/src/main/integrations/child-process.ts
@@ -1,12 +1,12 @@
-import { addBreadcrumb, captureMessage, convertIntegrationFnToClass } from '@sentry/core';
+import { addBreadcrumb, captureMessage, convertIntegrationFnToClass, defineIntegration } from '@sentry/core';
 import { NodeClient } from '@sentry/node';
-import { IntegrationFn, SeverityLevel } from '@sentry/types';
+import { SeverityLevel } from '@sentry/types';
 
 import { OrBool } from '../../common/types';
 import { EXIT_REASONS, ExitReason, onChildProcessGone, onRendererProcessGone } from '../electron-normalize';
 import { ElectronMainOptions } from '../sdk';
 
-interface ChildProcessOptions {
+export interface ChildProcessOptions {
   /** Child process events that generate breadcrumbs */
   breadcrumbs: Readonly<ExitReason[]>;
   /** Child process events that generate Sentry events */
@@ -38,7 +38,10 @@ function getMessageAndSeverity(reason: ExitReason, proc?: string): { message: st
 
 const INTEGRATION_NAME = 'ChildProcess';
 
-const childProcess: IntegrationFn = (userOptions: Partial<OrBool<ChildProcessOptions>> = {}) => {
+/**
+ * Adds breadcrumbs for Electron child process events.
+ */
+export const childProcessIntegration = defineIntegration((userOptions: Partial<OrBool<ChildProcessOptions>> = {}) => {
   const { breadcrumbs, events } = userOptions;
 
   const options: ChildProcessOptions = {
@@ -102,8 +105,12 @@ const childProcess: IntegrationFn = (userOptions: Partial<OrBool<ChildProcessOpt
       }
     },
   };
-};
+});
 
-/** Adds breadcrumbs for Electron events. */
+/**
+ * Adds breadcrumbs for Electron child process events.
+ *
+ * @deprecated Use `childProcessIntegration()` instead
+ */
 // eslint-disable-next-line deprecation/deprecation
-export const ChildProcess = convertIntegrationFnToClass(INTEGRATION_NAME, childProcess);
+export const ChildProcess = convertIntegrationFnToClass(INTEGRATION_NAME, childProcessIntegration);

--- a/src/main/integrations/electron-minidump.ts
+++ b/src/main/integrations/electron-minidump.ts
@@ -1,6 +1,6 @@
-import { applyScopeDataToEvent, convertIntegrationFnToClass, getCurrentScope } from '@sentry/core';
+import { applyScopeDataToEvent, convertIntegrationFnToClass, defineIntegration, getCurrentScope } from '@sentry/core';
 import { NodeClient, NodeOptions } from '@sentry/node';
-import { Event, IntegrationFn, ScopeData } from '@sentry/types';
+import { Event, ScopeData } from '@sentry/types';
 import { logger, makeDsn, SentryError, uuid4 } from '@sentry/utils';
 import { app, crashReporter } from 'electron';
 
@@ -95,7 +95,10 @@ export function minidumpUrlFromDsn(dsn: string): string | undefined {
 
 const INTEGRATION_NAME = 'ElectronMinidump';
 
-const electronMinidump: IntegrationFn = () => {
+/**
+ * Sends minidumps via the Electron built-in uploader.
+ */
+export const electronMinidumpIntegration = defineIntegration(() => {
   /** Counter used to ensure no race condition when updating extra params */
   let updateEpoch = 0;
   let customRelease: string | undefined;
@@ -212,8 +215,12 @@ const electronMinidump: IntegrationFn = () => {
       }, logger.error);
     },
   };
-};
+});
 
-/** Sends minidumps via the Electron built-in uploader. */
+/**
+ * Sends minidumps via the Electron built-in uploader.
+ *
+ * @deprecated Use `electronMinidumpIntegration()` instead
+ */
 // eslint-disable-next-line deprecation/deprecation
-export const ElectronMinidump = convertIntegrationFnToClass(INTEGRATION_NAME, electronMinidump);
+export const ElectronMinidump = convertIntegrationFnToClass(INTEGRATION_NAME, electronMinidumpIntegration);

--- a/src/main/integrations/index.ts
+++ b/src/main/integrations/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 export { ElectronBreadcrumbs } from './electron-breadcrumbs';
 export { OnUncaughtException } from './onuncaughtexception';
 export { MainContext } from './main-context';

--- a/src/main/integrations/main-context.ts
+++ b/src/main/integrations/main-context.ts
@@ -1,5 +1,4 @@
-import { convertIntegrationFnToClass } from '@sentry/core';
-import { IntegrationFn } from '@sentry/types';
+import { convertIntegrationFnToClass, defineIntegration } from '@sentry/core';
 import { app } from 'electron';
 
 import { mergeEvents, normalizeEvent } from '../../common';
@@ -7,7 +6,8 @@ import { getEventDefaults } from '../context';
 
 const INTEGRATION_NAME = 'MainContext';
 
-const mainContext: IntegrationFn = () => {
+/** Adds Electron context to events and normalises paths. */
+export const mainContextIntegration = defineIntegration(() => {
   return {
     name: INTEGRATION_NAME,
     setupOnce() {
@@ -20,8 +20,12 @@ const mainContext: IntegrationFn = () => {
       return mergeEvents(defaults, normalized);
     },
   };
-};
+});
 
-/** Adds Electron context to events and normalises paths. */
+/**
+ * Adds Electron context to events and normalises paths.
+ *
+ * @deprecated Use `mainContextIntegration()` instead
+ */
 // eslint-disable-next-line deprecation/deprecation
-export const MainContext = convertIntegrationFnToClass(INTEGRATION_NAME, mainContext);
+export const MainContext = convertIntegrationFnToClass(INTEGRATION_NAME, mainContextIntegration);

--- a/src/main/integrations/main-process-session.ts
+++ b/src/main/integrations/main-process-session.ts
@@ -1,9 +1,8 @@
-import { convertIntegrationFnToClass } from '@sentry/core';
-import { IntegrationFn } from '@sentry/types';
+import { convertIntegrationFnToClass, defineIntegration } from '@sentry/core';
 
 import { endSessionOnExit, startSession } from '../sessions';
 
-interface Options {
+export interface Options {
   /**
    * Whether sessions should be sent immediately on creation
    *
@@ -14,7 +13,8 @@ interface Options {
 
 const INTEGRATION_NAME = 'MainProcessSession';
 
-const mainProcessSession: IntegrationFn = (options: Options = {}) => {
+/** Tracks sessions as the main process lifetime. */
+export const mainProcessSessionIntegration = defineIntegration((options: Options = {}) => {
   return {
     name: INTEGRATION_NAME,
     setupOnce() {
@@ -25,8 +25,12 @@ const mainProcessSession: IntegrationFn = (options: Options = {}) => {
       endSessionOnExit();
     },
   };
-};
+});
 
-/** Tracks sessions as the main process lifetime. */
+/**
+ * Tracks sessions as the main process lifetime.
+ *
+ * @deprecated Use `mainProcessSessionIntegration()` instead
+ */
 // eslint-disable-next-line deprecation/deprecation
-export const MainProcessSession = convertIntegrationFnToClass(INTEGRATION_NAME, mainProcessSession);
+export const MainProcessSession = convertIntegrationFnToClass(INTEGRATION_NAME, mainProcessSessionIntegration);

--- a/src/main/integrations/net-breadcrumbs.ts
+++ b/src/main/integrations/net-breadcrumbs.ts
@@ -2,11 +2,12 @@ import {
   addBreadcrumb,
   /* eslint-disable deprecation/deprecation */
   convertIntegrationFnToClass,
+  defineIntegration,
   getClient,
   getCurrentScope,
   getDynamicSamplingContextFromClient,
 } from '@sentry/core';
-import { DynamicSamplingContext, IntegrationFn, Span, TracePropagationTargets } from '@sentry/types';
+import { DynamicSamplingContext, Span, TracePropagationTargets } from '@sentry/types';
 import {
   dynamicSamplingContextToSentryBaggageHeader,
   fill,
@@ -20,7 +21,7 @@ import * as urlModule from 'url';
 
 type ShouldTraceFn = (method: string, url: string) => boolean;
 
-interface NetOptions {
+export interface NetOptions {
   /**
    * Whether breadcrumbs should be captured for net requests
    *
@@ -109,7 +110,6 @@ type RequestOptions = string | ClientRequestConstructorOptions;
 type RequestMethod = (opt: RequestOptions) => ClientRequest;
 type WrappedRequestMethodFactory = (original: RequestMethod) => RequestMethod;
 
-/** */
 function createWrappedRequestFactory(
   options: NetOptions,
   tracePropagationTargets: TracePropagationTargets | undefined,
@@ -273,7 +273,10 @@ function addRequestBreadcrumb(
 
 const INTEGRATION_NAME = 'Net';
 
-const net: IntegrationFn = (options: NetOptions = {}) => {
+/**
+ * Electron 'net' module integration
+ */
+export const electronNetIntegration = defineIntegration((options: NetOptions = {}) => {
   return {
     name: INTEGRATION_NAME,
     setupOnce() {
@@ -290,8 +293,12 @@ const net: IntegrationFn = (options: NetOptions = {}) => {
       fill(electronNet, 'request', createWrappedRequestFactory(options, clientOptions?.tracePropagationTargets));
     },
   };
-};
+});
 
-/** http module integration */
+/**
+ * Electron 'net' module integration
+ *
+ * @deprecated Use `electronNetIntegration()` instead
+ */
 // eslint-disable-next-line deprecation/deprecation
-export const Net = convertIntegrationFnToClass(INTEGRATION_NAME, net);
+export const Net = convertIntegrationFnToClass(INTEGRATION_NAME, electronNetIntegration);

--- a/src/main/integrations/onuncaughtexception.ts
+++ b/src/main/integrations/onuncaughtexception.ts
@@ -1,11 +1,12 @@
-import { convertIntegrationFnToClass, getCurrentScope } from '@sentry/core';
+import { convertIntegrationFnToClass, defineIntegration, getCurrentScope } from '@sentry/core';
 import { NodeClient } from '@sentry/node';
-import { Event, IntegrationFn } from '@sentry/types';
+import { Event } from '@sentry/types';
 import { dialog } from 'electron';
 
 const INTEGRATION_NAME = 'OnUncaughtException';
 
-const onUncaughtException: IntegrationFn = () => {
+/** Capture unhandled errors. */
+export const onUncaughtExceptionIntegration = defineIntegration(() => {
   return {
     name: INTEGRATION_NAME,
     setupOnce() {
@@ -60,8 +61,12 @@ const onUncaughtException: IntegrationFn = () => {
       });
     },
   };
-};
+});
 
-/** Capture unhandled errors. */
+/**
+ * Capture unhandled errors.
+ *
+ * @deprecated Use `onUncaughtExceptionIntegration()` instead
+ */
 // eslint-disable-next-line deprecation/deprecation
-export const OnUncaughtException = convertIntegrationFnToClass(INTEGRATION_NAME, onUncaughtException);
+export const OnUncaughtException = convertIntegrationFnToClass(INTEGRATION_NAME, onUncaughtExceptionIntegration);

--- a/src/main/integrations/preload-injection.ts
+++ b/src/main/integrations/preload-injection.ts
@@ -1,5 +1,4 @@
-import { convertIntegrationFnToClass } from '@sentry/core';
-import { IntegrationFn } from '@sentry/types';
+import { convertIntegrationFnToClass, defineIntegration } from '@sentry/core';
 import { logger } from '@sentry/utils';
 import { app } from 'electron';
 import { existsSync } from 'fs';
@@ -33,7 +32,12 @@ function getPreloadPath(): string | number | undefined {
 
 const INTEGRATION_NAME = 'PreloadInjection';
 
-const preloadInjection: IntegrationFn = () => {
+/**
+ * Injects the preload script into the provided sessions.
+ *
+ * Defaults to injecting into the defaultSession
+ */
+export const preloadInjectionIntegration = defineIntegration(() => {
   return {
     name: INTEGRATION_NAME,
     setupOnce() {
@@ -65,12 +69,14 @@ const preloadInjection: IntegrationFn = () => {
       });
     },
   };
-};
+});
 
 /**
  * Injects the preload script into the provided sessions.
  *
  * Defaults to injecting into the defaultSession
+ *
+ * @deprecated Use `preloadInjectionIntegration()` instead
  */
 // eslint-disable-next-line deprecation/deprecation
-export const PreloadInjection = convertIntegrationFnToClass(INTEGRATION_NAME, preloadInjection);
+export const PreloadInjection = convertIntegrationFnToClass(INTEGRATION_NAME, preloadInjectionIntegration);

--- a/src/main/integrations/renderer-profiling.ts
+++ b/src/main/integrations/renderer-profiling.ts
@@ -1,5 +1,5 @@
-import { convertIntegrationFnToClass } from '@sentry/core';
-import { Event, IntegrationFn, Profile } from '@sentry/types';
+import { convertIntegrationFnToClass, defineIntegration } from '@sentry/core';
+import { Event, Profile } from '@sentry/types';
 import { forEachEnvelopeItem, LRUMap } from '@sentry/utils';
 import { app } from 'electron';
 
@@ -56,7 +56,10 @@ function addJsProfilingHeader(
 
 const INTEGRATION_NAME = 'RendererProfiling';
 
-const rendererProfiling: IntegrationFn = () => {
+/**
+ * Injects 'js-profiling' document policy headers and ensures that profiles get forwarded with transactions
+ */
+export const rendererProfilingIntegration = defineIntegration(() => {
   return {
     name: INTEGRATION_NAME,
     setupOnce() {
@@ -122,10 +125,12 @@ const rendererProfiling: IntegrationFn = () => {
       });
     },
   };
-};
+});
 
 /**
  * Injects 'js-profiling' document policy headers and ensures that profiles get forwarded with transactions
+ *
+ * @deprecated Use `rendererProfilingIntegration()` instead
  */
 // eslint-disable-next-line deprecation/deprecation
-export const RendererProfiling = convertIntegrationFnToClass(INTEGRATION_NAME, rendererProfiling);
+export const RendererProfiling = convertIntegrationFnToClass(INTEGRATION_NAME, rendererProfilingIntegration);

--- a/src/main/integrations/screenshots.ts
+++ b/src/main/integrations/screenshots.ts
@@ -1,5 +1,4 @@
-import { convertIntegrationFnToClass } from '@sentry/core';
-import { IntegrationFn } from '@sentry/types';
+import { convertIntegrationFnToClass, defineIntegration } from '@sentry/core';
 import { logger } from '@sentry/utils';
 import { BrowserWindow } from 'electron';
 
@@ -8,7 +7,10 @@ import { ElectronMainOptions } from '../sdk';
 
 const INTEGRATION_NAME = 'Screenshots';
 
-const screenshots: IntegrationFn = () => {
+/**
+ * Captures and attaches screenshots to events
+ */
+export const screenshotsIntegration = defineIntegration(() => {
   return {
     name: INTEGRATION_NAME,
     setupOnce() {
@@ -49,8 +51,12 @@ const screenshots: IntegrationFn = () => {
       return event;
     },
   };
-};
+});
 
-/** Adds Screenshots to events */
+/**
+ * Adds Screenshots to events
+ *
+ * @deprecated Use `screenshotsIntegration()` instead
+ */
 // eslint-disable-next-line deprecation/deprecation
-export const Screenshots = convertIntegrationFnToClass(INTEGRATION_NAME, screenshots);
+export const Screenshots = convertIntegrationFnToClass(INTEGRATION_NAME, screenshotsIntegration);

--- a/src/main/integrations/sentry-minidump/index.ts
+++ b/src/main/integrations/sentry-minidump/index.ts
@@ -1,6 +1,13 @@
-import { applyScopeDataToEvent, captureEvent, convertIntegrationFnToClass, getCurrentScope, Scope } from '@sentry/core';
+import {
+  applyScopeDataToEvent,
+  captureEvent,
+  convertIntegrationFnToClass,
+  defineIntegration,
+  getCurrentScope,
+  Scope,
+} from '@sentry/core';
 import { NodeClient } from '@sentry/node';
-import { Event, IntegrationFn, ScopeData } from '@sentry/types';
+import { Event, ScopeData } from '@sentry/types';
 import { logger, SentryError } from '@sentry/utils';
 import { app, crashReporter } from 'electron';
 
@@ -21,7 +28,10 @@ interface PreviousRun {
 
 const INTEGRATION_NAME = 'SentryMinidump';
 
-const sentryMinidump: IntegrationFn = () => {
+/**
+ * Sends minidumps via the Sentry uploader
+ */
+export const sentryMinidumpIntegration = defineIntegration(() => {
   /** Store to persist context information beyond application crashes. */
   let scopeStore: BufferedWriteStore<PreviousRun> | undefined;
   // We need to store the scope in a variable here so it can be attached to minidumps
@@ -232,8 +242,12 @@ const sentryMinidump: IntegrationFn = () => {
         .catch((error) => logger.error(error));
     },
   };
-};
+});
 
-/** Sends minidumps via the Sentry uploader */
+/**
+ * Sends minidumps via the Sentry uploader
+ *
+ * @deprecated Use `sentryMinidumpIntegration()` instead
+ */
 // eslint-disable-next-line deprecation/deprecation
-export const SentryMinidump = convertIntegrationFnToClass(INTEGRATION_NAME, sentryMinidump);
+export const SentryMinidump = convertIntegrationFnToClass(INTEGRATION_NAME, sentryMinidumpIntegration);

--- a/src/main/sdk.ts
+++ b/src/main/sdk.ts
@@ -6,34 +6,32 @@ import { Integration, Options } from '@sentry/types';
 import { Session, session, WebContents } from 'electron';
 
 import { getDefaultEnvironment, getDefaultReleaseName, getSdkInfo } from './context';
-import {
-  AdditionalContext,
-  ChildProcess,
-  ElectronBreadcrumbs,
-  MainContext,
-  MainProcessSession,
-  Net,
-  OnUncaughtException,
-  PreloadInjection,
-  RendererProfiling,
-  Screenshots,
-  SentryMinidump,
-} from './integrations';
+import { additionalContextIntegration } from './integrations/additional-context';
+import { childProcessIntegration } from './integrations/child-process';
+import { electronBreadcrumbsIntegration } from './integrations/electron-breadcrumbs';
+import { mainContextIntegration } from './integrations/main-context';
+import { mainProcessSessionIntegration } from './integrations/main-process-session';
+import { electronNetIntegration } from './integrations/net-breadcrumbs';
+import { onUncaughtExceptionIntegration } from './integrations/onuncaughtexception';
+import { preloadInjectionIntegration } from './integrations/preload-injection';
+import { rendererProfilingIntegration } from './integrations/renderer-profiling';
+import { screenshotsIntegration } from './integrations/screenshots';
+import { sentryMinidumpIntegration } from './integrations/sentry-minidump';
 import { configureIPC } from './ipc';
 import { defaultStackParser } from './stack-parse';
 import { ElectronOfflineTransportOptions, makeElectronOfflineTransport } from './transports/electron-offline-net';
 
 export const defaultIntegrations: Integration[] = [
-  new SentryMinidump(),
-  new ElectronBreadcrumbs(),
-  new Net(),
-  new MainContext(),
-  new ChildProcess(),
-  new OnUncaughtException(),
-  new PreloadInjection(),
-  new AdditionalContext(),
-  new Screenshots(),
-  new RendererProfiling(),
+  sentryMinidumpIntegration(),
+  electronBreadcrumbsIntegration(),
+  electronNetIntegration(),
+  mainContextIntegration(),
+  childProcessIntegration(),
+  onUncaughtExceptionIntegration(),
+  preloadInjectionIntegration(),
+  additionalContextIntegration(),
+  screenshotsIntegration(),
+  rendererProfilingIntegration(),
   // eslint-disable-next-line deprecation/deprecation
   ...defaultNodeIntegrations.filter(
     (integration) => integration.name !== 'OnUncaughtException' && integration.name !== 'Context',
@@ -118,7 +116,7 @@ export function init(userOptions: ElectronMainOptions): void {
   // Unless autoSessionTracking is specifically disabled, we track sessions as the
   // lifetime of the Electron main process
   if (options.autoSessionTracking !== false) {
-    defaults.push(new MainProcessSession());
+    defaults.push(mainProcessSessionIntegration());
     // We don't want nodejs autoSessionTracking
     options.autoSessionTracking = false;
   }

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -82,6 +82,9 @@ export {
 } from '@sentry/core';
 export type { SpanStatusType } from '@sentry/core';
 
+export { scopeToMainIntegration } from './integrations/scope-to-main';
+export { metricsAggregatorIntegration } from './integrations/metrics-aggregator';
+
 import { metrics as coreMetrics } from '@sentry/core';
 
 import { MetricsAggregator } from './integrations/metrics-aggregator';

--- a/src/renderer/integrations/index.ts
+++ b/src/renderer/integrations/index.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line deprecation/deprecation
 export { ScopeToMain } from './scope-to-main';
 // eslint-disable-next-line deprecation/deprecation
 export { EventToMain } from './event-to-main';

--- a/src/renderer/integrations/metrics-aggregator.ts
+++ b/src/renderer/integrations/metrics-aggregator.ts
@@ -6,7 +6,12 @@ import { ElectronRendererMetricsAggregator } from '../metrics';
 
 const INTEGRATION_NAME = 'MetricsAggregator';
 
-const metricsAggregatorIntegration: IntegrationFn = () => {
+/**
+ * Enables Sentry metrics monitoring.
+ *
+ * @experimental This API is experimental and might having breaking changes in the future.
+ */
+export const metricsAggregatorIntegration: IntegrationFn = () => {
   return {
     name: INTEGRATION_NAME,
     setupOnce() {
@@ -22,6 +27,8 @@ const metricsAggregatorIntegration: IntegrationFn = () => {
  * Enables Sentry metrics monitoring.
  *
  * @experimental This API is experimental and might having breaking changes in the future.
+ *
+ * @deprecated Use `metricsAggregatorIntegration()` instead
  */
 // eslint-disable-next-line deprecation/deprecation
 export const MetricsAggregator = convertIntegrationFnToClass(INTEGRATION_NAME, metricsAggregatorIntegration);

--- a/src/renderer/integrations/scope-to-main.ts
+++ b/src/renderer/integrations/scope-to-main.ts
@@ -1,12 +1,14 @@
-import { convertIntegrationFnToClass, getCurrentScope } from '@sentry/core';
-import { IntegrationFn } from '@sentry/types';
+import { convertIntegrationFnToClass, defineIntegration, getCurrentScope } from '@sentry/core';
 import { normalize } from '@sentry/utils';
 
 import { getIPC } from '../ipc';
 
 const INTEGRATION_NAME = 'ScopeToMain';
 
-const scopeToMain: IntegrationFn = () => {
+/**
+ * Passes scope changes to the main process.
+ */
+export const scopeToMainIntegration = defineIntegration(() => {
   return {
     name: INTEGRATION_NAME,
     setupOnce() {
@@ -25,10 +27,12 @@ const scopeToMain: IntegrationFn = () => {
       }
     },
   };
-};
+});
 
 /**
  * Passes scope changes to the main process.
+ *
+ * @deprecated Use `scopeToMainIntegration()` instead
  */
 // eslint-disable-next-line deprecation/deprecation
-export const ScopeToMain = convertIntegrationFnToClass(INTEGRATION_NAME, scopeToMain);
+export const ScopeToMain = convertIntegrationFnToClass(INTEGRATION_NAME, scopeToMainIntegration);

--- a/src/renderer/sdk.ts
+++ b/src/renderer/sdk.ts
@@ -8,13 +8,17 @@ import { logger } from '@sentry/utils';
 
 import { ensureProcess, RendererProcessAnrOptions } from '../common';
 import { enableAnrRendererMessages } from './anr';
-import { ScopeToMain } from './integrations';
-import { MetricsAggregator } from './integrations/metrics-aggregator';
+import { metricsAggregatorIntegration } from './integrations/metrics-aggregator';
+import { scopeToMainIntegration } from './integrations/scope-to-main';
 import { electronRendererStackParser } from './stack-parse';
 import { makeRendererTransport } from './transport';
 
-// eslint-disable-next-line deprecation/deprecation
-export const defaultIntegrations = [...defaultBrowserIntegrations, new ScopeToMain(), new MetricsAggregator()];
+export const defaultIntegrations = [
+  // eslint-disable-next-line deprecation/deprecation
+  ...defaultBrowserIntegrations,
+  scopeToMainIntegration(),
+  metricsAggregatorIntegration(),
+];
 
 interface ElectronRendererOptions extends BrowserOptions {
   /**

--- a/test/e2e/test-apps/native-electron/gpu/src/main.js
+++ b/test/e2e/test-apps/native-electron/gpu/src/main.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, Integrations } = require('@sentry/electron');
+const { init, electronMinidumpIntegration } = require('@sentry/electron');
 
 app.commandLine.appendSwitch('enable-crashpad');
 
@@ -9,7 +9,7 @@ init({
   dsn: '__DSN__',
   debug: true,
   autoSessionTracking: false,
-  integrations: [new Integrations.ElectronMinidump()],
+  integrations: [electronMinidumpIntegration()],
   initialScope: { user: { username: 'some_user' } },
   onFatalError: () => {},
 });

--- a/test/e2e/test-apps/native-electron/gpu/src/main.js
+++ b/test/e2e/test-apps/native-electron/gpu/src/main.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, electronMinidumpIntegration } = require('@sentry/electron');
+const { init, electronMinidumpIntegration } = require('@sentry/electron/main');
 
 app.commandLine.appendSwitch('enable-crashpad');
 

--- a/test/e2e/test-apps/native-electron/main-custom-release/src/main.js
+++ b/test/e2e/test-apps/native-electron/main-custom-release/src/main.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, Integrations } = require('@sentry/electron');
+const { init, electronMinidumpIntegration } = require('@sentry/electron');
 
 app.commandLine.appendSwitch('enable-crashpad');
 
@@ -10,7 +10,7 @@ init({
   debug: true,
   release: 'custom-name',
   autoSessionTracking: false,
-  integrations: [new Integrations.ElectronMinidump()],
+  integrations: [electronMinidumpIntegration()],
   initialScope: { user: { username: 'some_user' } },
   onFatalError: () => {},
 });

--- a/test/e2e/test-apps/native-electron/main-custom-release/src/main.js
+++ b/test/e2e/test-apps/native-electron/main-custom-release/src/main.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, electronMinidumpIntegration } = require('@sentry/electron');
+const { init, electronMinidumpIntegration } = require('@sentry/electron/main');
 
 app.commandLine.appendSwitch('enable-crashpad');
 

--- a/test/e2e/test-apps/native-electron/main/src/main.js
+++ b/test/e2e/test-apps/native-electron/main/src/main.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, Integrations } = require('@sentry/electron');
+const { init, electronMinidumpIntegration } = require('@sentry/electron');
 
 app.commandLine.appendSwitch('enable-crashpad');
 
@@ -9,7 +9,7 @@ init({
   dsn: '__DSN__',
   debug: true,
   autoSessionTracking: false,
-  integrations: [new Integrations.ElectronMinidump()],
+  integrations: [electronMinidumpIntegration()],
   initialScope: { user: { username: 'some_user' } },
   onFatalError: () => {},
 });

--- a/test/e2e/test-apps/native-electron/main/src/main.js
+++ b/test/e2e/test-apps/native-electron/main/src/main.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, electronMinidumpIntegration } = require('@sentry/electron');
+const { init, electronMinidumpIntegration } = require('@sentry/electron/main');
 
 app.commandLine.appendSwitch('enable-crashpad');
 

--- a/test/e2e/test-apps/native-electron/renderer-custom-release/src/main.js
+++ b/test/e2e/test-apps/native-electron/renderer-custom-release/src/main.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, Integrations } = require('@sentry/electron');
+const { init, electronMinidumpIntegration } = require('@sentry/electron');
 
 app.commandLine.appendSwitch('enable-crashpad');
 
@@ -10,7 +10,7 @@ init({
   debug: true,
   release: 'custom-name',
   autoSessionTracking: false,
-  integrations: [new Integrations.ElectronMinidump()],
+  integrations: [electronMinidumpIntegration()],
   initialScope: { user: { username: 'some_user' } },
   onFatalError: () => {},
 });

--- a/test/e2e/test-apps/native-electron/renderer-custom-release/src/main.js
+++ b/test/e2e/test-apps/native-electron/renderer-custom-release/src/main.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, electronMinidumpIntegration } = require('@sentry/electron');
+const { init, electronMinidumpIntegration } = require('@sentry/electron/main');
 
 app.commandLine.appendSwitch('enable-crashpad');
 

--- a/test/e2e/test-apps/native-electron/renderer/src/main.js
+++ b/test/e2e/test-apps/native-electron/renderer/src/main.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, Integrations } = require('@sentry/electron');
+const { init, electronMinidumpIntegration } = require('@sentry/electron');
 
 app.commandLine.appendSwitch('enable-crashpad');
 
@@ -9,7 +9,7 @@ init({
   dsn: '__DSN__',
   debug: true,
   autoSessionTracking: false,
-  integrations: [new Integrations.ElectronMinidump()],
+  integrations: [electronMinidumpIntegration()],
   initialScope: { user: { username: 'some_user' } },
   onFatalError: () => {},
 });

--- a/test/e2e/test-apps/native-electron/renderer/src/main.js
+++ b/test/e2e/test-apps/native-electron/renderer/src/main.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, electronMinidumpIntegration } = require('@sentry/electron');
+const { init, electronMinidumpIntegration } = require('@sentry/electron/main');
 
 app.commandLine.appendSwitch('enable-crashpad');
 

--- a/test/e2e/test-apps/other/child-process/src/main.js
+++ b/test/e2e/test-apps/other/child-process/src/main.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, childProcessIntegration } = require('@sentry/electron');
+const { init, childProcessIntegration } = require('@sentry/electron/main');
 
 init({
   dsn: '__DSN__',

--- a/test/e2e/test-apps/other/child-process/src/main.js
+++ b/test/e2e/test-apps/other/child-process/src/main.js
@@ -1,13 +1,13 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, Integrations } = require('@sentry/electron');
+const { init, childProcessIntegration } = require('@sentry/electron');
 
 init({
   dsn: '__DSN__',
   debug: true,
   autoSessionTracking: false,
-  integrations: [new Integrations.ChildProcess({ events: ['killed'] })],
+  integrations: [childProcessIntegration({ events: ['killed'] })],
   onFatalError: () => {},
 });
 

--- a/test/e2e/test-apps/sessions/abnormal-exit-electron-uploader/src/main.js
+++ b/test/e2e/test-apps/sessions/abnormal-exit-electron-uploader/src/main.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, electronMinidumpIntegration, mainProcessSessionIntegration } = require('@sentry/electron');
+const { init, electronMinidumpIntegration, mainProcessSessionIntegration } = require('@sentry/electron/main');
 
 app.commandLine.appendSwitch('enable-crashpad');
 

--- a/test/e2e/test-apps/sessions/abnormal-exit-electron-uploader/src/main.js
+++ b/test/e2e/test-apps/sessions/abnormal-exit-electron-uploader/src/main.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, Integrations } = require('@sentry/electron');
+const { init, electronMinidumpIntegration, mainProcessSessionIntegration } = require('@sentry/electron');
 
 app.commandLine.appendSwitch('enable-crashpad');
 
@@ -9,8 +9,8 @@ init({
   dsn: '__DSN__',
   debug: true,
   integrations: (defaults) => [
-    new Integrations.ElectronMinidump(),
-    new Integrations.MainProcessSession({ sendOnCreate: true }),
+    electronMinidumpIntegration(),
+    mainProcessSessionIntegration({ sendOnCreate: true }),
     ...defaults,
   ],
   initialScope: { user: { username: 'some_user' } },

--- a/test/e2e/test-apps/sessions/abnormal-exit/src/main.js
+++ b/test/e2e/test-apps/sessions/abnormal-exit/src/main.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, mainProcessSessionIntegration } = require('@sentry/electron');
+const { init, mainProcessSessionIntegration } = require('@sentry/electron/main');
 
 init({
   dsn: '__DSN__',

--- a/test/e2e/test-apps/sessions/abnormal-exit/src/main.js
+++ b/test/e2e/test-apps/sessions/abnormal-exit/src/main.js
@@ -1,12 +1,12 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, Integrations } = require('@sentry/electron');
+const { init, mainProcessSessionIntegration } = require('@sentry/electron');
 
 init({
   dsn: '__DSN__',
   debug: true,
-  integrations: [new Integrations.MainProcessSession({ sendOnCreate: true })],
+  integrations: [mainProcessSessionIntegration({ sendOnCreate: true })],
   onFatalError: () => {},
 });
 

--- a/test/e2e/test-apps/sessions/good/src/main.js
+++ b/test/e2e/test-apps/sessions/good/src/main.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, mainProcessSessionIntegration } = require('@sentry/electron');
+const { init, mainProcessSessionIntegration } = require('@sentry/electron/main');
 
 init({
   dsn: '__DSN__',

--- a/test/e2e/test-apps/sessions/good/src/main.js
+++ b/test/e2e/test-apps/sessions/good/src/main.js
@@ -1,12 +1,12 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, Integrations } = require('@sentry/electron');
+const { init, mainProcessSessionIntegration } = require('@sentry/electron');
 
 init({
   dsn: '__DSN__',
   debug: true,
-  integrations: [new Integrations.MainProcessSession({ sendOnCreate: true })],
+  integrations: [mainProcessSessionIntegration({ sendOnCreate: true })],
   onFatalError: () => {},
 });
 

--- a/test/e2e/test-apps/sessions/javascript-error/src/main.js
+++ b/test/e2e/test-apps/sessions/javascript-error/src/main.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, mainProcessSessionIntegration } = require('@sentry/electron');
+const { init, mainProcessSessionIntegration } = require('@sentry/electron/main');
 
 init({
   dsn: '__DSN__',

--- a/test/e2e/test-apps/sessions/javascript-error/src/main.js
+++ b/test/e2e/test-apps/sessions/javascript-error/src/main.js
@@ -1,12 +1,12 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, Integrations } = require('@sentry/electron');
+const { init, mainProcessSessionIntegration } = require('@sentry/electron');
 
 init({
   dsn: '__DSN__',
   debug: true,
-  integrations: [new Integrations.MainProcessSession({ sendOnCreate: true })],
+  integrations: [mainProcessSessionIntegration({ sendOnCreate: true })],
   onFatalError: () => {},
 });
 

--- a/test/e2e/test-apps/sessions/native-crash-main-electron-uploader/src/main.js
+++ b/test/e2e/test-apps/sessions/native-crash-main-electron-uploader/src/main.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, Integrations } = require('@sentry/electron');
+const { init, mainProcessSessionIntegration, electronMinidumpIntegration } = require('@sentry/electron');
 
 app.commandLine.appendSwitch('enable-crashpad');
 
@@ -9,8 +9,8 @@ init({
   dsn: '__DSN__',
   debug: true,
   integrations: (defaults) => [
-    new Integrations.ElectronMinidump(),
-    new Integrations.MainProcessSession({ sendOnCreate: true }),
+    electronMinidumpIntegration(),
+    mainProcessSessionIntegration({ sendOnCreate: true }),
     ...defaults,
   ],
   initialScope: { user: { username: 'some_user' } },

--- a/test/e2e/test-apps/sessions/native-crash-main-electron-uploader/src/main.js
+++ b/test/e2e/test-apps/sessions/native-crash-main-electron-uploader/src/main.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, mainProcessSessionIntegration, electronMinidumpIntegration } = require('@sentry/electron');
+const { init, mainProcessSessionIntegration, electronMinidumpIntegration } = require('@sentry/electron/main');
 
 app.commandLine.appendSwitch('enable-crashpad');
 

--- a/test/e2e/test-apps/sessions/native-crash-main/src/main.js
+++ b/test/e2e/test-apps/sessions/native-crash-main/src/main.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, mainProcessSessionIntegration } = require('@sentry/electron');
+const { init, mainProcessSessionIntegration } = require('@sentry/electron/main');
 
 init({
   dsn: '__DSN__',

--- a/test/e2e/test-apps/sessions/native-crash-main/src/main.js
+++ b/test/e2e/test-apps/sessions/native-crash-main/src/main.js
@@ -1,12 +1,12 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, Integrations } = require('@sentry/electron');
+const { init, mainProcessSessionIntegration } = require('@sentry/electron');
 
 init({
   dsn: '__DSN__',
   debug: true,
-  integrations: [new Integrations.MainProcessSession({ sendOnCreate: true })],
+  integrations: [mainProcessSessionIntegration({ sendOnCreate: true })],
   onFatalError: () => {},
 });
 

--- a/test/e2e/test-apps/sessions/native-crash-renderer-electron-uploader/src/main.js
+++ b/test/e2e/test-apps/sessions/native-crash-renderer-electron-uploader/src/main.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, Integrations } = require('@sentry/electron');
+const { init, mainProcessSessionIntegration, electronMinidumpIntegration } = require('@sentry/electron');
 
 app.commandLine.appendSwitch('enable-crashpad');
 
@@ -9,8 +9,8 @@ init({
   dsn: '__DSN__',
   debug: true,
   integrations: (defaults) => [
-    new Integrations.ElectronMinidump(),
-    new Integrations.MainProcessSession({ sendOnCreate: true }),
+    electronMinidumpIntegration(),
+    mainProcessSessionIntegration({ sendOnCreate: true }),
     ...defaults,
   ],
   initialScope: { user: { username: 'some_user' } },

--- a/test/e2e/test-apps/sessions/native-crash-renderer-electron-uploader/src/main.js
+++ b/test/e2e/test-apps/sessions/native-crash-renderer-electron-uploader/src/main.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, mainProcessSessionIntegration, electronMinidumpIntegration } = require('@sentry/electron');
+const { init, mainProcessSessionIntegration, electronMinidumpIntegration } = require('@sentry/electron/main');
 
 app.commandLine.appendSwitch('enable-crashpad');
 

--- a/test/e2e/test-apps/sessions/native-crash-renderer/src/main.js
+++ b/test/e2e/test-apps/sessions/native-crash-renderer/src/main.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, mainProcessSessionIntegration } = require('@sentry/electron');
+const { init, mainProcessSessionIntegration } = require('@sentry/electron/main');
 
 init({
   dsn: '__DSN__',

--- a/test/e2e/test-apps/sessions/native-crash-renderer/src/main.js
+++ b/test/e2e/test-apps/sessions/native-crash-renderer/src/main.js
@@ -1,12 +1,12 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, Integrations } = require('@sentry/electron');
+const { init, mainProcessSessionIntegration } = require('@sentry/electron');
 
 init({
   dsn: '__DSN__',
   debug: true,
-  integrations: [new Integrations.MainProcessSession({ sendOnCreate: true })],
+  integrations: [mainProcessSessionIntegration({ sendOnCreate: true })],
   onFatalError: () => {},
 });
 

--- a/test/e2e/test-apps/sessions/window-bad/src/main.js
+++ b/test/e2e/test-apps/sessions/window-bad/src/main.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, browserWindowSessionIntegration } = require('@sentry/electron');
+const { init, browserWindowSessionIntegration } = require('@sentry/electron/main');
 
 init({
   dsn: '__DSN__',

--- a/test/e2e/test-apps/sessions/window-bad/src/main.js
+++ b/test/e2e/test-apps/sessions/window-bad/src/main.js
@@ -1,12 +1,12 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, Integrations } = require('@sentry/electron');
+const { init, browserWindowSessionIntegration } = require('@sentry/electron');
 
 init({
   dsn: '__DSN__',
   debug: true,
-  integrations: [new Integrations.BrowserWindowSession({ backgroundTimeoutSeconds: 1 })],
+  integrations: [browserWindowSessionIntegration({ backgroundTimeoutSeconds: 1 })],
   onFatalError: () => {},
 });
 

--- a/test/e2e/test-apps/sessions/window-good/src/main.js
+++ b/test/e2e/test-apps/sessions/window-good/src/main.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, browserWindowSessionIntegration } = require('@sentry/electron');
+const { init, browserWindowSessionIntegration } = require('@sentry/electron/main');
 
 init({
   dsn: '__DSN__',

--- a/test/e2e/test-apps/sessions/window-good/src/main.js
+++ b/test/e2e/test-apps/sessions/window-good/src/main.js
@@ -1,12 +1,12 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, Integrations } = require('@sentry/electron');
+const { init, browserWindowSessionIntegration } = require('@sentry/electron');
 
 init({
   dsn: '__DSN__',
   debug: true,
-  integrations: [new Integrations.BrowserWindowSession({ backgroundTimeoutSeconds: 1 })],
+  integrations: [browserWindowSessionIntegration({ backgroundTimeoutSeconds: 1 })],
   onFatalError: () => {},
 });
 

--- a/test/unit/net.test.ts
+++ b/test/unit/net.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import { expect, should, use } from 'chai';
 import * as http from 'http';
 import chaiAsPromised = require('chai-as-promised');


### PR DESCRIPTION
This deprecates all the class based integrations apart form `Anr` which is stili class based in `@sentry/node`.

For the current version of the Electron SDK, [we do some acrobatics](https://github.com/getsentry/sentry-electron/blob/3c00c12fb65f423445fd58ca7027738c05bed5ba/src/integrations.ts#L39) so that integrations can be included from any Electron process so that users can simply import `@sentry/electron`. In the next major we are likely to insist that users specifically import `@sentry/electron/main` or `@sentry/electron/renderer`. For that reason, the functional integrations are currently only exported from their respective process.

