### PR TITLE
fix: Duplicate renderer breadcrumbs

### DIFF
--- a/src/common/scope.ts
+++ b/src/common/scope.ts
@@ -10,15 +10,13 @@ export function getScopeData(): ScopeData {
 }
 
 /** Hooks both current and isolation scope changes and passes merged scope on changes  */
-export function addScopeListener(callback: (merged: ScopeData, current: Scope, isolation: Scope) => void): void {
+export function addScopeListener(callback: (merged: ScopeData, changed: Scope) => void): void {
   getIsolationScope().addScopeListener((isolation) => {
-    const current = getCurrentScope();
     const merged = getScopeData();
-    callback(merged, current, isolation);
+    callback(merged, isolation);
   });
   getCurrentScope().addScopeListener((current) => {
-    const isolation = getIsolationScope();
     const merged = getScopeData();
-    callback(merged, current, isolation);
+    callback(merged, current);
   });
 }

--- a/src/renderer/integrations/scope-to-main.ts
+++ b/src/renderer/integrations/scope-to-main.ts
@@ -13,12 +13,10 @@ export const scopeToMainIntegration = defineIntegration(() => {
     setup() {
       const ipc = getIPC();
 
-      addScopeListener((merged, current, isolated) => {
+      addScopeListener((merged, changed) => {
         ipc.sendScope(JSON.stringify(normalize(merged, 20, 2_000)));
-        current.clearBreadcrumbs();
-        current.clearAttachments();
-        isolated.clearBreadcrumbs();
-        isolated.clearAttachments();
+        changed.clearBreadcrumbs();
+        changed.clearAttachments();
       });
     },
   };


### PR DESCRIPTION
Clearing the breadcrumbs for a scope that is currently not notifying of changes causes more scope updates to be triggered.