### PR TITLE
meta: Update changelog for v4.18.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 4.18.0
+
+- feat: Update from [v7.92.0](https://github.com/getsentry/sentry-javascript/releases/tag/7.92.0) to
+  [v7.101.0](https://github.com/getsentry/sentry-javascript/releases/tag/7.101.0) of JavaScript SDKs (#815, #821, #826)
+
 ## 4.17.0
 
 - feat: Update from [v7.90.0](https://github.com/getsentry/sentry-javascript/releases/tag/7.90.0) to


### PR DESCRIPTION
Update changelog for v4.18.0 release

Closes #825
Requires #826 to be merged first
