### PR TITLE
fix: No sub-module imports in type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "prebuild": "yarn clean && node scripts/update-version.js",
     "build": "rollup --config rollup.config.mjs",
-    "postbuild": "node scripts/check-exports.mjs",
+    "postbuild": "node scripts/check-exports.mjs && node scripts/check-types.mjs",
     "clean": "rimraf --glob coverage common esm main preload renderer index.* sentry-electron*.tgz .eslintcache",
     "prelint": "node scripts/update-version.js",
     "lint": "run-s lint:prettier lint:eslint",

--- a/scripts/check-types.mjs
+++ b/scripts/check-types.mjs
@@ -1,0 +1,39 @@
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+
+async function walk(dir, ty) {
+  let files = await fs.readdir(dir);
+  files = await Promise.all(
+    files.map(async (file) => {
+      const filePath = path.join(dir, file);
+      const stats = await fs.stat(filePath);
+      if (stats.isDirectory()) {
+        return filePath.endsWith('node_modules') ? [] : walk(filePath, ty);
+      } else if (stats.isFile() && file.endsWith(ty)) {
+        return filePath;
+      }
+    }),
+  );
+
+  return files.filter(Boolean).reduce((all, f) => all.concat(f), []);
+}
+
+// Find all the .d.ts files in the project
+const typeDefs = await walk(process.cwd(), '.d.ts');
+
+// Check for any sub-module imports in the type definitions
+const regex = /import\("@sentry\/.+\//gi;
+let failed = false;
+
+for (const file of typeDefs) {
+  const content = await fs.readFile(file, 'utf-8');
+  const matches = content.match(regex);
+  if (matches) {
+    console.log(`Sub-module import in type def file '${file}':\n`, matches);
+    failed = true;
+  }
+}
+
+if (failed) {
+  process.exit(1);
+}

--- a/src/main/integrations/anr.ts
+++ b/src/main/integrations/anr.ts
@@ -1,13 +1,16 @@
 import { defineIntegration } from '@sentry/core';
 import { anrIntegration as nodeAnrIntegration } from '@sentry/node';
+import { Integration } from '@sentry/types';
 import { app, powerMonitor } from 'electron';
 
 import { ELECTRON_MAJOR_VERSION } from '../electron-normalize';
 
+type Options = Parameters<typeof nodeAnrIntegration>[0];
+
 /**
  * Starts a worker thread to detect App Not Responding (ANR) events
  */
-export const anrIntegration = defineIntegration((options: Parameters<typeof nodeAnrIntegration>[0] = {}) => {
+export const anrIntegration: (options: Options) => Integration = defineIntegration((options: Options = {}) => {
   if (ELECTRON_MAJOR_VERSION < 22) {
     throw new Error('Main process ANR detection requires Electron v22+');
   }


### PR DESCRIPTION
Closes #957

I couldn't get a test to reproduce the above linked issue within this repository so I resorted to regex'ing all the output type defs for sub-module imports.