### PR TITLE
meta: changelog for 8.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 5.1.0
 
 - feat: Update from [v8.0.0](https://github.com/getsentry/sentry-javascript/releases/tag/8.0.0) to
-  [v8.8.0](https://github.com/getsentry/sentry-javascript/releases/tag/8.8.0) of JavaScript SDKs
+  [v8.9.2](https://github.com/getsentry/sentry-javascript/releases/tag/8.9.2) of JavaScript SDKs
 - feat: Include trace origin in auto spans (#915)
 
 ## 5.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 5.1.0
+
+- feat: Update from [v8.0.0](https://github.com/getsentry/sentry-javascript/releases/tag/8.0.0) to
+  [v8.8.0](https://github.com/getsentry/sentry-javascript/releases/tag/8.8.0) of JavaScript SDKs
+- feat: Include trace origin in auto spans (#915)
+
 ## 5.0.0
 
 This release updates the underlying Sentry JavaScript SDKs to v8 which includes a number of breaking changes, including


### PR DESCRIPTION
- feat: Update from [v8.0.0](https://github.com/getsentry/sentry-javascript/releases/tag/8.0.0) to [v8.9.2](https://github.com/getsentry/sentry-javascript/releases/tag/8.9.2) of JavaScript SDKs
- feat: Include trace origin in auto spans