### PR TITLE
feat: Determine Electron process from minidump metadata

### DIFF
--- a/src/main/integrations/sentry-minidump/index.ts
+++ b/src/main/integrations/sentry-minidump/index.ts
@@ -148,7 +148,7 @@ export const sentryMinidumpIntegration = defineIntegration((options: Options = {
     const found = await sendNativeCrashes(client, (minidumpProcess) => {
       // We only call 'getRendererName' if this was in fact a renderer crash
       const crashedProcess =
-        (minidumpProcess === 'renderer' ? getRendererName?.(contents) : minidumpProcess) || 'renderer';
+        (minidumpProcess === 'renderer' ? getRendererName?.(contents) : minidumpProcess) || 'unknown';
 
       logger.log(`'${crashedProcess}' process '${details.reason}'`);
 
@@ -248,7 +248,7 @@ export const sentryMinidumpIntegration = defineIntegration((options: Options = {
         platform: 'native',
         tags: {
           'event.environment': 'native',
-          'event.process': minidumpProcess || 'browser',
+          'event.process': minidumpProcess || 'unknown',
         },
       }))
         .then((minidumpsFound) =>

--- a/src/main/integrations/sentry-minidump/index.ts
+++ b/src/main/integrations/sentry-minidump/index.ts
@@ -147,7 +147,8 @@ export const sentryMinidumpIntegration = defineIntegration((options: Options = {
 
     const found = await sendNativeCrashes(client, (minidumpProcess) => {
       // We only call 'getRendererName' if this was in fact a renderer crash
-      const crashedProcess = (minidumpProcess === 'renderer' ? getRendererName?.(contents) : minidumpProcess) || 'renderer';
+      const crashedProcess =
+        (minidumpProcess === 'renderer' ? getRendererName?.(contents) : minidumpProcess) || 'renderer';
 
       logger.log(`'${crashedProcess}' process '${details.reason}'`);
 

--- a/src/main/integrations/sentry-minidump/index.ts
+++ b/src/main/integrations/sentry-minidump/index.ts
@@ -148,7 +148,7 @@ export const sentryMinidumpIntegration = defineIntegration((options: Options = {
     const found = await sendNativeCrashes(client, (minidumpProcess) => {
       // We only call 'getRendererName' if this was in fact a renderer crash
       const crashedProcess =
-        (minidumpProcess === 'renderer' ? getRendererName?.(contents) : minidumpProcess) || 'unknown';
+        (minidumpProcess === 'renderer' && getRendererName ? getRendererName(contents) : minidumpProcess) || 'unknown';
 
       logger.log(`'${crashedProcess}' process '${details.reason}'`);
 

--- a/test/e2e/test-apps/native-sentry/unknown/event.json
+++ b/test/e2e/test-apps/native-sentry/unknown/event.json
@@ -1,0 +1,84 @@
+{
+  "method": "envelope",
+  "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
+  "appId": "277345",
+  "data": {
+    "sdk": {
+      "name": "sentry.javascript.electron",
+      "packages": [
+        {
+          "name": "npm:@sentry/electron",
+          "version": "{{version}}"
+        }
+      ],
+      "version": "{{version}}"
+    },
+    "contexts": {
+      "app": {
+        "app_name": "native-sentry-unknown",
+        "app_version": "1.0.0",
+        "app_start_time": "{{time}}"
+      },
+      "browser": {
+        "name": "Chrome"
+      },
+      "chrome": {
+        "name": "Chrome",
+        "type": "runtime",
+        "version": "{{version}}"
+      },
+      "device": {
+        "arch": "{{arch}}",
+        "family": "Desktop",
+        "memory_size": 0,
+        "free_memory": 0,
+        "processor_count": 0,
+        "processor_frequency": 0,
+        "cpu_description": "{{cpu}}",
+        "screen_resolution": "{{screen}}",
+        "screen_density": 1
+      },
+      "culture": {
+        "locale": "{{locale}}",
+        "timezone": "{{timezone}}"
+      },
+      "node": {
+        "name": "Node",
+        "type": "runtime",
+        "version": "{{version}}"
+      },
+      "os": {
+        "name": "{{platform}}",
+        "version": "{{version}}"
+      },
+      "runtime": {
+        "name": "Electron",
+        "version": "{{version}}"
+      }
+    },
+    "release": "native-sentry-unknown@1.0.0",
+    "environment": "development",
+    "event_id": "{{id}}",
+    "timestamp": 0,
+    "breadcrumbs": [
+      {
+        "category": "console",
+        "level": "log",
+        "message": "main process breadcrumb from second run"
+      }
+    ],
+    "tags": {
+      "event.environment": "native",
+      "event.origin": "electron",
+      "event.process": "unknown",
+      "app-run": "second"
+    }
+  },
+  "attachments": [
+    {
+      "length": 12004,
+      "filename": "0dc9e285-df8d-47b7-8147-85308b54065a.dmp",
+      "attachment_type": "event.minidump"
+    }
+  ]
+}

--- a/test/e2e/test-apps/native-sentry/unknown/package.json
+++ b/test/e2e/test-apps/native-sentry/unknown/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "native-sentry-unknown",
+  "version": "1.0.0",
+  "main": "src/main.js",
+  "dependencies": {
+    "@sentry/electron": "5.6.0"
+  }
+}

--- a/test/e2e/test-apps/native-sentry/unknown/recipe.yml
+++ b/test/e2e/test-apps/native-sentry/unknown/recipe.yml
@@ -1,0 +1,5 @@
+description: Native Unknown Crash
+category: Native (Sentry Uploader)
+command: yarn
+condition: usesCrashpad
+runTwice: true

--- a/test/e2e/test-apps/native-sentry/unknown/src/index.html
+++ b/test/e2e/test-apps/native-sentry/unknown/src/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <script>
+      const { init } = require('@sentry/electron/renderer');
+
+      init({
+        debug: true,
+      });
+    </script>
+  </body>
+</html>

--- a/test/e2e/test-apps/native-sentry/unknown/src/main.js
+++ b/test/e2e/test-apps/native-sentry/unknown/src/main.js
@@ -1,0 +1,48 @@
+const path = require('path');
+const { writeFileSync } = require('fs');
+
+const { app, BrowserWindow } = require('electron');
+const { init, getCurrentScope } = require('@sentry/electron/main');
+
+const VALID_LOOKING_MINIDUMP = Buffer.from(`MDMP${'X'.repeat(12000)}`);
+
+const minidumpPath = path.join(
+  app.getPath('crashDumps'),
+  process.platform === 'win32' ? 'reports' : 'completed',
+  '0dc9e285-df8d-47b7-8147-85308b54065a.dmp'
+);
+
+init({
+  dsn: '__DSN__',
+  debug: true,
+  autoSessionTracking: false,
+  onFatalError: () => {},
+});
+
+getCurrentScope().setTag('app-run', process.env.APP_FIRST_RUN ? 'first' : 'second');
+
+app.on('ready', () => {
+  const mainWindow = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+
+  mainWindow.loadFile(path.join(__dirname, 'index.html'));
+
+  if (process.env.APP_FIRST_RUN) {
+    console.log('main process breadcrumb from first crashing run');
+
+    setTimeout(() => {
+      writeFileSync(minidumpPath, VALID_LOOKING_MINIDUMP);
+
+      setTimeout(() => {
+        process.exit();
+       });
+    }, 2000);
+  } else {
+    console.log('main process breadcrumb from second run');
+  }
+});

--- a/test/e2e/test-apps/native-sentry/unknown/src/main.js
+++ b/test/e2e/test-apps/native-sentry/unknown/src/main.js
@@ -4,6 +4,8 @@ const { writeFileSync } = require('fs');
 const { app, BrowserWindow } = require('electron');
 const { init, getCurrentScope } = require('@sentry/electron/main');
 
+app.commandLine.appendSwitch('enable-crashpad');
+
 const VALID_LOOKING_MINIDUMP = Buffer.from(`MDMP${'X'.repeat(12000)}`);
 
 const minidumpPath = path.join(

--- a/test/unit/minidump-loader.test.ts
+++ b/test/unit/minidump-loader.test.ts
@@ -36,7 +36,7 @@ describe('createMinidumpLoader', () => {
 
       const loader = createMinidumpLoader(() => Promise.resolve([dumpPath]));
 
-      void loader(false, (attachment) => {
+      void loader(false, (_, attachment) => {
         expect(attachment).to.eql({
           data: VALID_LOOKING_MINIDUMP,
           filename: name,
@@ -151,7 +151,7 @@ describe('createMinidumpLoader', () => {
 
       const loader = createMinidumpLoader(() => Promise.resolve([missingPath, dumpPath]));
 
-      void loader(false, (attachment) => {
+      void loader(false, (_, attachment) => {
         expect(attachment.filename).to.eql(name);
 
         setTimeout(() => {


### PR DESCRIPTION
- Closes #1047

As described in the above issue:
> Currently we read minidumps from the crashpad directory when we are notified by Electron that a renderer or child process has crashed. We assume that all the minidumps we find correspond the the Electron event. All minidumps we read at startup are assumed to be main process crashes because they cause the process to exit immediately.
>
>Although these assumptions are usually correct, I've personally seen events recorded incorrectly and so have other users (https://github.com/getsentry/sentry-electron/issues/1045).

Rather than fully parse the minidumps as described in the above issue (ie. header + enumerate the streams), we just search for the `process_type` key in the minidump file and pick out the string that follows. This simplified approach is reasonable because Electrons Crashpad is configured to emit minimal minidumps (250-400kb). 

If we can't determine the process type from parsing the minidump, we have a new `event.process` tag of `unknown`. In most cases, these will be for child processes and I've added a test to confirm that if these are found at startup, they are correctly categorised.

