### PR TITLE
test: Add test for `captureConsoleIntegration`

### DIFF
--- a/test/e2e/recipe/index.ts
+++ b/test/e2e/recipe/index.ts
@@ -171,6 +171,7 @@ export class RecipeRunner {
           // We replace the Sentry JavaScript dependency versions to match that of @sentry/core
           .replace(/"@sentry\/replay": ".*"/, `"@sentry/replay": "${JS_VERSION}"`)
           .replace(/"@sentry\/react": ".*"/, `"@sentry/react": "${JS_VERSION}"`)
+          .replace(/"@sentry\/integrations": ".*"/, `"@sentry/integrations": "${JS_VERSION}"`)
           .replace(/"@sentry\/vue": ".*"/, `"@sentry/vue": "${JS_VERSION}"`);
       }
 

--- a/test/e2e/test-apps/other/capture-console/event.json
+++ b/test/e2e/test-apps/other/capture-console/event.json
@@ -1,0 +1,75 @@
+{
+  "method": "envelope",
+  "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
+  "appId": "277345",
+  "data": {
+    "sdk": {
+      "name": "sentry.javascript.electron",
+      "packages": [
+        {
+          "name": "npm:@sentry/electron",
+          "version": "{{version}}"
+        }
+      ],
+      "version": "{{version}}"
+    },
+    "contexts": {
+      "app": {
+        "app_name": "capture-console",
+        "app_version": "1.0.0",
+        "app_start_time": "{{time}}"
+      },
+      "browser": {
+        "name": "Chrome"
+      },
+      "chrome": {
+        "name": "Chrome",
+        "type": "runtime",
+        "version": "{{version}}"
+      },
+      "device": {
+        "arch": "{{arch}}",
+        "family": "Desktop",
+        "memory_size": 0,
+        "free_memory": 0,
+        "processor_count": 0,
+        "processor_frequency": 0,
+        "cpu_description": "{{cpu}}",
+        "screen_resolution":"{{screen}}",
+        "screen_density": 1,
+        "language": "{{language}}"
+      },
+      "node": {
+        "name": "Node",
+        "type": "runtime",
+        "version": "{{version}}"
+      },
+      "os": {
+        "name": "{{platform}}",
+        "version": "{{version}}"
+      },
+      "runtime": {
+        "name": "Electron",
+        "version": "{{version}}"
+      }
+    },
+    "message": "This is an error message",
+    "release": "capture-console@1.0.0",
+    "environment": "development",
+    "user": {
+      "ip_address": "{{auto}}"
+    },
+    "event_id": "{{id}}",
+    "platform": "javascript",
+    "timestamp": 0,
+    "breadcrumbs": [],
+    "request": {
+      "url": "app:///src/index.html"
+    },
+    "tags": {
+      "event.environment": "javascript",
+      "event.origin": "electron",
+      "event_type": "javascript"
+    }
+  }
+}

--- a/test/e2e/test-apps/other/capture-console/package.json
+++ b/test/e2e/test-apps/other/capture-console/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "capture-console",
+  "version": "1.0.0",
+  "main": "src/main.js",
+  "dependencies": {
+    "@sentry/electron": "3.0.0",
+    "@sentry/integrations": "7.0.0"
+  }
+}

--- a/test/e2e/test-apps/other/capture-console/recipe.yml
+++ b/test/e2e/test-apps/other/capture-console/recipe.yml
@@ -1,0 +1,2 @@
+description: Browser Tracing
+command: yarn

--- a/test/e2e/test-apps/other/capture-console/src/index.html
+++ b/test/e2e/test-apps/other/capture-console/src/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <script>
+      const { init } = require('@sentry/electron/renderer');
+      const { captureConsoleIntegration } = require('@sentry/integrations');
+
+      init({
+        debug: true,
+        integrations: [captureConsoleIntegration()],
+      });
+
+      setTimeout(() => {
+        console.error('This is an error message');
+      }, 1000);
+    </script>
+  </body>
+</html>

--- a/test/e2e/test-apps/other/capture-console/src/main.js
+++ b/test/e2e/test-apps/other/capture-console/src/main.js
@@ -1,0 +1,23 @@
+const path = require('path');
+
+const { app, BrowserWindow } = require('electron');
+const { init } = require('@sentry/electron');
+
+init({
+  dsn: '__DSN__',
+  debug: true,
+  autoSessionTracking: false,
+  onFatalError: () => {},
+});
+
+app.on('ready', () => {
+  const mainWindow = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+
+  mainWindow.loadFile(path.join(__dirname, 'index.html'));
+});


### PR DESCRIPTION
Closes #833

This integration works if you use the same Sentry JavaScript version used by the Electron SDK. 