### PR TITLE
test: More child process types

### DIFF
--- a/test/e2e/test-apps/native-sentry/child-exec/event.json
+++ b/test/e2e/test-apps/native-sentry/child-exec/event.json
@@ -1,0 +1,75 @@
+{
+  "method": "envelope",
+  "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
+  "appId": "277345",
+  "data": {
+    "sdk": {
+      "name": "sentry.javascript.electron",
+      "packages": [
+        {
+          "name": "npm:@sentry/electron",
+          "version": "{{version}}"
+        }
+      ],
+      "version": "{{version}}"
+    },
+    "contexts": {
+      "app": {
+        "app_name": "native-sentry-child-exec",
+        "app_version": "1.0.0",
+        "app_start_time": "{{time}}"
+      },
+      "browser": {
+        "name": "Chrome"
+      },
+      "chrome": {
+        "name": "Chrome",
+        "type": "runtime",
+        "version": "{{version}}"
+      },
+      "device": {
+        "arch": "{{arch}}",
+        "family": "Desktop",
+        "memory_size": 0,
+        "free_memory": 0,
+        "processor_count": 0,
+        "processor_frequency": 0,
+        "cpu_description": "{{cpu}}",
+        "screen_resolution": "{{screen}}",
+        "screen_density": 1
+      },
+      "culture": {
+        "locale": "{{locale}}",
+        "timezone": "{{timezone}}"
+      },
+      "node": {
+        "name": "Node",
+        "type": "runtime",
+        "version": "{{version}}"
+      },
+      "os": {
+        "name": "{{platform}}",
+        "version": "{{version}}"
+      },
+      "runtime": {
+        "name": "Electron",
+        "version": "{{version}}"
+      }
+    },
+    "release": "native-sentry-child-exec@1.0.0",
+    "environment": "development",
+    "event_id": "{{id}}",
+    "timestamp": 0,
+    "breadcrumbs": [],
+    "tags": {
+      "event.environment": "native",
+      "event.origin": "electron",
+      "event.process": "unknown"
+    }
+  },
+  "attachments": [
+    {
+      "attachment_type": "event.minidump"
+    }
+  ]
+}

--- a/test/e2e/test-apps/native-sentry/child-exec/package.json
+++ b/test/e2e/test-apps/native-sentry/child-exec/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "native-sentry-child-exec",
+  "version": "1.0.0",
+  "main": "src/main.js",
+  "dependencies": {
+    "@sentry/electron": "5.6.0",
+    "crashy-cli": "1.0.1"
+  }
+}

--- a/test/e2e/test-apps/native-sentry/child-exec/recipe.yml
+++ b/test/e2e/test-apps/native-sentry/child-exec/recipe.yml
@@ -1,0 +1,5 @@
+description: Native Child Exec Crash
+category: Native (Sentry Uploader)
+command: yarn
+runTwice: true
+condition: platform === 'darwin'

--- a/test/e2e/test-apps/native-sentry/child-exec/src/index.html
+++ b/test/e2e/test-apps/native-sentry/child-exec/src/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <script>
+      const { init } = require('@sentry/electron/renderer');
+
+      init({
+        debug: true,
+      });
+    </script>
+  </body>
+</html>

--- a/test/e2e/test-apps/native-sentry/child-exec/src/main.js
+++ b/test/e2e/test-apps/native-sentry/child-exec/src/main.js
@@ -1,0 +1,37 @@
+const path = require('path');
+const child_process = require('child_process');
+
+const { getPath } = require('crashy-cli');
+const { app, BrowserWindow } = require('electron');
+const { init } = require('@sentry/electron/main');
+
+init({
+  dsn: '__DSN__',
+  debug: true,
+  autoSessionTracking: false,
+  onFatalError: () => {},
+});
+
+app.on('ready', () => {
+  const mainWindow = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+
+  mainWindow.loadFile(path.join(__dirname, 'index.html'));
+
+  if (process.env.APP_FIRST_RUN) {
+    try {
+      child_process.execSync(getPath());
+    } catch (_) {
+      //
+    }
+
+    setTimeout(() => {
+      app.exit();
+    }, 3000);
+  }
+});

