### PR TITLE
fix: Don't test v20 in CI on macOS

### DIFF
--- a/scripts/e2e-test-versions.js
+++ b/scripts/e2e-test-versions.js
@@ -1,12 +1,17 @@
 const { readFileSync } = require('fs');
 
-const versions = JSON.parse(readFileSync('./test/e2e/versions.json', 'utf8'));
+let versions = JSON.parse(readFileSync('./test/e2e/versions.json', 'utf8'));
+
+// Electron v20 exits immediately on macOS arch64 in GitHub Actions with SIGTRAP
+if (process.env.CI && process.platform === 'darwin') {
+  versions = versions.filter((version) => !version.startsWith('20.'));
+}
 
 if (process.env.GITHUB_REF && process.env.GITHUB_REF.includes('release/')) {
   // For release builds we test all versions
   console.log(JSON.stringify(versions));
 } else {
   const versionCount = process.platform === 'darwin' ? -3 : -7;
-  // Otherwise we test the oldest version and the last 10 versions
+  // Otherwise we test the oldest supported version and the last 3 or 7 versions depending on the platform
   console.log(JSON.stringify([versions[0], ...versions.slice(versionCount)]));
 }


### PR DESCRIPTION
I've tested various versions of v20 but they all exit with `SIGTRAP` on macOS arch64 in CI even though it runs and the tests pass locally.

I've spent far too long trying to fix this so I think the best thing for now is to exclude this version in combination with macOS from CI!