### PR TITLE
fix: `contextLinesIntegration` should come before path normalization

### DIFF
--- a/src/main/sdk.ts
+++ b/src/main/sdk.ts
@@ -47,7 +47,6 @@ export function getDefaultIntegrations(options: ElectronMainOptions): Integratio
     electronNetIntegration(),
     electronContextIntegration(),
     childProcessIntegration(),
-    normalizePathsIntegration(),
     onUncaughtExceptionIntegration(),
     preloadInjectionIntegration(),
     additionalContextIntegration(),
@@ -63,6 +62,9 @@ export function getDefaultIntegrations(options: ElectronMainOptions): Integratio
     contextLinesIntegration(),
     localVariablesIntegration(),
     nodeContextIntegration({ cloudResource: false }),
+
+    // We want paths to be normailzed after we've captured context
+    normalizePathsIntegration(),
   ];
 
   if (options.autoSessionTracking !== false) {


### PR DESCRIPTION
While debugging another issue I found that the `contextLinesIntegration` could not find files because their paths had already been normalised to `app://` base path.

This PR simply ensures that path normalisation occurs last.