### PR TITLE
fix: Guard against invalid queue entries

### DIFF
--- a/src/main/transports/offline-store.ts
+++ b/src/main/transports/offline-store.ts
@@ -63,7 +63,7 @@ export function createOfflineStore(userOptions: Partial<OfflineStoreOptions>): O
     });
   }
 
-  function removeStaleRequests(queue: Array<Partial<PersistedRequest> | undefined>): void {
+  function removeStaleRequests(queue: Array<Partial<PersistedRequest>>): void {
     while (queue[0] && isOutdated(queue[0], options.maxAgeDays)) {
       const removed = queue.shift() as PersistedRequest;
       log('Removing stale envelope', removed);

--- a/src/main/transports/offline-store.ts
+++ b/src/main/transports/offline-store.ts
@@ -28,9 +28,9 @@ export interface OfflineStoreOptions {
 
 const MILLISECONDS_PER_DAY = 86_400_000;
 
-function isOutdated(request: PersistedRequest, maxAgeDays: number): boolean {
+function isOutdated(request: Partial<PersistedRequest> | undefined, maxAgeDays: number): boolean {
   const cutOff = Date.now() - MILLISECONDS_PER_DAY * maxAgeDays;
-  return request.date.getTime() < cutOff;
+  return (request?.date?.getTime() || 0) < cutOff;
 }
 
 function getSentAtFromEnvelope(envelope: Envelope): Date | undefined {
@@ -63,7 +63,7 @@ export function createOfflineStore(userOptions: Partial<OfflineStoreOptions>): O
     });
   }
 
-  function removeStaleRequests(queue: PersistedRequest[]): void {
+  function removeStaleRequests(queue: Array<Partial<PersistedRequest> | undefined>): void {
     while (queue[0] && isOutdated(queue[0], options.maxAgeDays)) {
       const removed = queue.shift() as PersistedRequest;
       log('Removing stale envelope', removed);


### PR DESCRIPTION
- Closes #1051

I don't know exactly what caused this issue. I suspect it could be due to an invalid read of the data store.