### PR TITLE
test: Skip e2e tests for macOS v20

### DIFF
--- a/scripts/e2e-test-versions.js
+++ b/scripts/e2e-test-versions.js
@@ -1,11 +1,6 @@
 const { readFileSync } = require('fs');
 
-let versions = JSON.parse(readFileSync('./test/e2e/versions.json', 'utf8'));
-
-// Electron v20 exits immediately on macOS arch64 in GitHub Actions with SIGTRAP
-if (process.platform === 'darwin') {
-  versions = versions.filter((version) => !version.startsWith('20.'));
-}
+const versions = JSON.parse(readFileSync('./test/e2e/versions.json', 'utf8'));
 
 if (process.env.GITHUB_REF && process.env.GITHUB_REF.includes('release/')) {
   // For release builds we test all versions

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -29,6 +29,9 @@ describe('E2E Tests', async () => {
   });
 
   for (const electronVersion of getElectronTestVersions()) {
+    // Electron v20 exits immediately on macOS arch64 in GitHub Actions with SIGTRAP
+    const skipAll = process.platform === 'darwin' && process.env.CI && electronVersion.startsWith('20.');
+
     console.log(`Downloading Electron v${electronVersion}...`);
     const electronPath = await downloadElectron(electronVersion);
     console.log('Downloading complete!');
@@ -57,7 +60,7 @@ describe('E2E Tests', async () => {
               testFn(
                 recipe.description,
                 async (ctx) => {
-                  if (!recipe.shouldRun()) {
+                  if (skipAll || !recipe.shouldRun()) {
                     ctx.skip();
                   }
 


### PR DESCRIPTION
The test matrix is calculated in the build step so this version needs skipping in the specific e2e test runner