### PR TITLE
feat: Update Sentry JavaScript SDKs to v8.42.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,17 +60,16 @@
     "e2e": "xvfb-maybe vitest run --root=./test/e2e --silent=false --disable-console-intercept"
   },
   "dependencies": {
-    "@sentry/browser": "8.41.0",
-    "@sentry/core": "8.41.0",
-    "@sentry/node": "8.41.0",
-    "@sentry/types": "8.41.0",
+    "@sentry/browser": "8.42.0",
+    "@sentry/core": "8.42.0",
+    "@sentry/node": "8.42.0",
     "deepmerge": "4.3.1"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-typescript": "^11.1.6",
-    "@sentry-internal/eslint-config-sdk": "8.41.0",
-    "@sentry-internal/typescript": "8.41.0",
+    "@sentry-internal/eslint-config-sdk": "8.42.0",
+    "@sentry-internal/typescript": "8.42.0",
     "@types/busboy": "^1.5.4",
     "@types/form-data": "^2.5.0",
     "@types/koa": "^2.0.52",

--- a/src/common/envelope.ts
+++ b/src/common/envelope.ts
@@ -1,5 +1,4 @@
-import { forEachEnvelopeItem } from '@sentry/core';
-import { Attachment, AttachmentItem, Envelope, Event, EventItem, Profile } from '@sentry/types';
+import { Attachment, AttachmentItem, Envelope, Event, EventItem, forEachEnvelopeItem, Profile } from '@sentry/core';
 
 /** Pulls an event and additional envelope items out of an envelope. Returns undefined if there was no event */
 export function eventFromEnvelope(envelope: Envelope): [Event, Attachment[], Profile | undefined] | undefined {

--- a/src/common/ipc.ts
+++ b/src/common/ipc.ts
@@ -1,4 +1,4 @@
-import { MeasurementUnit, Primitive } from '@sentry/types';
+import { MeasurementUnit, Primitive } from '@sentry/core';
 
 /** Ways to communicate between the renderer and main process  */
 export enum IPCMode {

--- a/src/common/scope.ts
+++ b/src/common/scope.ts
@@ -1,5 +1,4 @@
-import { getCurrentScope, getGlobalScope, getIsolationScope, mergeScopeData } from '@sentry/core';
-import { Scope, ScopeData } from '@sentry/types';
+import { getCurrentScope, getGlobalScope, getIsolationScope, mergeScopeData, Scope, ScopeData } from '@sentry/core';
 
 /** Gets the merged scope data */
 export function getScopeData(): ScopeData {

--- a/src/main/anr.ts
+++ b/src/main/anr.ts
@@ -1,6 +1,5 @@
-import { callFrameToStackFrame, logger, stripSentryFramesAndReverse, watchdogTimer } from '@sentry/core';
+import { callFrameToStackFrame, Event, logger, stripSentryFramesAndReverse, watchdogTimer } from '@sentry/core';
 import { captureEvent, createGetModuleFromFilename, getClient, StackFrame } from '@sentry/node';
-import { Event } from '@sentry/types';
 import { app, WebContents } from 'electron';
 
 import { RendererStatus } from '../common/ipc';

--- a/src/main/context.ts
+++ b/src/main/context.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
+import { Event, EventHint, SdkInfo } from '@sentry/core';
 import { NodeClient } from '@sentry/node';
-import { Event, EventHint, SdkInfo } from '@sentry/types';
 import { app } from 'electron';
 
 import { SDK_VERSION } from './version';

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,12 +15,13 @@ export type {
   Thread,
   User,
   Span,
-} from '@sentry/types';
+} from '@sentry/core';
 
 export {
   addBreadcrumb,
   addEventProcessor,
   addIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   addOpenTelemetryInstrumentation,
   // eslint-disable-next-line deprecation/deprecation
   addRequestDataToEvent,

--- a/src/main/integrations/additional-context.ts
+++ b/src/main/integrations/additional-context.ts
@@ -1,5 +1,4 @@
-import { defineIntegration } from '@sentry/core';
-import { DeviceContext } from '@sentry/types';
+import { defineIntegration, DeviceContext } from '@sentry/core';
 import { app, screen as electronScreen } from 'electron';
 
 import { mergeEvents } from '../merge';

--- a/src/main/integrations/anr.ts
+++ b/src/main/integrations/anr.ts
@@ -1,6 +1,5 @@
-import { defineIntegration } from '@sentry/core';
+import { defineIntegration, Integration } from '@sentry/core';
 import { anrIntegration as nodeAnrIntegration } from '@sentry/node';
-import { Integration } from '@sentry/types';
 import { app, powerMonitor } from 'electron';
 
 import { ELECTRON_MAJOR_VERSION } from '../electron-normalize';

--- a/src/main/integrations/child-process.ts
+++ b/src/main/integrations/child-process.ts
@@ -1,6 +1,5 @@
-import { addBreadcrumb, captureMessage, defineIntegration } from '@sentry/core';
+import { addBreadcrumb, captureMessage, defineIntegration, SeverityLevel } from '@sentry/core';
 import { NodeClient } from '@sentry/node';
-import { SeverityLevel } from '@sentry/types';
 import { app } from 'electron';
 
 import { EXIT_REASONS, ExitReason } from '../electron-normalize';

--- a/src/main/integrations/electron-breadcrumbs.ts
+++ b/src/main/integrations/electron-breadcrumbs.ts
@@ -1,6 +1,5 @@
-import { addBreadcrumb, defineIntegration } from '@sentry/core';
+import { addBreadcrumb, Breadcrumb, defineIntegration } from '@sentry/core';
 import { NodeClient } from '@sentry/node';
-import { Breadcrumb } from '@sentry/types';
 import { app, autoUpdater, BrowserWindow, powerMonitor, screen, WebContents } from 'electron';
 
 import { getRendererProperties, trackRendererProperties } from '../renderers';

--- a/src/main/integrations/electron-minidump.ts
+++ b/src/main/integrations/electron-minidump.ts
@@ -1,6 +1,14 @@
-import { applyScopeDataToEvent, defineIntegration, logger, makeDsn, SentryError, uuid4 } from '@sentry/core';
+import {
+  applyScopeDataToEvent,
+  defineIntegration,
+  Event,
+  logger,
+  makeDsn,
+  ScopeData,
+  SentryError,
+  uuid4,
+} from '@sentry/core';
 import { NodeClient, NodeOptions } from '@sentry/node';
-import { Event, ScopeData } from '@sentry/types';
 import { app, crashReporter } from 'electron';
 
 import { addScopeListener, getScopeData } from '../../common/scope';

--- a/src/main/integrations/net-breadcrumbs.ts
+++ b/src/main/integrations/net-breadcrumbs.ts
@@ -1,6 +1,7 @@
 import {
   addBreadcrumb,
   defineIntegration,
+  DynamicSamplingContext,
   dynamicSamplingContextToSentryBaggageHeader,
   fill,
   generateSentryTraceHeader,
@@ -17,8 +18,8 @@ import {
   spanToTraceHeader,
   startInactiveSpan,
   stringMatchesSomePattern,
+  TracePropagationTargets,
 } from '@sentry/core';
-import { DynamicSamplingContext, TracePropagationTargets } from '@sentry/types';
 import { ClientRequest, ClientRequestConstructorOptions, IncomingMessage, net as electronNet } from 'electron';
 import * as urlModule from 'url';
 
@@ -180,6 +181,7 @@ function createWrappedRequestFactory(
       span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, 'auto.http.electron.net');
 
       if (shouldAttachTraceData(method, url)) {
+        // eslint-disable-next-line deprecation/deprecation
         const { traceId, spanId, sampled, dsc } = {
           ...getIsolationScope().getPropagationContext(),
           ...getCurrentScope().getPropagationContext(),

--- a/src/main/integrations/renderer-profiling.ts
+++ b/src/main/integrations/renderer-profiling.ts
@@ -1,5 +1,4 @@
-import { defineIntegration, forEachEnvelopeItem, LRUMap } from '@sentry/core';
-import { Event, Profile } from '@sentry/types';
+import { defineIntegration, Event, forEachEnvelopeItem, LRUMap, Profile } from '@sentry/core';
 import { app } from 'electron';
 
 import { getDefaultEnvironment, getDefaultReleaseName } from '../context';

--- a/src/main/integrations/sentry-minidump/index.ts
+++ b/src/main/integrations/sentry-minidump/index.ts
@@ -1,6 +1,14 @@
-import { applyScopeDataToEvent, captureEvent, defineIntegration, logger, Scope, SentryError } from '@sentry/core';
+import {
+  applyScopeDataToEvent,
+  captureEvent,
+  defineIntegration,
+  Event,
+  logger,
+  Scope,
+  ScopeData,
+  SentryError,
+} from '@sentry/core';
 import { NodeClient } from '@sentry/node';
-import { Event, ScopeData } from '@sentry/types';
 import { app, crashReporter } from 'electron';
 
 import { addScopeListener, getScopeData } from '../../../common/scope';

--- a/src/main/integrations/sentry-minidump/minidump-loader.ts
+++ b/src/main/integrations/sentry-minidump/minidump-loader.ts
@@ -1,5 +1,4 @@
-import { basename, logger } from '@sentry/core';
-import { Attachment } from '@sentry/types';
+import { Attachment, basename, logger } from '@sentry/core';
 import { app } from 'electron';
 import { promises as fs } from 'fs';
 import { join } from 'path';

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,6 +1,5 @@
-import { logger, parseEnvelope, SentryError } from '@sentry/core';
+import { Attachment, Event, logger, parseEnvelope, ScopeData, SentryError } from '@sentry/core';
 import { captureEvent, getClient, getCurrentScope, metrics } from '@sentry/node';
-import { Attachment, Event, ScopeData } from '@sentry/types';
 import { app, ipcMain, protocol, WebContents, webContents } from 'electron';
 
 import { eventFromEnvelope } from '../common/envelope';

--- a/src/main/merge.ts
+++ b/src/main/merge.ts
@@ -1,4 +1,4 @@
-import { Event } from '@sentry/types';
+import { Event } from '@sentry/core';
 import deepMerge from 'deepmerge';
 
 /** Removes private properties from event before merging */

--- a/src/main/normalize.ts
+++ b/src/main/normalize.ts
@@ -1,11 +1,14 @@
 import {
   addItemToEnvelope,
   createEnvelope,
+  Envelope,
+  Event,
   forEachEnvelopeItem,
   getCurrentScope,
   normalizeUrlToBase,
+  Profile,
+  ReplayEvent,
 } from '@sentry/core';
-import { Envelope, Event, Profile, ReplayEvent } from '@sentry/types';
 
 /**
  * Normalizes all URLs in an event. See {@link normalizeUrl} for more

--- a/src/main/sdk.ts
+++ b/src/main/sdk.ts
@@ -1,4 +1,4 @@
-import { getIntegrationsToSetup, logger, stackParserFromStackParserOptions } from '@sentry/core';
+import { getIntegrationsToSetup, Integration, logger, Options, stackParserFromStackParserOptions } from '@sentry/core';
 import {
   consoleIntegration,
   contextLinesIntegration,
@@ -15,7 +15,6 @@ import {
   onUnhandledRejectionIntegration,
   setNodeAsyncContextStrategy,
 } from '@sentry/node';
-import { Integration, Options } from '@sentry/types';
 import { Session, session, WebContents } from 'electron';
 
 import { IPCMode } from '../common/ipc';

--- a/src/main/sessions.ts
+++ b/src/main/sessions.ts
@@ -5,11 +5,14 @@ import {
   getCurrentScope,
   logger,
   makeSession,
+  SerializedSession,
+  Session,
+  SessionContext,
+  SessionStatus,
   startSession as startSessionCore,
   updateSession,
 } from '@sentry/core';
 import { flush, NodeClient } from '@sentry/node';
-import { SerializedSession, Session, SessionContext, SessionStatus } from '@sentry/types';
 import { app } from 'electron';
 
 import { getSentryCachePath } from './electron-normalize';

--- a/src/main/stack-parse.ts
+++ b/src/main/stack-parse.ts
@@ -1,6 +1,5 @@
-import { createStackParser, nodeStackLineParser } from '@sentry/core';
+import { createStackParser, nodeStackLineParser, StackParser } from '@sentry/core';
 import { createGetModuleFromFilename } from '@sentry/node';
-import { StackParser } from '@sentry/types';
 import { app } from 'electron';
 
 // node.js stack parser but filename normalized before parsing the module

--- a/src/main/transports/electron-net.ts
+++ b/src/main/transports/electron-net.ts
@@ -1,11 +1,12 @@
-import { createTransport, dropUndefinedKeys } from '@sentry/core';
 import {
   BaseTransportOptions,
+  createTransport,
+  dropUndefinedKeys,
   Transport,
   TransportMakeRequestResponse,
   TransportRequest,
   TransportRequestExecutor,
-} from '@sentry/types';
+} from '@sentry/core';
 import { app, net } from 'electron';
 import { Readable, Writable } from 'stream';
 import { URL } from 'url';

--- a/src/main/transports/electron-offline-net.ts
+++ b/src/main/transports/electron-offline-net.ts
@@ -1,5 +1,4 @@
-import { makeOfflineTransport, OfflineTransportOptions } from '@sentry/core';
-import { BaseTransportOptions, Envelope, Transport } from '@sentry/types';
+import { BaseTransportOptions, Envelope, makeOfflineTransport, OfflineTransportOptions, Transport } from '@sentry/core';
 
 import { ElectronNetTransportOptions, makeElectronTransport } from './electron-net';
 import { createOfflineStore, OfflineStoreOptions } from './offline-store';

--- a/src/main/transports/offline-store.ts
+++ b/src/main/transports/offline-store.ts
@@ -1,5 +1,4 @@
-import { logger, OfflineStore, parseEnvelope, serializeEnvelope, uuid4 } from '@sentry/core';
-import { Envelope } from '@sentry/types';
+import { Envelope, logger, OfflineStore, parseEnvelope, serializeEnvelope, uuid4 } from '@sentry/core';
 import { promises as fs } from 'fs';
 import { join } from 'path';
 

--- a/src/main/utility-processes.ts
+++ b/src/main/utility-processes.ts
@@ -1,6 +1,5 @@
-import { logger, parseEnvelope } from '@sentry/core';
+import { Attachment, Event, logger, parseEnvelope } from '@sentry/core';
 import { captureEvent, getClient } from '@sentry/node';
-import { Attachment, Event } from '@sentry/types';
 import * as electron from 'electron';
 
 import { eventFromEnvelope } from '../common/envelope';

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -13,7 +13,7 @@ export type {
   Thread,
   User,
   Session,
-} from '@sentry/types';
+} from '@sentry/core';
 
 export {
   addBreadcrumb,

--- a/src/renderer/metrics.ts
+++ b/src/renderer/metrics.ts
@@ -1,6 +1,5 @@
 import type { MetricData } from '@sentry/core';
-import { metrics as metricsCore } from '@sentry/core';
-import { DurationUnit, MeasurementUnit, MetricsAggregator, Primitive } from '@sentry/types';
+import { DurationUnit, MeasurementUnit, metrics as metricsCore, MetricsAggregator, Primitive } from '@sentry/core';
 
 import { IPCInterface } from '../common/ipc';
 import { getIPC } from './ipc';

--- a/src/renderer/sdk.ts
+++ b/src/renderer/sdk.ts
@@ -4,8 +4,7 @@ import {
   getDefaultIntegrations as getDefaultBrowserIntegrations,
   init as browserInit,
 } from '@sentry/browser';
-import { logger } from '@sentry/core';
-import { Integration } from '@sentry/types';
+import { Integration, logger } from '@sentry/core';
 
 import { RendererProcessAnrOptions } from '../common/ipc';
 import { enableAnrRendererMessages } from './anr';
@@ -44,7 +43,7 @@ interface ElectronRendererOptions extends BrowserOptions {
 export function init<O extends ElectronRendererOptions>(
   options: ElectronRendererOptions & O = {} as ElectronRendererOptions & O,
   // This parameter name ensures that TypeScript error messages contain a hint for fixing SDK version mismatches
-  originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v8_41_0: O) => void = browserInit,
+  originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v8_42_0: O) => void = browserInit,
 ): void {
   // Ensure the browser SDK is only init'ed once.
   if (window?.__SENTRY__RENDERER_INIT__) {

--- a/src/renderer/stack-parse.ts
+++ b/src/renderer/stack-parse.ts
@@ -1,6 +1,11 @@
 import { chromeStackLineParser } from '@sentry/browser';
-import { dropUndefinedKeys, nodeStackLineParser, stripSentryFramesAndReverse } from '@sentry/core';
-import { StackFrame, StackParser } from '@sentry/types';
+import {
+  dropUndefinedKeys,
+  nodeStackLineParser,
+  StackFrame,
+  StackParser,
+  stripSentryFramesAndReverse,
+} from '@sentry/core';
 
 const STACKTRACE_FRAME_LIMIT = 50;
 

--- a/src/renderer/transport.ts
+++ b/src/renderer/transport.ts
@@ -1,5 +1,10 @@
-import { createTransport } from '@sentry/core';
-import { BaseTransportOptions, Transport, TransportMakeRequestResponse, TransportRequest } from '@sentry/types';
+import {
+  BaseTransportOptions,
+  createTransport,
+  Transport,
+  TransportMakeRequestResponse,
+  TransportRequest,
+} from '@sentry/core';
 
 import { getIPC } from './ipc';
 

--- a/src/utility/index.ts
+++ b/src/utility/index.ts
@@ -15,12 +15,13 @@ export type {
   Thread,
   User,
   Span,
-} from '@sentry/types';
+} from '@sentry/core';
 
 export {
   addBreadcrumb,
   addEventProcessor,
   addIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   addOpenTelemetryInstrumentation,
   // eslint-disable-next-line deprecation/deprecation
   addRequestDataToEvent,

--- a/src/utility/sdk.ts
+++ b/src/utility/sdk.ts
@@ -1,8 +1,10 @@
 import {
   createStackParser,
   getIntegrationsToSetup,
+  Integration,
   logger,
   nodeStackLineParser,
+  StackParser,
   stackParserFromStackParserOptions,
 } from '@sentry/core';
 import {
@@ -20,7 +22,6 @@ import {
   onUnhandledRejectionIntegration,
   setNodeAsyncContextStrategy,
 } from '@sentry/node';
-import { Integration, StackParser } from '@sentry/types';
 
 import { makeUtilityProcessTransport } from './transport';
 

--- a/src/utility/transport.ts
+++ b/src/utility/transport.ts
@@ -1,5 +1,10 @@
-import { createTransport } from '@sentry/core';
-import { BaseTransportOptions, Transport, TransportMakeRequestResponse, TransportRequest } from '@sentry/types';
+import {
+  BaseTransportOptions,
+  createTransport,
+  Transport,
+  TransportMakeRequestResponse,
+  TransportRequest,
+} from '@sentry/core';
 
 import { getMagicMessage, isMagicMessage } from '../common/ipc';
 

--- a/test/e2e/recipe/index.ts
+++ b/test/e2e/recipe/index.ts
@@ -1,5 +1,4 @@
-import { parseSemver } from '@sentry/core';
-import { Event } from '@sentry/types';
+import { Event, parseSemver } from '@sentry/core';
 import { spawnSync } from 'child_process';
 import { mkdirSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';

--- a/test/e2e/recipe/normalize.ts
+++ b/test/e2e/recipe/normalize.ts
@@ -1,5 +1,5 @@
 /* eslint-disable complexity */
-import { Event, Profile, ReplayEvent, Session } from '@sentry/types';
+import { Event, Profile, ReplayEvent, Session } from '@sentry/core';
 
 import { TestServerEvent } from '../server';
 

--- a/test/e2e/recipe/parser.ts
+++ b/test/e2e/recipe/parser.ts
@@ -1,4 +1,4 @@
-import { Event, Session } from '@sentry/types';
+import { Event, Session } from '@sentry/core';
 import { readdirSync, readFileSync } from 'fs';
 import { dirname, join, sep } from 'path';
 import YAML from 'yaml';

--- a/test/e2e/server/index.ts
+++ b/test/e2e/server/index.ts
@@ -1,5 +1,12 @@
-import { dropUndefinedKeys, forEachEnvelopeItem, parseEnvelope } from '@sentry/core';
-import { Event, Profile, ReplayEvent, Session } from '@sentry/types';
+import {
+  dropUndefinedKeys,
+  Event,
+  forEachEnvelopeItem,
+  parseEnvelope,
+  Profile,
+  ReplayEvent,
+  Session,
+} from '@sentry/core';
 import { Server } from 'http';
 import Koa from 'koa';
 import bodyParser from 'koa-bodyparser';

--- a/test/e2e/server/multi-part.ts
+++ b/test/e2e/server/multi-part.ts
@@ -1,4 +1,4 @@
-import { Event } from '@sentry/types';
+import { Event } from '@sentry/core';
 import Busboy from 'busboy';
 import Koa from 'koa';
 import Router from 'koa-tree-router';

--- a/test/e2e/test-apps/other/window-titles/events.ts
+++ b/test/e2e/test-apps/other/window-titles/events.ts
@@ -1,4 +1,4 @@
-import { Event } from '@sentry/types';
+import { Event } from '@sentry/core';
 import { expect } from 'vitest';
 
 import { TestServerEvent } from '../../../server';

--- a/test/unit/offline-store.test.ts
+++ b/test/unit/offline-store.test.ts
@@ -1,7 +1,6 @@
 import '../../scripts/electron-shim.mjs';
 
-import { createEventEnvelope } from '@sentry/core';
-import { Envelope, Event } from '@sentry/types';
+import { createEventEnvelope, Envelope, Event } from '@sentry/core';
 import * as tmp from 'tmp';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 

--- a/test/unit/offline-transport.test.ts
+++ b/test/unit/offline-transport.test.ts
@@ -1,7 +1,13 @@
 import '../../scripts/electron-shim.mjs';
 
-import { createEventEnvelope, createTransport, OfflineTransportOptions } from '@sentry/core';
-import { Envelope, InternalBaseTransportOptions, TransportMakeRequestResponse } from '@sentry/types';
+import {
+  createEventEnvelope,
+  createTransport,
+  Envelope,
+  InternalBaseTransportOptions,
+  OfflineTransportOptions,
+  TransportMakeRequestResponse,
+} from '@sentry/core';
 import { describe, expect, test } from 'vitest';
 
 import { ElectronOfflineTransportOptions } from '../../src/main/transports/electron-offline-net';

--- a/yarn.lock
+++ b/yarn.lock
@@ -724,21 +724,20 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@sentry-internal/browser-utils@8.41.0":
-  version "8.41.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/browser-utils/-/browser-utils-8.41.0.tgz#9dc30a8c88aa6e1e542e5acae29ceabd1b377cc4"
-  integrity sha512-nU7Bn3jEUmf1QXRUT3j2ewUBlFJpe9vnAnjqpeVPDWTsVI52BwVNcJHuE37PrGs66OZ1ZkGMfKnQk43oCAa+oQ==
+"@sentry-internal/browser-utils@8.42.0":
+  version "8.42.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/browser-utils/-/browser-utils-8.42.0.tgz#18155ea3d01ddb0234a6e9f59a2c6c329ff09dde"
+  integrity sha512-xzgRI0wglKYsPrna574w1t38aftuvo44gjOKFvPNGPnYfiW9y4m+64kUz3JFbtanvOrKPcaITpdYiB4DeJXEbA==
   dependencies:
-    "@sentry/core" "8.41.0"
-    "@sentry/types" "8.41.0"
+    "@sentry/core" "8.42.0"
 
-"@sentry-internal/eslint-config-sdk@8.41.0":
-  version "8.41.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-8.41.0.tgz#23fb347122c3f54d81949815bd8bb674ab30f0d3"
-  integrity sha512-LhPGItkR77rR8ivufdMIWcWdfXD5zo0ofgjjeLDi4lke+vXBetp/JZYiBxAokamEe5o5iGOoV4R5aRr9UUuJsw==
+"@sentry-internal/eslint-config-sdk@8.42.0":
+  version "8.42.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-8.42.0.tgz#69b2f2abd3a8d3eadca91a40178f0eeaa781f2ae"
+  integrity sha512-W3vIVOkamkpLSrRJeBDmp5htyPqW2znW4bHrpGhQrId1qlh5cpa2u0QAkAme2VaE4be2U1HLGk8hr0JWFRqEjQ==
   dependencies:
-    "@sentry-internal/eslint-plugin-sdk" "8.41.0"
-    "@sentry-internal/typescript" "8.41.0"
+    "@sentry-internal/eslint-plugin-sdk" "8.42.0"
+    "@sentry-internal/typescript" "8.42.0"
     "@typescript-eslint/eslint-plugin" "^5.48.0"
     "@typescript-eslint/parser" "^5.48.0"
     eslint-config-prettier "^6.11.0"
@@ -748,65 +747,59 @@
     eslint-plugin-jsdoc "^30.0.3"
     eslint-plugin-simple-import-sort "^5.0.3"
 
-"@sentry-internal/eslint-plugin-sdk@8.41.0":
-  version "8.41.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-8.41.0.tgz#2733e5b098336a1625d0ab3d684a569953a60d8d"
-  integrity sha512-OdeV3m0kQHoWmFeEDGYvEBr1m24RW1ZlVQ/3J75exw22bAEHX00gX7zQ0ZXSlc+I/8qrQY+6Em/EN4ebohDznA==
+"@sentry-internal/eslint-plugin-sdk@8.42.0":
+  version "8.42.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-8.42.0.tgz#1f0aa21dbb49836f0bbb477699fb296b7b2e72b0"
+  integrity sha512-eIkq2NWls4UNWYiL8XMShIBevRWJmRs+1J3eEJdy8Cv4dlUXwxD9rP9e/1cdmFG2xcG8TF+IqbQcYEXZqiAaEg==
 
-"@sentry-internal/feedback@8.41.0":
-  version "8.41.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/feedback/-/feedback-8.41.0.tgz#9c3c95e6f7738a0d00fcb89061c284baef313ba2"
-  integrity sha512-bw+BrSNw8abOnu/IpD8YSbYubXkkT8jyNS7TM4e4UPZMuXcbtia7/r5d7kAiUfKv/sV5PNMlZLOk+EYJeLTANg==
+"@sentry-internal/feedback@8.42.0":
+  version "8.42.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/feedback/-/feedback-8.42.0.tgz#20275774ab81b9cf776a2ab2f8b17269b8f5f62f"
+  integrity sha512-dkIw5Wdukwzngg5gNJ0QcK48LyJaMAnBspqTqZ3ItR01STi6Z+6+/Bt5XgmrvDgRD+FNBinflc5zMmfdFXXhvw==
   dependencies:
-    "@sentry/core" "8.41.0"
-    "@sentry/types" "8.41.0"
+    "@sentry/core" "8.42.0"
 
-"@sentry-internal/replay-canvas@8.41.0":
-  version "8.41.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/replay-canvas/-/replay-canvas-8.41.0.tgz#9da984adc54fcd8ebe07cbbc13132fa78396dd01"
-  integrity sha512-lpgOBHWr1ZNxidD72A2pfoUMjIpwonOPYoQZWAHr86Oa3eIVQOyfklZlHW+gKPFl2/IEl9Lbtcke0JiDp3dkIQ==
+"@sentry-internal/replay-canvas@8.42.0":
+  version "8.42.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/replay-canvas/-/replay-canvas-8.42.0.tgz#4b8cf2e6e390a697038123f80208368bf507fb5d"
+  integrity sha512-XrPErqVhPsPh/oFLVKvz7Wb+Fi2J1zCPLeZCxWqFuPWI2agRyLVu0KvqJyzSpSrRAEJC/XFzuSVILlYlXXSfgA==
   dependencies:
-    "@sentry-internal/replay" "8.41.0"
-    "@sentry/core" "8.41.0"
-    "@sentry/types" "8.41.0"
+    "@sentry-internal/replay" "8.42.0"
+    "@sentry/core" "8.42.0"
 
-"@sentry-internal/replay@8.41.0":
-  version "8.41.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/replay/-/replay-8.41.0.tgz#b1112a52a0cf1727589ad4d42a8fac9f98f6d733"
-  integrity sha512-ByXEY7JI95y4Qr9fS3d28l9uuVU5Qa0HgL+xDmYElNx7CXz3Q9hFN6ibgUeC3h8BO5pDULxWNgAppl7FRY8N5w==
+"@sentry-internal/replay@8.42.0":
+  version "8.42.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/replay/-/replay-8.42.0.tgz#9024eb254e60295d303899c904db8ba933e17d05"
+  integrity sha512-oNcJEBlDfXnRFYC5Mxj5fairyZHNqlnU4g8kPuztB9G5zlsyLgWfPxzcn1ixVQunth2/WZRklDi4o1ZfyHww7w==
   dependencies:
-    "@sentry-internal/browser-utils" "8.41.0"
-    "@sentry/core" "8.41.0"
-    "@sentry/types" "8.41.0"
+    "@sentry-internal/browser-utils" "8.42.0"
+    "@sentry/core" "8.42.0"
 
-"@sentry-internal/typescript@8.41.0":
-  version "8.41.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-8.41.0.tgz#ca9ddea52fb21740298572efac71e999ab3f1323"
-  integrity sha512-Ri4x6FLJzAsBaU8fmS4jbrw4pSnmy7i9jlBt4MkyMATRFgL/5WfLvvra7ZnSGxsbL1f/CvbawENZJkNRq5xrMg==
+"@sentry-internal/typescript@8.42.0":
+  version "8.42.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-8.42.0.tgz#aec98119db304a168f56f7f94c2659b97894f4ff"
+  integrity sha512-jf1pHDJM+eaIdw6H96TLBZjjDf4b3pfrUzljVJ3EUEWoPXA2r/smZF7atjtG5pIHSlazYOGWlGnlkyvMCupazA==
 
-"@sentry/browser@8.41.0":
-  version "8.41.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-8.41.0.tgz#f594012e6377a92db72127ef39aee812efe3a3b7"
-  integrity sha512-FfAU55eYwW2lG4M3dEw2472RvHrD5YWSfHCZvuRf/4skX38kFvKghZQ+epL+CVHTzvIRHOrbj8qQK6YLTGl9ew==
+"@sentry/browser@8.42.0":
+  version "8.42.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-8.42.0.tgz#2408a627f263adf2466b5a304957aa6c00d8351f"
+  integrity sha512-lStrEk609KJHwXfDrOgoYVVoFFExixHywxSExk7ZDtwj2YPv6r6Y1gogvgr7dAZj7jWzadHkxZ33l9EOSJBfug==
   dependencies:
-    "@sentry-internal/browser-utils" "8.41.0"
-    "@sentry-internal/feedback" "8.41.0"
-    "@sentry-internal/replay" "8.41.0"
-    "@sentry-internal/replay-canvas" "8.41.0"
-    "@sentry/core" "8.41.0"
-    "@sentry/types" "8.41.0"
+    "@sentry-internal/browser-utils" "8.42.0"
+    "@sentry-internal/feedback" "8.42.0"
+    "@sentry-internal/replay" "8.42.0"
+    "@sentry-internal/replay-canvas" "8.42.0"
+    "@sentry/core" "8.42.0"
 
-"@sentry/core@8.41.0":
-  version "8.41.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-8.41.0.tgz#e8a25cacd25fe4358f3179e85f3c2697427fe5a6"
-  integrity sha512-3v7u3t4LozCA5SpZY4yqUN2U3jSrkXNoLgz6L2SUUiydyCuSwXZIFEwpLJfgQyidpNDifeQbBI5E1O910XkPsA==
-  dependencies:
-    "@sentry/types" "8.41.0"
+"@sentry/core@8.42.0":
+  version "8.42.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-8.42.0.tgz#9fc0db6794186dc2d1167cf82e579e387198ba77"
+  integrity sha512-ac6O3pgoIbU6rpwz6LlwW0wp3/GAHuSI0C5IsTgIY6baN8rOBnlAtG6KrHDDkGmUQ2srxkDJu9n1O6Td3cBCqw==
 
-"@sentry/node@8.41.0":
-  version "8.41.0"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-8.41.0.tgz#52f970648d961f6e82a1b23a88c0000aa72ba21a"
-  integrity sha512-eYD5S8Lti9efBHFSIhZ/0C5uI1DQtGqjuNWQ62CKC47G2qgJddBtb2HgqRFAnMajYL9FXEtiDT6uqQhKQnmLcQ==
+"@sentry/node@8.42.0":
+  version "8.42.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-8.42.0.tgz#829a02ce322bf7ee13e2bd09acc2eb56a8e04525"
+  integrity sha512-MsNrmAIwDaxf1jTX1FsgZ+3mUq6G6IuU6FAqyp7TDnvUTsbWUtr0OM6EvVUz0zCImybIh9dcTQ+6KTmUyA7URw==
   dependencies:
     "@opentelemetry/api" "^1.9.0"
     "@opentelemetry/context-async-hooks" "^1.25.1"
@@ -840,23 +833,16 @@
     "@opentelemetry/sdk-trace-base" "^1.26.0"
     "@opentelemetry/semantic-conventions" "^1.27.0"
     "@prisma/instrumentation" "5.19.1"
-    "@sentry/core" "8.41.0"
-    "@sentry/opentelemetry" "8.41.0"
-    "@sentry/types" "8.41.0"
+    "@sentry/core" "8.42.0"
+    "@sentry/opentelemetry" "8.42.0"
     import-in-the-middle "^1.11.2"
 
-"@sentry/opentelemetry@8.41.0":
-  version "8.41.0"
-  resolved "https://registry.yarnpkg.com/@sentry/opentelemetry/-/opentelemetry-8.41.0.tgz#0e5c4bb8d5b58f07eb80e312fc66b8709a688c61"
-  integrity sha512-Ld6KdBQsmSk2IfFSoZ7CMpmuQbfb3viV6nTDCz6+11wL9S+1b+hadCN+38yBW4CmI4/hEpYfwwWQPseQQTvBCg==
+"@sentry/opentelemetry@8.42.0":
+  version "8.42.0"
+  resolved "https://registry.yarnpkg.com/@sentry/opentelemetry/-/opentelemetry-8.42.0.tgz#d4a5e988689b3c64370eff5763e7cf3af4e43cba"
+  integrity sha512-QPb9kMFgl35TIwIz0u+BFTbPG461CofMiloidJ44GFZ9cB33T5cB0oIN7ut/5tsH/AvqUmucydsV/Nj3HNQx9g==
   dependencies:
-    "@sentry/core" "8.41.0"
-    "@sentry/types" "8.41.0"
-
-"@sentry/types@8.41.0":
-  version "8.41.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-8.41.0.tgz#db40c93bcedad26569c5dfe10a4b31253c349a10"
-  integrity sha512-eqdnGr9k9H++b9CjVUoTNUVahPVWeNnMy0YGkqS5+cjWWC+x43p56202oidGFmWo6702ub/xwUNH6M5PC4kq6A==
+    "@sentry/core" "8.42.0"
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"


### PR DESCRIPTION
This involved migrating imports from `@sentry/types` to `@sentry/core` and handling some more deprecations.