### PR TITLE
fix: Only set `ip.address: '{{auto}}'` when `sendDefaultPii: true`

### DIFF
--- a/src/main/sdk.ts
+++ b/src/main/sdk.ts
@@ -182,8 +182,10 @@ export function init(userOptions: ElectronMainOptions): void {
 
   const client = new NodeClient(options);
 
-  client.on('postprocessEvent', addAutoIpAddressToUser);
-  client.on('beforeSendSession', addAutoIpAddressToSession);
+  if (options.sendDefaultPii === true) {
+    client.on('postprocessEvent', addAutoIpAddressToUser);
+    client.on('beforeSendSession', addAutoIpAddressToSession);
+  }
 
   scope.setClient(client);
   client.init();

--- a/test/e2e/test-apps/other/no-pii/events.ts
+++ b/test/e2e/test-apps/other/no-pii/events.ts
@@ -1,0 +1,12 @@
+import { Event } from '@sentry/core';
+import { expect } from 'vitest';
+
+import { TestServerEvent } from '../../../server';
+
+export async function execute(events: TestServerEvent<Event>[]): Promise<void> {
+  expect(events.length).greaterThanOrEqual(1);
+
+  for (const event of events) {
+    expect(event.data.user?.ip_address).toBeUndefined();
+  }
+}

--- a/test/e2e/test-apps/other/no-pii/package.json
+++ b/test/e2e/test-apps/other/no-pii/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "javascript-no-pii",
+  "version": "1.0.0",
+  "main": "src/main.js",
+  "dependencies": {
+    "@sentry/electron": "5.6.0"
+  }
+}

--- a/test/e2e/test-apps/other/no-pii/recipe.yml
+++ b/test/e2e/test-apps/other/no-pii/recipe.yml
@@ -1,0 +1,3 @@
+description: No PII
+category: JavaScript
+command: yarn

--- a/test/e2e/test-apps/other/no-pii/src/index.html
+++ b/test/e2e/test-apps/other/no-pii/src/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <script>
+      const { init } = require('@sentry/electron/renderer');
+
+      init({
+        debug: true,
+      });
+
+      setTimeout(() => {
+        throw new Error('Some renderer error');
+      }, 500);
+    </script>
+  </body>
+</html>

--- a/test/e2e/test-apps/other/no-pii/src/main.js
+++ b/test/e2e/test-apps/other/no-pii/src/main.js
@@ -1,0 +1,23 @@
+const path = require('path');
+
+const { app, BrowserWindow } = require('electron');
+const { init } = require('@sentry/electron/main');
+
+init({
+  dsn: '__DSN__',
+  debug: true,
+  integrations: (integrations) => integrations.filter((i) => i.name !== 'MainProcessSession'),
+  onFatalError: () => {},
+});
+
+app.on('ready', () => {
+  const mainWindow = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+
+  mainWindow.loadFile(path.join(__dirname, 'index.html'));
+});


### PR DESCRIPTION
This PR:
- Ensures that we only add the ip address if `sendDefaultPii: true`
- Adds a test to ensure the IP address is not added by default