### PR TITLE
Remove date range for LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2018 Functional Software, Inc. dba Sentry
 Copyright (c) 2017 Tim Fish
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
In our internal [Open Source Legal Policy](https://www.notion.so/sentry/Open-Source-Legal-Policy-ac4885d265cb4d7898a01c060b061e42), we decided that licenses don't require a data range. This also has the advantage of not updating the date range yearly.

#skip-changelog

cc @gavin-zee