### PR TITLE
fix: Don't require CI environment variable

### DIFF
--- a/scripts/e2e-test-versions.js
+++ b/scripts/e2e-test-versions.js
@@ -3,7 +3,7 @@ const { readFileSync } = require('fs');
 let versions = JSON.parse(readFileSync('./test/e2e/versions.json', 'utf8'));
 
 // Electron v20 exits immediately on macOS arch64 in GitHub Actions with SIGTRAP
-if (process.env.CI && process.platform === 'darwin') {
+if (process.platform === 'darwin') {
   versions = versions.filter((version) => !version.startsWith('20.'));
 }
 


### PR DESCRIPTION
I was under the impression that the `CI` environment variable is defined in GHA but that doesn't appear to be the case here.

This script is only called in CI so this env check is not required. I've tested this script locally and it does not return v20 on macOS...