### PR TITLE
test: Back to testing on `ubuntu-latest`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
       # we want that the matrix keeps running, default is to cancel all if one fails.
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -73,7 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         electron: ${{ fromJson(needs.build.outputs.matrix) }}
     env:
       ELECTRON_VERSION: ${{ matrix.electron }}

--- a/test/e2e/context.ts
+++ b/test/e2e/context.ts
@@ -1,4 +1,3 @@
-import { parseSemver } from '@sentry/core';
 import { ChildProcess, spawn, spawnSync } from 'child_process';
 import { rmSync } from 'fs';
 import { homedir } from 'os';
@@ -68,11 +67,9 @@ export class TestContext {
       this._clearAppUserData();
     }
 
-    const version = parseSemver(this._electronVersion);
-
     const args = [this._appPath];
-    // Older versions of Electron no longer work correctly on 'ubuntu-latest' with sandbox
-    if (process.platform === 'linux' && (version.major || 0) < 13) {
+    // Electron no longer work correctly on Github Actions 'ubuntu-latest' with sandbox
+    if (process.platform === 'linux') {
       args.push('--no-sandbox');
     }
 

--- a/test/unit/getPath-test-app/package.json
+++ b/test/unit/getPath-test-app/package.json
@@ -4,6 +4,6 @@
   "main": "main.js",
   "scripts": {
 
-    "start": "../../../node_modules/.bin/electron ."
+    "start": "../../../node_modules/.bin/electron . --no-sandbox"
   }
 }


### PR DESCRIPTION
In a recent PR I had to pin to `ubuntu-22.04` because latest didn't support Electrons sandbox in it's default configuration.

This PR disables the sandbox for the Linux tests and reverts to `ubuntu-latest`. This means we do not test sandbox functionality on Linux but we test other platforms and Electron has extensive tests to cover sandbox behaviour. 