--- a/test/e2e/test-apps/native-sentry/child-fork/event.json
+++ b/test/e2e/test-apps/native-sentry/child-fork/event.json
@@ -1,0 +1,75 @@
+{
+  "method": "envelope",
+  "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
+  "appId": "277345",
+  "data": {
+    "sdk": {
+      "name": "sentry.javascript.electron",
+      "packages": [
+        {
+          "name": "npm:@sentry/electron",
+          "version": "{{version}}"
+        }
+      ],
+      "version": "{{version}}"
+    },
+    "contexts": {
+      "app": {
+        "app_name": "native-sentry-child-fork",
+        "app_version": "1.0.0",
+        "app_start_time": "{{time}}"
+      },
+      "browser": {
+        "name": "Chrome"
+      },
+      "chrome": {
+        "name": "Chrome",
+        "type": "runtime",
+        "version": "{{version}}"
+      },
+      "device": {
+        "arch": "{{arch}}",
+        "family": "Desktop",
+        "memory_size": 0,
+        "free_memory": 0,
+        "processor_count": 0,
+        "processor_frequency": 0,
+        "cpu_description": "{{cpu}}",
+        "screen_resolution": "{{screen}}",
+        "screen_density": 1
+      },
+      "culture": {
+        "locale": "{{locale}}",
+        "timezone": "{{timezone}}"
+      },
+      "node": {
+        "name": "Node",
+        "type": "runtime",
+        "version": "{{version}}"
+      },
+      "os": {
+        "name": "{{platform}}",
+        "version": "{{version}}"
+      },
+      "runtime": {
+        "name": "Electron",
+        "version": "{{version}}"
+      }
+    },
+    "release": "native-sentry-child-fork@1.0.0",
+    "environment": "development",
+    "event_id": "{{id}}",
+    "timestamp": 0,
+    "breadcrumbs": [],
+    "tags": {
+      "event.environment": "native",
+      "event.origin": "electron",
+      "event.process": "node"
+    }
+  },
+  "attachments": [
+    {
+      "attachment_type": "event.minidump"
+    }
+  ]
+}

--- a/test/e2e/test-apps/native-sentry/child-fork/package.json
+++ b/test/e2e/test-apps/native-sentry/child-fork/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "native-sentry-child-fork",
+  "version": "1.0.0",
+  "main": "src/main.js",
+  "dependencies": {
+    "@sentry/electron": "5.6.0",
+    "sadness-generator": "0.0.2"
+  }
+}

--- a/test/e2e/test-apps/native-sentry/child-fork/recipe.yml
+++ b/test/e2e/test-apps/native-sentry/child-fork/recipe.yml
@@ -1,0 +1,5 @@
+description: Native Child Crash
+category: Native (Sentry Uploader)
+command: yarn
+runTwice: true
+condition: platform !== 'linux'

--- a/test/e2e/test-apps/native-sentry/child-fork/src/child.js
+++ b/test/e2e/test-apps/native-sentry/child-fork/src/child.js
@@ -1,0 +1,5 @@
+const { raiseSegfault } = require('sadness-generator')
+
+setTimeout(() => {
+  raiseSegfault();
+}, 1000);

--- a/test/e2e/test-apps/native-sentry/child-fork/src/index.html
+++ b/test/e2e/test-apps/native-sentry/child-fork/src/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <script>
+      const { init } = require('@sentry/electron/renderer');
+
+      init({
+        debug: true,
+      });
+    </script>
+  </body>
+</html>

--- a/test/e2e/test-apps/native-sentry/child-fork/src/main.js
+++ b/test/e2e/test-apps/native-sentry/child-fork/src/main.js
@@ -1,0 +1,32 @@
+const path = require('path');
+const child_process = require('child_process');
+
+const { app, BrowserWindow } = require('electron');
+const { init } = require('@sentry/electron/main');
+
+init({
+  dsn: '__DSN__',
+  debug: true,
+  autoSessionTracking: false,
+  onFatalError: () => {},
+});
+
+app.on('ready', () => {
+  const mainWindow = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+
+  mainWindow.loadFile(path.join(__dirname, 'index.html'));
+
+  if (process.env.APP_FIRST_RUN) {
+    child_process.fork(path.join(__dirname, 'child.js'));
+
+    setTimeout(() => {
+      app.exit();
+    }, 3000);
+  }
+});

