### PR TITLE
test: Limit crash limits test to latest Electron versions

### DIFF
--- a/test/e2e/test-apps/native-sentry/renderer-limit/recipe.yml
+++ b/test/e2e/test-apps/native-sentry/renderer-limit/recipe.yml
@@ -2,3 +2,4 @@ description: Native Crash Limits
 category: Native (Sentry Uploader)
 command: yarn
 waitAfterExpectedEvents: 10000
+condition: version.major >= 20


### PR DESCRIPTION
Older versions of Electron don't support the event used in the test