### PR TITLE
feat: Deprecate last class based integration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -207,11 +207,11 @@ export async function flush(timeout?: number): Promise<boolean> {
  * @deprecated Use `Anr` integration instead.
  *
  * ```js
- * import { init, Integrations } from '@sentry/electron';
+ * import { init, anrIntegration } from '@sentry/electron';
  *
  * init({
  *   dsn: "__DSN__",
- *   integrations: [new Integrations.Anr({ captureStackTrace: true })],
+ *   integrations: [anrIntegration({ captureStackTrace: true })],
  * });
  * ```
  */

--- a/src/main/anr.ts
+++ b/src/main/anr.ts
@@ -186,15 +186,16 @@ interface LegacyOptions {
  * @deprecated Use `Anr` integration instead.
  *
  * ```js
- * import { init, Integrations } from '@sentry/electron';
+ * import { init, anrIntegration } from '@sentry/electron';
  *
  * init({
  *   dsn: "__DSN__",
- *   integrations: [new Integrations.Anr({ captureStackTrace: true })],
+ *   integrations: [anrIntegration({ captureStackTrace: true })],
  * });
  * ```
  */
 export function enableMainProcessAnrDetection(options: Partial<LegacyOptions> = {}): Promise<void> {
+  // eslint-disable-next-line deprecation/deprecation
   const integration = new Anr(options);
   const client = getClient() as NodeClient;
   integration.setup?.(client);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -99,6 +99,7 @@ export { electronNetIntegration } from './integrations/net-breadcrumbs';
 export { childProcessIntegration } from './integrations/child-process';
 export { screenshotsIntegration } from './integrations/screenshots';
 export { rendererProfileFromIpc } from './integrations/renderer-profiling';
+export { anrIntegration } from './integrations/anr';
 
 export type { NodeOptions } from '@sentry/node';
 // eslint-disable-next-line deprecation/deprecation
@@ -106,6 +107,10 @@ export { flush, close, NodeClient, lastEventId } from '@sentry/node';
 
 export { makeElectronTransport } from './transports/electron-net';
 export { makeElectronOfflineTransport } from './transports/electron-offline-net';
+
+/**
+ * @deprecated All integrations are now exported from the root of the package.
+ */
 export const Integrations = { ...NodeIntegrations, ...ElectronMainIntegrations };
 
 export type { ElectronMainOptions } from './sdk';

--- a/src/main/integrations/anr.ts
+++ b/src/main/integrations/anr.ts
@@ -1,66 +1,31 @@
-import { Integrations } from '@sentry/node';
-import { Primitive } from '@sentry/types';
+import { convertIntegrationFnToClass, defineIntegration } from '@sentry/core';
+import { anrIntegration as nodeAnrIntegration } from '@sentry/node';
 import { app } from 'electron';
 
 import { ELECTRON_MAJOR_VERSION } from '../electron-normalize';
 
 /**
- * ConstructorParameters<typeof Integrations.Anr> doesn't work below because integration constructor types are broken here:
- * https://github.com/getsentry/sentry-javascript/blob/f28f3a968c52075694ecef4efef354f806fec100/packages/node/src/index.ts#L100-L116
- */
-interface Options {
-  /**
-   * Interval to send heartbeat messages to the ANR worker.
-   *
-   * Defaults to 50ms.
-   */
-  pollInterval: number;
-  /**
-   * Threshold in milliseconds to trigger an ANR event.
-   *
-   * Defaults to 5000ms.
-   */
-  anrThreshold: number;
-  /**
-   * Whether to capture a stack trace when the ANR event is triggered.
-   *
-   * Defaults to `false`.
-   *
-   * This uses the node debugger which enables the inspector API and opens the required ports.
-   */
-  captureStackTrace: boolean;
-  /**
-   * Tags to include with ANR events.
-   */
-  staticTags: { [key: string]: Primitive };
-  /**
-   * @ignore Internal use only.
-   *
-   * If this is supplied, stack frame filenames will be rewritten to be relative to this path.
-   */
-  appRootPath: string | undefined;
-}
-
-// We can't use the functional style of integration until they are exported as functions...
-
-/**
  * Starts a worker thread to detect App Not Responding (ANR) events
  */
-export class Anr extends Integrations.Anr {
-  public constructor(options: Partial<Options> = {}) {
-    if (ELECTRON_MAJOR_VERSION < 22) {
-      throw new Error('Main process ANR detection requires Electron v22+');
-    }
-
-    super({
-      ...options,
-      staticTags: {
-        'event.environment': 'javascript',
-        'event.origin': 'electron',
-        'event.process': 'browser',
-        ...options.staticTags,
-      },
-      appRootPath: app.getAppPath(),
-    });
+export const anrIntegration = defineIntegration((options: Parameters<typeof nodeAnrIntegration>[0] = {}) => {
+  if (ELECTRON_MAJOR_VERSION < 22) {
+    throw new Error('Main process ANR detection requires Electron v22+');
   }
-}
+
+  return nodeAnrIntegration({
+    ...options,
+    staticTags: {
+      'event.environment': 'javascript',
+      'event.origin': 'electron',
+      'event.process': 'browser',
+      ...options.staticTags,
+    },
+    appRootPath: app.getAppPath(),
+  });
+});
+
+/**
+ * @deprecated Use `anrIntegration()` instead.
+ */
+// eslint-disable-next-line deprecation/deprecation
+export const Anr = convertIntegrationFnToClass(anrIntegration.name, anrIntegration);

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -124,6 +124,9 @@ export {
 // eslint-disable-next-line deprecation/deprecation
 export type { BrowserOptions, ReportDialogOptions } from '@sentry/browser';
 
+/**
+ * @deprecated All integrations are now exported from the root of the package.
+ */
 // eslint-disable-next-line deprecation/deprecation
 export const Integrations = { ...BrowserIntegrations, ...ElectronRendererIntegrations };
 export { init, defaultIntegrations } from './sdk';

--- a/test/e2e/test-apps/anr/anr-main/src/main.js
+++ b/test/e2e/test-apps/anr/anr-main/src/main.js
@@ -1,13 +1,13 @@
 const crypto = require('crypto');
 
 const { app } = require('electron');
-const { init, Integrations } = require('@sentry/electron/main');
+const { init, anrIntegration } = require('@sentry/electron/main');
 
 init({
   dsn: '__DSN__',
   debug: true,
   onFatalError: () => {},
-  integrations: [new Integrations.Anr({ captureStackTrace: true, anrThreshold: 1000 })],
+  integrations: [anrIntegration({ captureStackTrace: true, anrThreshold: 1000 })],
 });
 
 function longWork() {


### PR DESCRIPTION
The last integration without a functional alternative was `Anr` but the wrapping in the Electron SDK is now functional too.