### PR TITLE
fix: Renderer ANR detection

### DIFF
--- a/src/renderer/anr.ts
+++ b/src/renderer/anr.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-globals */
 import { RendererProcessAnrOptions } from '../common/ipc';
 import { getIPC } from './ipc';
 
@@ -15,10 +14,7 @@ export function enableAnrRendererMessages(options: Partial<RendererProcessAnrOpt
 
   const ipc = getIPC();
 
-  document.addEventListener('visibilitychange', () => {
-    ipc.sendStatus({ status: document.visibilityState, config });
-  });
-
+  // eslint-disable-next-line no-restricted-globals
   ipc.sendStatus({ status: document.visibilityState, config });
 
   setInterval(() => {


### PR DESCRIPTION
- Closes #1035

This PR changes renderer ANR detection to use the Electron `blur`/`focus` events rather than the browser `visibilitychange` events to disable/enable ANR. When the page loses focus, execution can potentially be suspended and the visibilitychange cannot be propigated to main process quickly enough. I also hooked up the power monitor events to disable ANR too.