### PR TITLE
feat: Limit minidumps sent per app session

### DIFF
--- a/src/main/integrations/sentry-minidump/index.ts
+++ b/src/main/integrations/sentry-minidump/index.ts
@@ -118,6 +118,10 @@ export const sentryMinidumpIntegration = defineIntegration((options: Options = {
       return false;
     }
 
+    if (minidumpsRemaining <= 0) {
+      logger.log('Not sending minidumps because the limit has been reached');
+    }
+
     // If the SDK is not enabled, or we've already reached the minidump limit, tell the loader to delete all minidumps
     const deleteAll = client.getOptions().enabled === false || minidumpsRemaining <= 0;
 

--- a/test/e2e/recipe/index.ts
+++ b/test/e2e/recipe/index.ts
@@ -235,6 +235,12 @@ export class RecipeRunner {
 
     await context.waitForEvents(testServer, totalEvents);
 
+    // If a test need to ensure no other events are received after the expected number of events, wait a bit longer
+    if (this._recipe.metadata.waitAfterExpectedEvents) {
+      log(`Waiting ${this._recipe.metadata.waitAfterExpectedEvents}ms to see if any more events are sent...`);
+      await delay(this._recipe.metadata.waitAfterExpectedEvents);
+    }
+
     if (totalEvents !== testServer.events.length) {
       throw new Error(`Expected ${expectedEvents.length} events but server has ${testServer.events.length} events`);
     }

--- a/test/e2e/recipe/parser.ts
+++ b/test/e2e/recipe/parser.ts
@@ -18,6 +18,7 @@ export interface TestMetadata {
   expectedError?: string;
   distPath?: string;
   skipEsmAutoTransform?: boolean;
+  waitAfterExpectedEvents?: number;
 }
 
 export interface TestRecipe {

--- a/test/e2e/test-apps/native-sentry/renderer-limit/event.json
+++ b/test/e2e/test-apps/native-sentry/renderer-limit/event.json
@@ -1,0 +1,75 @@
+{
+  "method": "envelope",
+  "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
+  "appId": "277345",
+  "data": {
+    "sdk": {
+      "name": "sentry.javascript.electron",
+      "packages": [
+        {
+          "name": "npm:@sentry/electron",
+          "version": "{{version}}"
+        }
+      ],
+      "version": "{{version}}"
+    },
+    "contexts": {
+      "app": {
+        "app_name": "native-crash-limits",
+        "app_version": "1.0.0",
+        "app_start_time": "{{time}}"
+      },
+      "browser": {
+        "name": "Chrome"
+      },
+      "chrome": {
+        "name": "Chrome",
+        "type": "runtime",
+        "version": "{{version}}"
+      },
+      "device": {
+        "arch": "{{arch}}",
+        "family": "Desktop",
+        "memory_size": 0,
+        "free_memory": 0,
+        "processor_count": 0,
+        "processor_frequency": 0,
+        "cpu_description": "{{cpu}}",
+        "screen_resolution":"{{screen}}",
+        "screen_density": 1,
+        "language": "{{language}}"
+      },
+      "node": {
+        "name": "Node",
+        "type": "runtime",
+        "version": "{{version}}"
+      },
+      "os": {
+        "name": "{{platform}}",
+        "version": "{{version}}"
+      },
+      "runtime": {
+        "name": "Electron",
+        "version": "{{version}}"
+      },
+      "electron": {
+        "crashed_url": "app:///src/index.html"
+      }
+    },
+    "release": "native-crash-limits@1.0.0",
+    "environment": "development",
+    "user": {
+      "ip_address": "{{auto}}"
+    },
+    "event_id": "{{id}}",
+    "timestamp": 0,
+    "breadcrumbs": [],
+    "tags": {
+      "event.environment": "native",
+      "event.origin": "electron",
+      "event.process": "renderer",
+      "event_type": "native"
+    }
+  },
+  "attachments": [ { "attachment_type": "event.minidump" } ]
+}

--- a/test/e2e/test-apps/native-sentry/renderer-limit/package.json
+++ b/test/e2e/test-apps/native-sentry/renderer-limit/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "native-crash-limits",
+  "version": "1.0.0",
+  "main": "src/main.js",
+  "dependencies": {
+    "@sentry/electron": "3.0.0"
+  }
+}

--- a/test/e2e/test-apps/native-sentry/renderer-limit/recipe.yml
+++ b/test/e2e/test-apps/native-sentry/renderer-limit/recipe.yml
@@ -1,0 +1,4 @@
+description: Native Crash Limits
+category: Native (Sentry Uploader)
+command: yarn
+waitAfterExpectedEvents: 10000

--- a/test/e2e/test-apps/native-sentry/renderer-limit/src/index.html
+++ b/test/e2e/test-apps/native-sentry/renderer-limit/src/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <script>
+      const { init } = require('@sentry/electron');
+
+      init({
+        debug: true,
+      });
+
+      setTimeout(() => {
+        process.crash();
+      }, 500);
+    </script>
+  </body>
+</html>

--- a/test/e2e/test-apps/native-sentry/renderer-limit/src/main.js
+++ b/test/e2e/test-apps/native-sentry/renderer-limit/src/main.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init, sentryMinidumpIntegration } = require('@sentry/electron');
+const { init, sentryMinidumpIntegration } = require('@sentry/electron/main');
 
 init({
   dsn: '__DSN__',

--- a/test/e2e/test-apps/native-sentry/renderer-limit/src/main.js
+++ b/test/e2e/test-apps/native-sentry/renderer-limit/src/main.js
@@ -1,0 +1,30 @@
+const path = require('path');
+
+const { app, BrowserWindow } = require('electron');
+const { init, sentryMinidumpIntegration } = require('@sentry/electron');
+
+init({
+  dsn: '__DSN__',
+  debug: true,
+  autoSessionTracking: false,
+  integrations: [sentryMinidumpIntegration({ maxMinidumpsPerSession: 1 })],
+  onFatalError: () => {},
+});
+
+app.on('ready', () => {
+  const mainWindow = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+
+  mainWindow.loadFile(path.join(__dirname, 'index.html'));
+
+  // Keep reloading the window to cause multiple crash events
+  app.on('render-process-gone', () => {
+    console.log('Reloading window');
+    mainWindow.reload();
+  });
+});


### PR DESCRIPTION
Since the Dedupe integration cannot block sending of duplicate minidumps, there is effectively no limit to the number of duplicate minidumps that can be sent per session. 

This PR add a `maxMinidumpsPerSession` option to the integration that defaults to 10.

Internal doc: https://www.notion.so/sentry/096c7ce2987a4e598ca234c82a222853?v=693bea0c95b54382bb9523ab05711127&p=1a1abe81a8ca4689b831efe8bbbb87d9&pm=s