### PR TITLE
feat: Update Sentry JavaScript to v8.41.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,18 +60,17 @@
     "e2e": "xvfb-maybe vitest run --root=./test/e2e --silent=false --disable-console-intercept"
   },
   "dependencies": {
-    "@sentry/browser": "8.40.0",
-    "@sentry/core": "8.40.0",
-    "@sentry/node": "8.40.0",
-    "@sentry/types": "8.40.0",
-    "@sentry/utils": "8.40.0",
+    "@sentry/browser": "8.41.0",
+    "@sentry/core": "8.41.0",
+    "@sentry/node": "8.41.0",
+    "@sentry/types": "8.41.0",
     "deepmerge": "4.3.1"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-typescript": "^11.1.6",
-    "@sentry-internal/eslint-config-sdk": "8.40.0",
-    "@sentry-internal/typescript": "8.40.0",
+    "@sentry-internal/eslint-config-sdk": "8.41.0",
+    "@sentry-internal/typescript": "8.41.0",
     "@types/busboy": "^1.5.4",
     "@types/form-data": "^2.5.0",
     "@types/koa": "^2.0.52",

--- a/src/common/envelope.ts
+++ b/src/common/envelope.ts
@@ -1,5 +1,5 @@
+import { forEachEnvelopeItem } from '@sentry/core';
 import { Attachment, AttachmentItem, Envelope, Event, EventItem, Profile } from '@sentry/types';
-import { forEachEnvelopeItem } from '@sentry/utils';
 
 /** Pulls an event and additional envelope items out of an envelope. Returns undefined if there was no event */
 export function eventFromEnvelope(envelope: Envelope): [Event, Attachment[], Profile | undefined] | undefined {

--- a/src/main/anr.ts
+++ b/src/main/anr.ts
@@ -1,6 +1,6 @@
+import { callFrameToStackFrame, logger, stripSentryFramesAndReverse, watchdogTimer } from '@sentry/core';
 import { captureEvent, createGetModuleFromFilename, getClient, StackFrame } from '@sentry/node';
 import { Event } from '@sentry/types';
-import { callFrameToStackFrame, logger, stripSentryFramesAndReverse, watchdogTimer } from '@sentry/utils';
 import { app, WebContents } from 'electron';
 
 import { RendererStatus } from '../common/ipc';

--- a/src/main/electron-normalize.ts
+++ b/src/main/electron-normalize.ts
@@ -1,4 +1,4 @@
-import { parseSemver } from '@sentry/utils';
+import { parseSemver } from '@sentry/core';
 import { app } from 'electron';
 import { join } from 'path';
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -22,6 +22,7 @@ export {
   addEventProcessor,
   addIntegration,
   addOpenTelemetryInstrumentation,
+  // eslint-disable-next-line deprecation/deprecation
   addRequestDataToEvent,
   amqplibIntegration,
   captureCheckIn,
@@ -47,6 +48,7 @@ export {
   endSession,
   expressErrorHandler,
   expressIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   extractRequestData,
   extraErrorDataIntegration,
   fastifyIntegration,

--- a/src/main/integrations/electron-minidump.ts
+++ b/src/main/integrations/electron-minidump.ts
@@ -1,7 +1,6 @@
-import { applyScopeDataToEvent, defineIntegration } from '@sentry/core';
+import { applyScopeDataToEvent, defineIntegration, logger, makeDsn, SentryError, uuid4 } from '@sentry/core';
 import { NodeClient, NodeOptions } from '@sentry/node';
 import { Event, ScopeData } from '@sentry/types';
-import { logger, makeDsn, SentryError, uuid4 } from '@sentry/utils';
 import { app, crashReporter } from 'electron';
 
 import { addScopeListener, getScopeData } from '../../common/scope';

--- a/src/main/integrations/net-breadcrumbs.ts
+++ b/src/main/integrations/net-breadcrumbs.ts
@@ -1,26 +1,24 @@
 import {
   addBreadcrumb,
   defineIntegration,
+  dynamicSamplingContextToSentryBaggageHeader,
+  fill,
+  generateSentryTraceHeader,
   getClient,
   getCurrentScope,
   getDynamicSamplingContextFromClient,
   getDynamicSamplingContextFromSpan,
   getIsolationScope,
+  logger,
+  LRUMap,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SentryNonRecordingSpan,
   setHttpStatus,
   spanToTraceHeader,
   startInactiveSpan,
+  stringMatchesSomePattern,
 } from '@sentry/core';
 import { DynamicSamplingContext, TracePropagationTargets } from '@sentry/types';
-import {
-  dynamicSamplingContextToSentryBaggageHeader,
-  fill,
-  generateSentryTraceHeader,
-  logger,
-  LRUMap,
-  stringMatchesSomePattern,
-} from '@sentry/utils';
 import { ClientRequest, ClientRequestConstructorOptions, IncomingMessage, net as electronNet } from 'electron';
 import * as urlModule from 'url';
 

--- a/src/main/integrations/preload-injection.ts
+++ b/src/main/integrations/preload-injection.ts
@@ -1,5 +1,4 @@
-import { defineIntegration } from '@sentry/core';
-import { logger } from '@sentry/utils';
+import { defineIntegration, logger } from '@sentry/core';
 import { app } from 'electron';
 import { existsSync } from 'fs';
 import { isAbsolute, resolve } from 'path';

--- a/src/main/integrations/renderer-profiling.ts
+++ b/src/main/integrations/renderer-profiling.ts
@@ -1,6 +1,5 @@
-import { defineIntegration } from '@sentry/core';
+import { defineIntegration, forEachEnvelopeItem, LRUMap } from '@sentry/core';
 import { Event, Profile } from '@sentry/types';
-import { forEachEnvelopeItem, LRUMap } from '@sentry/utils';
 import { app } from 'electron';
 
 import { getDefaultEnvironment, getDefaultReleaseName } from '../context';

--- a/src/main/integrations/screenshots.ts
+++ b/src/main/integrations/screenshots.ts
@@ -1,5 +1,4 @@
-import { defineIntegration } from '@sentry/core';
-import { logger } from '@sentry/utils';
+import { defineIntegration, logger } from '@sentry/core';
 import { BrowserWindow } from 'electron';
 
 import { ElectronMainOptions } from '../sdk';

--- a/src/main/integrations/sentry-minidump/index.ts
+++ b/src/main/integrations/sentry-minidump/index.ts
@@ -1,7 +1,6 @@
-import { applyScopeDataToEvent, captureEvent, defineIntegration, Scope } from '@sentry/core';
+import { applyScopeDataToEvent, captureEvent, defineIntegration, logger, Scope, SentryError } from '@sentry/core';
 import { NodeClient } from '@sentry/node';
 import { Event, ScopeData } from '@sentry/types';
-import { logger, SentryError } from '@sentry/utils';
 import { app, crashReporter } from 'electron';
 
 import { addScopeListener, getScopeData } from '../../../common/scope';

--- a/src/main/integrations/sentry-minidump/minidump-loader.ts
+++ b/src/main/integrations/sentry-minidump/minidump-loader.ts
@@ -1,5 +1,5 @@
+import { basename, logger } from '@sentry/core';
 import { Attachment } from '@sentry/types';
-import { basename, logger } from '@sentry/utils';
 import { app } from 'electron';
 import { promises as fs } from 'fs';
 import { join } from 'path';

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,6 +1,6 @@
+import { logger, parseEnvelope, SentryError } from '@sentry/core';
 import { captureEvent, getClient, getCurrentScope, metrics } from '@sentry/node';
 import { Attachment, Event, ScopeData } from '@sentry/types';
-import { logger, parseEnvelope, SentryError } from '@sentry/utils';
 import { app, ipcMain, protocol, WebContents, webContents } from 'electron';
 
 import { eventFromEnvelope } from '../common/envelope';

--- a/src/main/normalize.ts
+++ b/src/main/normalize.ts
@@ -1,6 +1,11 @@
-import { getCurrentScope } from '@sentry/core';
+import {
+  addItemToEnvelope,
+  createEnvelope,
+  forEachEnvelopeItem,
+  getCurrentScope,
+  normalizeUrlToBase,
+} from '@sentry/core';
 import { Envelope, Event, Profile, ReplayEvent } from '@sentry/types';
-import { addItemToEnvelope, createEnvelope, forEachEnvelopeItem, normalizeUrlToBase } from '@sentry/utils';
 
 /**
  * Normalizes all URLs in an event. See {@link normalizeUrl} for more

--- a/src/main/renderers.ts
+++ b/src/main/renderers.ts
@@ -1,4 +1,4 @@
-import { normalizeUrlToBase } from '@sentry/utils';
+import { normalizeUrlToBase } from '@sentry/core';
 import { app } from 'electron';
 
 interface Renderer {

--- a/src/main/sdk.ts
+++ b/src/main/sdk.ts
@@ -1,4 +1,4 @@
-import { getIntegrationsToSetup } from '@sentry/core';
+import { getIntegrationsToSetup, logger, stackParserFromStackParserOptions } from '@sentry/core';
 import {
   consoleIntegration,
   contextLinesIntegration,
@@ -16,7 +16,6 @@ import {
   setNodeAsyncContextStrategy,
 } from '@sentry/node';
 import { Integration, Options } from '@sentry/types';
-import { logger, stackParserFromStackParserOptions } from '@sentry/utils';
 import { Session, session, WebContents } from 'electron';
 
 import { IPCMode } from '../common/ipc';

--- a/src/main/sessions.ts
+++ b/src/main/sessions.ts
@@ -3,13 +3,13 @@ import {
   endSession as endSessionCore,
   getClient,
   getCurrentScope,
+  logger,
   makeSession,
   startSession as startSessionCore,
   updateSession,
 } from '@sentry/core';
 import { flush, NodeClient } from '@sentry/node';
 import { SerializedSession, Session, SessionContext, SessionStatus } from '@sentry/types';
-import { logger } from '@sentry/utils';
 import { app } from 'electron';
 
 import { getSentryCachePath } from './electron-normalize';

--- a/src/main/stack-parse.ts
+++ b/src/main/stack-parse.ts
@@ -1,6 +1,6 @@
+import { createStackParser, nodeStackLineParser } from '@sentry/core';
 import { createGetModuleFromFilename } from '@sentry/node';
 import { StackParser } from '@sentry/types';
-import { createStackParser, nodeStackLineParser } from '@sentry/utils';
 import { app } from 'electron';
 
 // node.js stack parser but filename normalized before parsing the module

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -1,4 +1,4 @@
-import { logger } from '@sentry/utils';
+import { logger } from '@sentry/core';
 import { promises as fs } from 'fs';
 import { dirname, join } from 'path';
 

--- a/src/main/transports/electron-net.ts
+++ b/src/main/transports/electron-net.ts
@@ -1,4 +1,4 @@
-import { createTransport } from '@sentry/core';
+import { createTransport, dropUndefinedKeys } from '@sentry/core';
 import {
   BaseTransportOptions,
   Transport,
@@ -6,7 +6,6 @@ import {
   TransportRequest,
   TransportRequestExecutor,
 } from '@sentry/types';
-import { dropUndefinedKeys } from '@sentry/utils';
 import { app, net } from 'electron';
 import { Readable, Writable } from 'stream';
 import { URL } from 'url';

--- a/src/main/transports/offline-store.ts
+++ b/src/main/transports/offline-store.ts
@@ -1,6 +1,5 @@
-import { OfflineStore } from '@sentry/core';
+import { logger, OfflineStore, parseEnvelope, serializeEnvelope, uuid4 } from '@sentry/core';
 import { Envelope } from '@sentry/types';
-import { logger, parseEnvelope, serializeEnvelope, uuid4 } from '@sentry/utils';
 import { promises as fs } from 'fs';
 import { join } from 'path';
 

--- a/src/main/utility-processes.ts
+++ b/src/main/utility-processes.ts
@@ -1,6 +1,6 @@
+import { logger, parseEnvelope } from '@sentry/core';
 import { captureEvent, getClient } from '@sentry/node';
 import { Attachment, Event } from '@sentry/types';
-import { logger, parseEnvelope } from '@sentry/utils';
 import * as electron from 'electron';
 
 import { eventFromEnvelope } from '../common/envelope';

--- a/src/renderer/integrations/scope-to-main.ts
+++ b/src/renderer/integrations/scope-to-main.ts
@@ -1,5 +1,4 @@
-import { defineIntegration } from '@sentry/core';
-import { normalize } from '@sentry/utils';
+import { defineIntegration, normalize } from '@sentry/core';
 
 import { addScopeListener } from '../../common/scope';
 import { getIPC } from '../ipc';

--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-globals */
 /* eslint-disable no-console */
-import { logger, uuid4 } from '@sentry/utils';
+import { logger, uuid4 } from '@sentry/core';
 
 import {
   IPCChannel,

--- a/src/renderer/sdk.ts
+++ b/src/renderer/sdk.ts
@@ -4,8 +4,8 @@ import {
   getDefaultIntegrations as getDefaultBrowserIntegrations,
   init as browserInit,
 } from '@sentry/browser';
+import { logger } from '@sentry/core';
 import { Integration } from '@sentry/types';
-import { logger } from '@sentry/utils';
 
 import { RendererProcessAnrOptions } from '../common/ipc';
 import { enableAnrRendererMessages } from './anr';
@@ -44,7 +44,7 @@ interface ElectronRendererOptions extends BrowserOptions {
 export function init<O extends ElectronRendererOptions>(
   options: ElectronRendererOptions & O = {} as ElectronRendererOptions & O,
   // This parameter name ensures that TypeScript error messages contain a hint for fixing SDK version mismatches
-  originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v8_40_0: O) => void = browserInit,
+  originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v8_41_0: O) => void = browserInit,
 ): void {
   // Ensure the browser SDK is only init'ed once.
   if (window?.__SENTRY__RENDERER_INIT__) {

--- a/src/renderer/stack-parse.ts
+++ b/src/renderer/stack-parse.ts
@@ -1,6 +1,6 @@
 import { chromeStackLineParser } from '@sentry/browser';
+import { dropUndefinedKeys, nodeStackLineParser, stripSentryFramesAndReverse } from '@sentry/core';
 import { StackFrame, StackParser } from '@sentry/types';
-import { dropUndefinedKeys, nodeStackLineParser, stripSentryFramesAndReverse } from '@sentry/utils';
 
 const STACKTRACE_FRAME_LIMIT = 50;
 

--- a/src/utility/index.ts
+++ b/src/utility/index.ts
@@ -22,6 +22,7 @@ export {
   addEventProcessor,
   addIntegration,
   addOpenTelemetryInstrumentation,
+  // eslint-disable-next-line deprecation/deprecation
   addRequestDataToEvent,
   amqplibIntegration,
   captureCheckIn,
@@ -48,6 +49,7 @@ export {
   endSession,
   expressErrorHandler,
   expressIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   extractRequestData,
   extraErrorDataIntegration,
   fastifyIntegration,

--- a/src/utility/sdk.ts
+++ b/src/utility/sdk.ts
@@ -1,4 +1,10 @@
-import { getIntegrationsToSetup } from '@sentry/core';
+import {
+  createStackParser,
+  getIntegrationsToSetup,
+  logger,
+  nodeStackLineParser,
+  stackParserFromStackParserOptions,
+} from '@sentry/core';
 import {
   consoleIntegration,
   createGetModuleFromFilename,
@@ -15,7 +21,6 @@ import {
   setNodeAsyncContextStrategy,
 } from '@sentry/node';
 import { Integration, StackParser } from '@sentry/types';
-import { createStackParser, logger, nodeStackLineParser, stackParserFromStackParserOptions } from '@sentry/utils';
 
 import { makeUtilityProcessTransport } from './transport';
 

--- a/test/e2e/context.ts
+++ b/test/e2e/context.ts
@@ -1,4 +1,4 @@
-import { parseSemver } from '@sentry/utils';
+import { parseSemver } from '@sentry/core';
 import { ChildProcess, spawn, spawnSync } from 'child_process';
 import { rmSync } from 'fs';
 import { homedir } from 'os';

--- a/test/e2e/recipe/eval.ts
+++ b/test/e2e/recipe/eval.ts
@@ -1,4 +1,4 @@
-import { parseSemver } from '@sentry/utils';
+import { parseSemver } from '@sentry/core';
 import { Context, createContext, runInContext } from 'vm';
 
 import { createLogger } from '../utils';

--- a/test/e2e/recipe/index.ts
+++ b/test/e2e/recipe/index.ts
@@ -1,5 +1,5 @@
+import { parseSemver } from '@sentry/core';
 import { Event } from '@sentry/types';
-import { parseSemver } from '@sentry/utils';
 import { spawnSync } from 'child_process';
 import { mkdirSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';

--- a/test/e2e/server/index.ts
+++ b/test/e2e/server/index.ts
@@ -1,5 +1,5 @@
+import { dropUndefinedKeys, forEachEnvelopeItem, parseEnvelope } from '@sentry/core';
 import { Event, Profile, ReplayEvent, Session } from '@sentry/types';
-import { dropUndefinedKeys, forEachEnvelopeItem, parseEnvelope } from '@sentry/utils';
 import { Server } from 'http';
 import Koa from 'koa';
 import bodyParser from 'koa-bodyparser';

--- a/test/unit/minidump-loader.test.ts
+++ b/test/unit/minidump-loader.test.ts
@@ -1,6 +1,6 @@
 import '../../scripts/electron-shim.mjs';
 
-import { uuid4 } from '@sentry/utils';
+import { uuid4 } from '@sentry/core';
 import { closeSync, existsSync, openSync, utimesSync, writeFileSync, writeSync } from 'fs';
 import { join } from 'path';
 import * as tmp from 'tmp';

--- a/yarn.lock
+++ b/yarn.lock
@@ -724,21 +724,21 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@sentry-internal/browser-utils@8.40.0":
-  version "8.40.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/browser-utils/-/browser-utils-8.40.0.tgz#972925a9d600723dd1a022297100e97e92f4c903"
-  integrity sha512-tx7gb/PWMbTEyil/XPETVeRUeS3nKHIvQY2omyebw30TbhyLnibPZsUmXJiaIysL5PcY3k9maub3W/o0Y37T7Q==
+"@sentry-internal/browser-utils@8.41.0":
+  version "8.41.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/browser-utils/-/browser-utils-8.41.0.tgz#9dc30a8c88aa6e1e542e5acae29ceabd1b377cc4"
+  integrity sha512-nU7Bn3jEUmf1QXRUT3j2ewUBlFJpe9vnAnjqpeVPDWTsVI52BwVNcJHuE37PrGs66OZ1ZkGMfKnQk43oCAa+oQ==
   dependencies:
-    "@sentry/core" "8.40.0"
-    "@sentry/types" "8.40.0"
+    "@sentry/core" "8.41.0"
+    "@sentry/types" "8.41.0"
 
-"@sentry-internal/eslint-config-sdk@8.40.0":
-  version "8.40.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-8.40.0.tgz#cd3bfc8d20386535c0ba075f2fcae44576d6a985"
-  integrity sha512-utEkF8QqCHRSuN2/Wp2usjmhXUJDPcwlru/pEbqRMsE48xSQ28E0UapmYeiOYzQ9nOwpHXvq2ydosqBEk4+rPw==
+"@sentry-internal/eslint-config-sdk@8.41.0":
+  version "8.41.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-8.41.0.tgz#23fb347122c3f54d81949815bd8bb674ab30f0d3"
+  integrity sha512-LhPGItkR77rR8ivufdMIWcWdfXD5zo0ofgjjeLDi4lke+vXBetp/JZYiBxAokamEe5o5iGOoV4R5aRr9UUuJsw==
   dependencies:
-    "@sentry-internal/eslint-plugin-sdk" "8.40.0"
-    "@sentry-internal/typescript" "8.40.0"
+    "@sentry-internal/eslint-plugin-sdk" "8.41.0"
+    "@sentry-internal/typescript" "8.41.0"
     "@typescript-eslint/eslint-plugin" "^5.48.0"
     "@typescript-eslint/parser" "^5.48.0"
     eslint-config-prettier "^6.11.0"
@@ -748,65 +748,65 @@
     eslint-plugin-jsdoc "^30.0.3"
     eslint-plugin-simple-import-sort "^5.0.3"
 
-"@sentry-internal/eslint-plugin-sdk@8.40.0":
-  version "8.40.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-8.40.0.tgz#bf09f91dbff00c3d347193a80eb7aa5b2f552162"
-  integrity sha512-O324hSZ2Y1yMPQiH1/NZ79Rdl0Z0m9NblMZ8fPfFV1fn7inP8NrI8Oz1ziwEjFgL7wBAbLaWEfttjsQ/6M1IBQ==
+"@sentry-internal/eslint-plugin-sdk@8.41.0":
+  version "8.41.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-8.41.0.tgz#2733e5b098336a1625d0ab3d684a569953a60d8d"
+  integrity sha512-OdeV3m0kQHoWmFeEDGYvEBr1m24RW1ZlVQ/3J75exw22bAEHX00gX7zQ0ZXSlc+I/8qrQY+6Em/EN4ebohDznA==
 
-"@sentry-internal/feedback@8.40.0":
-  version "8.40.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/feedback/-/feedback-8.40.0.tgz#5549f73d32b9a2509ffb0a07bf462ed8085178ec"
-  integrity sha512-1O9F3z80HNE0VfepKS+v+dixdatNqWlrlwgvvWl4BGzzoA+XhqvZo+HWxiOt7yx7+k1TuZNrB6Gy3u/QvpozXA==
+"@sentry-internal/feedback@8.41.0":
+  version "8.41.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/feedback/-/feedback-8.41.0.tgz#9c3c95e6f7738a0d00fcb89061c284baef313ba2"
+  integrity sha512-bw+BrSNw8abOnu/IpD8YSbYubXkkT8jyNS7TM4e4UPZMuXcbtia7/r5d7kAiUfKv/sV5PNMlZLOk+EYJeLTANg==
   dependencies:
-    "@sentry/core" "8.40.0"
-    "@sentry/types" "8.40.0"
+    "@sentry/core" "8.41.0"
+    "@sentry/types" "8.41.0"
 
-"@sentry-internal/replay-canvas@8.40.0":
-  version "8.40.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/replay-canvas/-/replay-canvas-8.40.0.tgz#6de0d67ee2fe3e503c6f85faeefab5df742a3ebe"
-  integrity sha512-Zr+m/le0SH4RowZB7rBCM0aRnvH3wZTaOFhwUk03/oGf2BRcgKuDCUMjnXKC9MyOpmey7UYXkzb8ro+81R6Q8w==
+"@sentry-internal/replay-canvas@8.41.0":
+  version "8.41.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/replay-canvas/-/replay-canvas-8.41.0.tgz#9da984adc54fcd8ebe07cbbc13132fa78396dd01"
+  integrity sha512-lpgOBHWr1ZNxidD72A2pfoUMjIpwonOPYoQZWAHr86Oa3eIVQOyfklZlHW+gKPFl2/IEl9Lbtcke0JiDp3dkIQ==
   dependencies:
-    "@sentry-internal/replay" "8.40.0"
-    "@sentry/core" "8.40.0"
-    "@sentry/types" "8.40.0"
+    "@sentry-internal/replay" "8.41.0"
+    "@sentry/core" "8.41.0"
+    "@sentry/types" "8.41.0"
 
-"@sentry-internal/replay@8.40.0":
-  version "8.40.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/replay/-/replay-8.40.0.tgz#54c7f1e3d115f9324f34e1b8875a95463a23049f"
-  integrity sha512-0SaDsBCSWxNVgNmPKu23frrHEXzN/MKl0hIkfuO55vL5TgjLTwpgkf0Ne4rNvaZQ5omIKk9Qd63HuQP3PHAMaw==
+"@sentry-internal/replay@8.41.0":
+  version "8.41.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/replay/-/replay-8.41.0.tgz#b1112a52a0cf1727589ad4d42a8fac9f98f6d733"
+  integrity sha512-ByXEY7JI95y4Qr9fS3d28l9uuVU5Qa0HgL+xDmYElNx7CXz3Q9hFN6ibgUeC3h8BO5pDULxWNgAppl7FRY8N5w==
   dependencies:
-    "@sentry-internal/browser-utils" "8.40.0"
-    "@sentry/core" "8.40.0"
-    "@sentry/types" "8.40.0"
+    "@sentry-internal/browser-utils" "8.41.0"
+    "@sentry/core" "8.41.0"
+    "@sentry/types" "8.41.0"
 
-"@sentry-internal/typescript@8.40.0":
-  version "8.40.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-8.40.0.tgz#9ec76cbb95ba1e68c6188be80332b2654f781b4f"
-  integrity sha512-vqqcCvT6i8O5WQa5Z/b2C6VlUhddhWCik06UV3ds3AtyQnC7Xa6POEiSo9LsT8+V7ZHRwAkbpHJg932MK1Sd6w==
+"@sentry-internal/typescript@8.41.0":
+  version "8.41.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-8.41.0.tgz#ca9ddea52fb21740298572efac71e999ab3f1323"
+  integrity sha512-Ri4x6FLJzAsBaU8fmS4jbrw4pSnmy7i9jlBt4MkyMATRFgL/5WfLvvra7ZnSGxsbL1f/CvbawENZJkNRq5xrMg==
 
-"@sentry/browser@8.40.0":
-  version "8.40.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-8.40.0.tgz#de7b4531be2ac4667755e9e1b5da3808851392ae"
-  integrity sha512-m/Yor6IDBeDHtQochu8n6z4HXrXkrPhu6+o5Ouve0Zi3ptthSoK1FOGvJxVBat3nRq0ydQyuuPuTB6WfdWbwHQ==
+"@sentry/browser@8.41.0":
+  version "8.41.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-8.41.0.tgz#f594012e6377a92db72127ef39aee812efe3a3b7"
+  integrity sha512-FfAU55eYwW2lG4M3dEw2472RvHrD5YWSfHCZvuRf/4skX38kFvKghZQ+epL+CVHTzvIRHOrbj8qQK6YLTGl9ew==
   dependencies:
-    "@sentry-internal/browser-utils" "8.40.0"
-    "@sentry-internal/feedback" "8.40.0"
-    "@sentry-internal/replay" "8.40.0"
-    "@sentry-internal/replay-canvas" "8.40.0"
-    "@sentry/core" "8.40.0"
-    "@sentry/types" "8.40.0"
+    "@sentry-internal/browser-utils" "8.41.0"
+    "@sentry-internal/feedback" "8.41.0"
+    "@sentry-internal/replay" "8.41.0"
+    "@sentry-internal/replay-canvas" "8.41.0"
+    "@sentry/core" "8.41.0"
+    "@sentry/types" "8.41.0"
 
-"@sentry/core@8.40.0":
-  version "8.40.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-8.40.0.tgz#cb5c02d12e29070bf88692c64cfd7db7700be4ea"
-  integrity sha512-u/U2CJpG/+SmTR2bPM4ZZoPYTJAOUuxzj/0IURnvI0v9+rNu939J/fzrO9huA5IJVxS5TiYykhQm7o6I3Zuo3Q==
+"@sentry/core@8.41.0":
+  version "8.41.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-8.41.0.tgz#e8a25cacd25fe4358f3179e85f3c2697427fe5a6"
+  integrity sha512-3v7u3t4LozCA5SpZY4yqUN2U3jSrkXNoLgz6L2SUUiydyCuSwXZIFEwpLJfgQyidpNDifeQbBI5E1O910XkPsA==
   dependencies:
-    "@sentry/types" "8.40.0"
+    "@sentry/types" "8.41.0"
 
-"@sentry/node@8.40.0":
-  version "8.40.0"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-8.40.0.tgz#0dcf4ae224698191e59dba026a5249a27e98fc97"
-  integrity sha512-UO1jWuO+z4DnK2NYCvQQfpNbfFYgeV//cNS83QIPkj9hPIEOpUR2DAfPmI9bj2Yjdh7WE8IN9Can9xDcfJquMQ==
+"@sentry/node@8.41.0":
+  version "8.41.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-8.41.0.tgz#52f970648d961f6e82a1b23a88c0000aa72ba21a"
+  integrity sha512-eYD5S8Lti9efBHFSIhZ/0C5uI1DQtGqjuNWQ62CKC47G2qgJddBtb2HgqRFAnMajYL9FXEtiDT6uqQhKQnmLcQ==
   dependencies:
     "@opentelemetry/api" "^1.9.0"
     "@opentelemetry/context-async-hooks" "^1.25.1"
@@ -840,31 +840,23 @@
     "@opentelemetry/sdk-trace-base" "^1.26.0"
     "@opentelemetry/semantic-conventions" "^1.27.0"
     "@prisma/instrumentation" "5.19.1"
-    "@sentry/core" "8.40.0"
-    "@sentry/opentelemetry" "8.40.0"
-    "@sentry/types" "8.40.0"
+    "@sentry/core" "8.41.0"
+    "@sentry/opentelemetry" "8.41.0"
+    "@sentry/types" "8.41.0"
     import-in-the-middle "^1.11.2"
 
-"@sentry/opentelemetry@8.40.0":
-  version "8.40.0"
-  resolved "https://registry.yarnpkg.com/@sentry/opentelemetry/-/opentelemetry-8.40.0.tgz#55d19770cc2cc61084f4c04b728a550c06282ab0"
-  integrity sha512-kW9EBRESjNnBdj2zCqNMv8x0VIsmiALIOMpi25Dpm38IKtRg/ckQ7YOWx1lnT3iOFebO2GXUvOu+gPmuzIY2WQ==
+"@sentry/opentelemetry@8.41.0":
+  version "8.41.0"
+  resolved "https://registry.yarnpkg.com/@sentry/opentelemetry/-/opentelemetry-8.41.0.tgz#0e5c4bb8d5b58f07eb80e312fc66b8709a688c61"
+  integrity sha512-Ld6KdBQsmSk2IfFSoZ7CMpmuQbfb3viV6nTDCz6+11wL9S+1b+hadCN+38yBW4CmI4/hEpYfwwWQPseQQTvBCg==
   dependencies:
-    "@sentry/core" "8.40.0"
-    "@sentry/types" "8.40.0"
+    "@sentry/core" "8.41.0"
+    "@sentry/types" "8.41.0"
 
-"@sentry/types@8.40.0":
-  version "8.40.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-8.40.0.tgz#a98d2bcc48adbc066b403713688ded3ac5eb1cec"
-  integrity sha512-nuCf3U3deolPM9BjNnwCc33UtFl9ec15/r74ngAkNccn+A2JXdIAsDkGJMO/9mgSFykLe1QyeJ0pQFRisCGOiA==
-
-"@sentry/utils@8.40.0":
-  version "8.40.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-8.40.0.tgz#e2cbf1dfe2e97015568d24cbd777721ee1a95f14"
-  integrity sha512-JrfnrQ4irbXWTb+8QC5TCefr3KJJ1x4tJr5p+HyVy4df0n7SIvSqQNeG2P8uuT82F4puFsD6hkQYxuGr3y/NSw==
-  dependencies:
-    "@sentry/core" "8.40.0"
-    "@sentry/types" "8.40.0"
+"@sentry/types@8.41.0":
+  version "8.41.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-8.41.0.tgz#db40c93bcedad26569c5dfe10a4b31253c349a10"
+  integrity sha512-eqdnGr9k9H++b9CjVUoTNUVahPVWeNnMy0YGkqS5+cjWWC+x43p56202oidGFmWo6702ub/xwUNH6M5PC4kq6A==
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"


### PR DESCRIPTION
This involved removing `@sentry/utils` as a dependency and pointing all the existing imports to `@sentry/core`