--- a/test/e2e/test-apps/native-sentry/utility/event.json
+++ b/test/e2e/test-apps/native-sentry/utility/event.json
@@ -1,0 +1,83 @@
+{
+  "method": "envelope",
+  "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
+  "appId": "277345",
+  "data": {
+    "sdk": {
+      "name": "sentry.javascript.electron",
+      "packages": [
+        {
+          "name": "npm:@sentry/electron",
+          "version": "{{version}}"
+        }
+      ],
+      "version": "{{version}}"
+    },
+    "contexts": {
+      "app": {
+        "app_name": "native-sentry-utility",
+        "app_version": "1.0.0",
+        "app_start_time": "{{time}}"
+      },
+      "browser": {
+        "name": "Chrome"
+      },
+      "chrome": {
+        "name": "Chrome",
+        "type": "runtime",
+        "version": "{{version}}"
+      },
+      "device": {
+        "arch": "{{arch}}",
+        "family": "Desktop",
+        "memory_size": 0,
+        "free_memory": 0,
+        "processor_count": 0,
+        "processor_frequency": 0,
+        "cpu_description": "{{cpu}}",
+        "screen_resolution": "{{screen}}",
+        "screen_density": 1
+      },
+      "culture": {
+        "locale": "{{locale}}",
+        "timezone": "{{timezone}}"
+      },
+      "node": {
+        "name": "Node",
+        "type": "runtime",
+        "version": "{{version}}"
+      },
+      "os": {
+        "name": "{{platform}}",
+        "version": "{{version}}"
+      },
+      "runtime": {
+        "name": "Electron",
+        "version": "{{version}}"
+      },
+      "electron": {
+        "details": {
+          "name": "Node Utility Process",
+          "reason": "crashed",
+          "type": "Utility"
+        }
+      }
+    },
+    "release": "native-sentry-utility@1.0.0",
+    "environment": "development",
+    "event_id": "{{id}}",
+    "timestamp": 0,
+    "breadcrumbs": [],
+    "tags": {
+      "event.environment": "native",
+      "event.origin": "electron",
+      "event.process": "utility",
+      "exit.reason": "crashed"
+    }
+  },
+  "attachments": [
+    {
+      "attachment_type": "event.minidump"
+    }
+  ]
+}

--- a/test/e2e/test-apps/native-sentry/utility/package.json
+++ b/test/e2e/test-apps/native-sentry/utility/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "native-sentry-utility",
+  "version": "1.0.0",
+  "main": "src/main.js",
+  "dependencies": {
+    "@sentry/electron": "5.6.0",
+    "sadness-generator": "0.0.2"
+  }
+}

--- a/test/e2e/test-apps/native-sentry/utility/recipe.yml
+++ b/test/e2e/test-apps/native-sentry/utility/recipe.yml
@@ -1,0 +1,5 @@
+description: Native Utility Crash
+category: Native (Sentry Uploader)
+command: yarn
+# Not working on Linux with v29.4.6
+condition: version.major >= 22 && !(platform === 'linux' && version.major === 29)

--- a/test/e2e/test-apps/native-sentry/utility/src/child.js
+++ b/test/e2e/test-apps/native-sentry/utility/src/child.js
@@ -1,0 +1,5 @@
+const { raiseSegfault } = require('sadness-generator')
+
+setTimeout(() => {
+  raiseSegfault();
+}, 1000);

--- a/test/e2e/test-apps/native-sentry/utility/src/index.html
+++ b/test/e2e/test-apps/native-sentry/utility/src/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <script>
+      const { init } = require('@sentry/electron/renderer');
+
+      init({
+        debug: true,
+      });
+    </script>
+  </body>
+</html>

--- a/test/e2e/test-apps/native-sentry/utility/src/main.js
+++ b/test/e2e/test-apps/native-sentry/utility/src/main.js
@@ -1,0 +1,25 @@
+const path = require('path');
+
+const { app, BrowserWindow, utilityProcess } = require('electron');
+const { init } = require('@sentry/electron/main');
+
+init({
+  dsn: '__DSN__',
+  debug: true,
+  autoSessionTracking: false,
+  onFatalError: () => {},
+});
+
+app.on('ready', () => {
+  const mainWindow = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+
+  mainWindow.loadFile(path.join(__dirname, 'index.html'));
+
+  utilityProcess.fork(path.join(__dirname, 'child.js'), {stdio:'inherit'});
+});


### PR DESCRIPTION
This PR adds tests for:
- Electron utility process crash
- `child_process.fork` Node process crash
- `child_process.exec` executable crash

Not all platforms can capture child process crashes:

|                    | `event.process`|macOS | Windows | Linux | 
|--------------------|-------|---------|-------|---|
| Electron `utilityProcess`|`utility`|✅|✅|✅ <sup>1</sup>|
| `child_process.fork` | `node`|✅     | ✅       | ❌     |  
| `child_process.exec` | `unknown`|✅     | ❌       | ❌     |  

 - <sup>1</sup> Not working with v29.4.6. Possibly an Electron bug that won't get fixed because v29 is already EOL.
