### PR TITLE
feat: Update JavaScript SDKs to v7.101.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,19 +55,19 @@
     "e2e": "cross-env TS_NODE_PROJECT=tsconfig.test.json xvfb-maybe mocha --require ts-node/register/transpile-only --retries 3 ./test/e2e/*.ts"
   },
   "dependencies": {
-    "@sentry/browser": "7.98.0",
-    "@sentry/core": "7.98.0",
-    "@sentry/node": "7.98.0",
-    "@sentry/types": "7.98.0",
-    "@sentry/utils": "7.98.0",
+    "@sentry/browser": "7.101.0",
+    "@sentry/core": "7.101.0",
+    "@sentry/node": "7.101.0",
+    "@sentry/types": "7.101.0",
+    "@sentry/utils": "7.101.0",
     "deepmerge": "4.3.0",
     "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.2.1",
     "@rollup/plugin-typescript": "^11.1.4",
-    "@sentry-internal/eslint-config-sdk": "7.98.0",
-    "@sentry-internal/typescript": "7.98.0",
+    "@sentry-internal/eslint-config-sdk": "7.101.0",
+    "@sentry-internal/typescript": "7.101.0",
     "@types/busboy": "^0.2.3",
     "@types/chai": "^4.2.10",
     "@types/chai-as-promised": "^7.1.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,7 @@ export {
   setTag,
   setTags,
   setUser,
+  // eslint-disable-next-line deprecation/deprecation
   spanStatusfromHttpCode,
   // eslint-disable-next-line deprecation/deprecation
   trace,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -62,6 +62,7 @@ export {
   setTag,
   setTags,
   setUser,
+  // eslint-disable-next-line deprecation/deprecation
   spanStatusfromHttpCode,
   // eslint-disable-next-line deprecation/deprecation
   trace,

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -59,6 +59,7 @@ export {
   setTag,
   setTags,
   setUser,
+  // eslint-disable-next-line deprecation/deprecation
   spanStatusfromHttpCode,
   // eslint-disable-next-line deprecation/deprecation
   trace,
@@ -95,7 +96,9 @@ export const metrics = {
 export {
   addTracingExtensions,
   BrowserClient,
+  // eslint-disable-next-line deprecation/deprecation
   BrowserTracing,
+  // eslint-disable-next-line deprecation/deprecation
   BrowserProfilingIntegration,
   // eslint-disable-next-line deprecation/deprecation
   lastEventId,
@@ -112,6 +115,8 @@ export {
   httpContextIntegration,
   linkedErrorsIntegration,
   browserApiErrorsIntegration,
+  browserTracingIntegration,
+  browserProfilingIntegration,
 } from '@sentry/browser';
 // eslint-disable-next-line deprecation/deprecation
 export type { BrowserOptions, ReportDialogOptions } from '@sentry/browser';

--- a/src/renderer/sdk.ts
+++ b/src/renderer/sdk.ts
@@ -42,7 +42,7 @@ interface ElectronRendererOptions extends BrowserOptions {
 export function init<O extends ElectronRendererOptions>(
   options: ElectronRendererOptions & O = {} as ElectronRendererOptions & O,
   // This parameter name ensures that TypeScript error messages contain a hint for fixing SDK version mismatches
-  originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v7_98_0: O) => void = browserInit,
+  originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v7_101_0: O) => void = browserInit,
 ): void {
   ensureProcess('renderer');
 

--- a/test/e2e/test-apps/other/browser-profiling/src/index.html
+++ b/test/e2e/test-apps/other/browser-profiling/src/index.html
@@ -9,7 +9,7 @@
       const {
         addTracingExtensions,
         init,
-        BrowserProfilingIntegration,
+        browserProfilingIntegration,
         startSpan,
       } = require('@sentry/electron/renderer');
 
@@ -17,7 +17,7 @@
 
       init({
         debug: true,
-        integrations: [new BrowserProfilingIntegration()],
+        integrations: [browserProfilingIntegration()],
         tracesSampleRate: 1,
         profilesSampleRate: 1,
       });

--- a/test/e2e/test-apps/other/browser-tracing/src/index.html
+++ b/test/e2e/test-apps/other/browser-tracing/src/index.html
@@ -5,11 +5,11 @@
   </head>
   <body>
     <script>
-      const { init, BrowserTracing } = require('@sentry/electron/renderer');
+      const { init, browserTracingIntegration } = require('@sentry/electron/renderer');
 
       init({
         debug: true,
-        integrations: [new BrowserTracing()],
+        integrations: [browserTracingIntegration()],
         tracesSampleRate: 1,
       });
     </script>

--- a/test/unit/net.test.ts
+++ b/test/unit/net.test.ts
@@ -55,6 +55,7 @@ function mockAsyncContextStrategy(getHub: () => Hub): void {
 }
 
 function createHubOnScope(customOptions: Partial<ClientOptions> = {}): Hub {
+  // eslint-disable-next-line deprecation/deprecation
   const hub = new Hub();
   mockAsyncContextStrategy(() => hub);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -164,13 +164,13 @@
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
 
-"@sentry-internal/eslint-config-sdk@7.98.0":
-  version "7.98.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.98.0.tgz#138327174d9f6727cd38d2da5564a45ca6a82c6c"
-  integrity sha512-dfUmTCAEqFjzFxAk8HT3q3gwgbGbG6K9gwNwFaWJnPuw1I8mvvtsN15r0+VlQWowB+BcbIVHnEH8HNP1XtnBgg==
+"@sentry-internal/eslint-config-sdk@7.101.0":
+  version "7.101.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.101.0.tgz#cd9edca823f1d4b8cbb730ea7a7a942b043f2037"
+  integrity sha512-g3D6so/T3Hn3Wq8EvohhrNjsGxKSzvIoLAMjdWuEcK0k7sC0ZWh887jU9jiGDzhh74Y78AR8frlqy8qk7wlicA==
   dependencies:
-    "@sentry-internal/eslint-plugin-sdk" "7.98.0"
-    "@sentry-internal/typescript" "7.98.0"
+    "@sentry-internal/eslint-plugin-sdk" "7.101.0"
+    "@sentry-internal/typescript" "7.101.0"
     "@typescript-eslint/eslint-plugin" "^5.48.0"
     "@typescript-eslint/parser" "^5.48.0"
     eslint-config-prettier "^6.11.0"
@@ -180,98 +180,98 @@
     eslint-plugin-jsdoc "^30.0.3"
     eslint-plugin-simple-import-sort "^5.0.3"
 
-"@sentry-internal/eslint-plugin-sdk@7.98.0":
-  version "7.98.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.98.0.tgz#64dc7c809a50d4c1ca0a4169a8616b54398c8518"
-  integrity sha512-EGWacj/Y0z4w2dlfpRmjiKfJV3Ap+bHGPeMB0ui/rMAGwLAn97hF4wBNeSEEFBuFGisD+TztelfqZkmV3LQNbA==
+"@sentry-internal/eslint-plugin-sdk@7.101.0":
+  version "7.101.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.101.0.tgz#fa8edbb7a214e6c87244f70b6e56f48a07bd025f"
+  integrity sha512-LesYGx/gKVPpAR80u6yDn10O5beUoRpExmVRoe2a4kOQaAxaU9Gj9gTP2ZtosuUhGfrKGXN/ljxDlFZiZkevoA==
   dependencies:
     requireindex "~1.1.0"
 
-"@sentry-internal/feedback@7.98.0":
-  version "7.98.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/feedback/-/feedback-7.98.0.tgz#2dabbdc060dca49e79536ae99a9bd55f9c6f806f"
-  integrity sha512-t/mATvwkLcQLKRlx8SO5vlUjaadF6sT3lfR0PdWYyBy8qglbMTHDW4KP6JKh1gdzTVQGnwMByy+/4h9gy4AVzw==
+"@sentry-internal/feedback@7.101.0":
+  version "7.101.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/feedback/-/feedback-7.101.0.tgz#cce033c80c498212a5b9a9540ff3ab8297eefbe2"
+  integrity sha512-uQBMYhZp/qkBEA/GXRMm1OfSkRkZojxBrCrFmzkWhJzXT+YbL57/M1uCcwkKmorKlg393Soh7MLULInwmcwWkA==
   dependencies:
-    "@sentry/core" "7.98.0"
-    "@sentry/types" "7.98.0"
-    "@sentry/utils" "7.98.0"
+    "@sentry/core" "7.101.0"
+    "@sentry/types" "7.101.0"
+    "@sentry/utils" "7.101.0"
 
-"@sentry-internal/replay-canvas@7.98.0":
-  version "7.98.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/replay-canvas/-/replay-canvas-7.98.0.tgz#108160c49f714a6021368fd60e08b7291fe44450"
-  integrity sha512-vAR6KIycyazaY9HwxG5UONrPTe8jeKtZr6k04svPC8OvcoI0xF+l1jMEYcarffuzKpZlPfssYb5ChHtKuXCB+Q==
+"@sentry-internal/replay-canvas@7.101.0":
+  version "7.101.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/replay-canvas/-/replay-canvas-7.101.0.tgz#0e32e1bebd4d125126e481c0df5f7186edeadbf4"
+  integrity sha512-fiz4kPpz/j6ZaD+vOcUXuO1HqD49djs4QwyTsRwCCi77EKZOGAaijpqWckDWyZs0dOOnbGGGC5x3o+CfTJcjKA==
   dependencies:
-    "@sentry/core" "7.98.0"
-    "@sentry/replay" "7.98.0"
-    "@sentry/types" "7.98.0"
-    "@sentry/utils" "7.98.0"
+    "@sentry/core" "7.101.0"
+    "@sentry/replay" "7.101.0"
+    "@sentry/types" "7.101.0"
+    "@sentry/utils" "7.101.0"
 
-"@sentry-internal/tracing@7.98.0":
-  version "7.98.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.98.0.tgz#812ef7fce6b64794784f3279c66bc6b5cfd29d7f"
-  integrity sha512-FnhD2uMLIAJvv4XsYPv3qsTTtxrImyLxiZacudJyaWFhxoeVQ8bKKbWJ/Ar68FAwqTtjXMeY5evnEBbRMcQlaA==
+"@sentry-internal/tracing@7.101.0":
+  version "7.101.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.101.0.tgz#9a92ee722d071449a61c061867aa43a5beefcfb6"
+  integrity sha512-rp9oOLQs6vMuzvAnAHRRCNu5Z0o/ZVRI3WPYedxpdMWKD1Z3G9o+0joP+ZIUqHsamWWYiIgPqXgL9AK6AWjFRg==
   dependencies:
-    "@sentry/core" "7.98.0"
-    "@sentry/types" "7.98.0"
-    "@sentry/utils" "7.98.0"
+    "@sentry/core" "7.101.0"
+    "@sentry/types" "7.101.0"
+    "@sentry/utils" "7.101.0"
 
-"@sentry-internal/typescript@7.98.0":
-  version "7.98.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.98.0.tgz#c1032a0563b26cc136a65f9131692004ae1e255d"
-  integrity sha512-7tBQTLcNAPo86Xz2DUWLqjGCo2LjXwGOUGozb7RRTUH5jIVTSzPohkZbsWUkefqHdnCVt1fz9coTig8/p3r9eQ==
+"@sentry-internal/typescript@7.101.0":
+  version "7.101.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.101.0.tgz#376705403a17e282f1b9f540b9a1ffd2e4069b36"
+  integrity sha512-Pxpp18Z1H3T+THbRXLYiS327clCh/eOMC85+AQACK/URkU3cC8sQ4Qw27mIAgYLZVjYdGVa7fFrNoPJBI40NLQ==
 
-"@sentry/browser@7.98.0":
-  version "7.98.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.98.0.tgz#f249e6e38351de4cea1142f498e1169006e5dd76"
-  integrity sha512-/MzTS31N2iM6Qwyh4PSpHihgmkVD5xdfE5qi1mTlwQZz5Yz8t7MdMriX8bEDPlLB8sNxl7+D6/+KUJO8akX0nQ==
+"@sentry/browser@7.101.0":
+  version "7.101.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.101.0.tgz#53ecfa8a9b0076b95930dff5bbb616e827608606"
+  integrity sha512-wj9YLfS/caR20Yq0hdEjsZHuhnYLU7Ht0SlcJx5MNMnArtmW1k2CWZz3PCqcW/rTZe53npVTe6eMqMccB4aPrQ==
   dependencies:
-    "@sentry-internal/feedback" "7.98.0"
-    "@sentry-internal/replay-canvas" "7.98.0"
-    "@sentry-internal/tracing" "7.98.0"
-    "@sentry/core" "7.98.0"
-    "@sentry/replay" "7.98.0"
-    "@sentry/types" "7.98.0"
-    "@sentry/utils" "7.98.0"
+    "@sentry-internal/feedback" "7.101.0"
+    "@sentry-internal/replay-canvas" "7.101.0"
+    "@sentry-internal/tracing" "7.101.0"
+    "@sentry/core" "7.101.0"
+    "@sentry/replay" "7.101.0"
+    "@sentry/types" "7.101.0"
+    "@sentry/utils" "7.101.0"
 
-"@sentry/core@7.98.0":
-  version "7.98.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.98.0.tgz#e4f5353bc3986e510b8dd2507355787440d6e25d"
-  integrity sha512-baRUcpCNGyk7cApQHMfqEZJkXdvAKK+z/dVWiMqWc5T5uhzMnPE8/gjP1JZsMtJSQ8g5nHimBdI5TwOyZtxPaA==
+"@sentry/core@7.101.0":
+  version "7.101.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.101.0.tgz#7ddae48771bad6d3170df0d9807f86c39824dd0a"
+  integrity sha512-dRNrNV5OLGARkOGgxJsVDhA98Pev5G1LVJcud5E83cRg49BCUx2riqEtDP6iIS1nvem6cApkSnLC1kvl/T5/Cw==
   dependencies:
-    "@sentry/types" "7.98.0"
-    "@sentry/utils" "7.98.0"
+    "@sentry/types" "7.101.0"
+    "@sentry/utils" "7.101.0"
 
-"@sentry/node@7.98.0":
-  version "7.98.0"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.98.0.tgz#49d0a46e72f4e6116b4929d033322951e5a7e88b"
-  integrity sha512-9cHW217DnU9wC4iR+QxmY3q59N1Touh23hPMDtpMRmbRHSgrmLMoHTVPhK9zHsXRs0mUeidmMqY1ubAWauQByw==
+"@sentry/node@7.101.0":
+  version "7.101.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.101.0.tgz#acafd4efc81035bb3ffe73ef92f348099c7c5df1"
+  integrity sha512-4z01VAFjRYk7XcajbWPJlhkPN6PBG4nVX8n1dl+OH2OeqTxFxcnmY5zR5v+AtEbNJgg5PMwy8mnnGZRG/wLZgA==
   dependencies:
-    "@sentry-internal/tracing" "7.98.0"
-    "@sentry/core" "7.98.0"
-    "@sentry/types" "7.98.0"
-    "@sentry/utils" "7.98.0"
+    "@sentry-internal/tracing" "7.101.0"
+    "@sentry/core" "7.101.0"
+    "@sentry/types" "7.101.0"
+    "@sentry/utils" "7.101.0"
 
-"@sentry/replay@7.98.0":
-  version "7.98.0"
-  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.98.0.tgz#21ba96d501260c1a33bc1af445f5cfbe02d0ba30"
-  integrity sha512-CQabv/3KnpMkpc2TzIquPu5krpjeMRAaDIO0OpTj5SQeH2RqSq3fVWNZkHa8tLsADxcfLFINxqOg2jd1NxvwxA==
+"@sentry/replay@7.101.0":
+  version "7.101.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.101.0.tgz#66d199316be3f0fc2ed82a5294f519d58a2c2260"
+  integrity sha512-DSWkGKI/QhCAY+qm4mBnPob3/YsewisskVTak7KMDotJ75H85WFJhVwOMtvaEWIzVezCOItPv7ql51jTwhR3wA==
   dependencies:
-    "@sentry-internal/tracing" "7.98.0"
-    "@sentry/core" "7.98.0"
-    "@sentry/types" "7.98.0"
-    "@sentry/utils" "7.98.0"
+    "@sentry-internal/tracing" "7.101.0"
+    "@sentry/core" "7.101.0"
+    "@sentry/types" "7.101.0"
+    "@sentry/utils" "7.101.0"
 
-"@sentry/types@7.98.0":
-  version "7.98.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.98.0.tgz#6a88bf60679aea88ac6cba4d1517958726c2bafb"
-  integrity sha512-pc034ziM0VTETue4bfBcBqTWGy4w0okidtoZJjGVrYAfE95ObZnUGVj/XYIQ3FeCYWIa7NFN2MvdsCS0buwivQ==
+"@sentry/types@7.101.0":
+  version "7.101.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.101.0.tgz#0174a32d6c12def73f438dc2a10bd52cc0ba0c81"
+  integrity sha512-YC+ltO/AlbEyJHjCUYQ4is1HcDT2zSMuLkIAcyQmK7fUdlGT4iR5sfENriY9ZopYHgjPdJKfhI8ohScam7zp/A==
 
-"@sentry/utils@7.98.0":
-  version "7.98.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.98.0.tgz#54355a197f7f71a6d17354a3d043022df402b502"
-  integrity sha512-0/LY+kpHxItVRY0xPDXPXVsKRb95cXsGSQf8sVMtfSjz++0bLL1U4k7PFz1c5s2/Vk0B8hS6duRrgMv6dMIZDw==
+"@sentry/utils@7.101.0":
+  version "7.101.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.101.0.tgz#0eadb9709c9b6fbc03d509acf7fe6a00ab4e6220"
+  integrity sha512-px1NUkCLsD9UKLE4W4DghpyzmAVHgYhskrjRt30ubyUKqlggtHkOXRvS8MjuWowR/i0wF0GuTCbU9StBd7JMrw==
   dependencies:
-    "@sentry/types" "7.98.0"
+    "@sentry/types" "7.101.0"
 
 "@sindresorhus/is@^4.0.0":
   version "4.6.0"


### PR DESCRIPTION
Updates to v7.101.0 of the JavaScript SDKs. There we just a few new deprecations.