### PR TITLE
feat: Support `@sentry/profiling-node`

### DIFF
--- a/src/main/integrations/normalize-paths.ts
+++ b/src/main/integrations/normalize-paths.ts
@@ -1,11 +1,24 @@
-import { defineIntegration } from '@sentry/core';
+import { defineIntegration, forEachEnvelopeItem, Profile } from '@sentry/core';
 import { app } from 'electron';
 
-import { normalizePaths } from '../normalize';
+import { normaliseProfile, normalizePaths } from '../normalize';
 
 export const normalizePathsIntegration = defineIntegration(() => {
   return {
     name: 'NormalizePaths',
+    setup: (client) => {
+      // We want this hook to be registered after the profiling-node hook so we can normalise the profile after it's
+      // been attached
+      setImmediate(() => {
+        client.on('beforeEnvelope', (envelope) => {
+          forEachEnvelopeItem(envelope, (item, type) => {
+            if (type === 'profile') {
+              normaliseProfile(item[1] as Profile, app.getAppPath());
+            }
+          });
+        });
+      });
+    },
     processEvent(event) {
       return normalizePaths(event, app.getAppPath());
     },

--- a/src/main/normalize.ts
+++ b/src/main/normalize.ts
@@ -104,7 +104,6 @@ export function normaliseProfile(profile: Profile, basePath: string): void {
       frame.abs_path = normalizeUrlToBase(frame.abs_path, basePath);
     }
 
-
     // filename isn't in the types but its in the actual data
     if ('filename' in frame && typeof frame.filename === 'string') {
       frame.filename = normalizeUrlToBase(frame.filename, basePath);

--- a/src/main/normalize.ts
+++ b/src/main/normalize.ts
@@ -9,6 +9,10 @@ import {
   Profile,
   ReplayEvent,
 } from '@sentry/core';
+import { createGetModuleFromFilename } from '@sentry/node';
+import { app } from 'electron';
+
+const getModuleFromFilename = createGetModuleFromFilename(app.getAppPath());
 
 /**
  * Normalizes all URLs in an event. See {@link normalizeUrl} for more
@@ -98,6 +102,16 @@ export function normaliseProfile(profile: Profile, basePath: string): void {
   for (const frame of profile.profile.frames) {
     if (frame.abs_path) {
       frame.abs_path = normalizeUrlToBase(frame.abs_path, basePath);
+    }
+
+
+    // filename isn't in the types but its in the actual data
+    if ('filename' in frame && typeof frame.filename === 'string') {
+      frame.filename = normalizeUrlToBase(frame.filename, basePath);
+    }
+
+    if (frame.module) {
+      frame.module = getModuleFromFilename(frame.abs_path);
     }
   }
 }

--- a/test/e2e/recipe/index.ts
+++ b/test/e2e/recipe/index.ts
@@ -171,6 +171,7 @@ export class RecipeRunner {
           // We replace the Sentry JavaScript dependency versions to match that of @sentry/core
           .replace(/"@sentry\/replay": ".*"/, `"@sentry/replay": "${JS_VERSION}"`)
           .replace(/"@sentry\/react": ".*"/, `"@sentry/react": "${JS_VERSION}"`)
+          .replace(/"@sentry\/profiling-node": ".*"/, `"@sentry/profiling-node": "${JS_VERSION}"`)
           .replace(/"@sentry\/integrations": ".*"/, `"@sentry/integrations": "${JS_VERSION}"`)
           .replace(/"@sentry\/vue": ".*"/, `"@sentry/vue": "${JS_VERSION}"`);
       }

--- a/test/e2e/test-apps/other/node-profiling/event.json
+++ b/test/e2e/test-apps/other/node-profiling/event.json
@@ -122,10 +122,24 @@
           "thread_id": "0"
         }
       ],
-      "thread_metadata": { "0": { "name": "main" } }
+      "frames": [
+        {
+          "function": "startSpan",
+          "abs_path": "app:///node_modules/@sentry/core/build/esm/tracing/trace.js",
+          "module": "@sentry.core.build.esm.tracing:trace"
+        },
+        {
+          "module": "main"
+        }
+      ],
+      "thread_metadata": {
+        "0": {
+          "name": "main"
+        }
+      }
     },
     "transaction": {
-        "name": "Long work"
+      "name": "Long work"
     }
   }
 }

--- a/test/e2e/test-apps/other/node-profiling/event.json
+++ b/test/e2e/test-apps/other/node-profiling/event.json
@@ -124,9 +124,7 @@
       ],
       "frames": [
         {
-          "function": "startSpan",
-          "abs_path": "app:///node_modules/@sentry/core/build/esm/tracing/trace.js",
-          "module": "@sentry.core.build.esm.tracing:trace"
+          "function": "startSpan"
         },
         {
           "module": "main"

--- a/test/e2e/test-apps/other/node-profiling/event.json
+++ b/test/e2e/test-apps/other/node-profiling/event.json
@@ -1,0 +1,131 @@
+{
+  "method": "envelope",
+  "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
+  "appId": "277345",
+  "data": {
+    "sdk": {
+      "name": "sentry.javascript.electron",
+      "packages": [
+        {
+          "name": "npm:@sentry/electron",
+          "version": "{{version}}"
+        }
+      ],
+      "version": "{{version}}"
+    },
+    "contexts": {
+      "app": {
+        "app_name": "node-profiling",
+        "app_version": "1.0.0",
+        "app_start_time": "{{time}}"
+      },
+      "browser": {
+        "name": "Chrome"
+      },
+      "chrome": {
+        "name": "Chrome",
+        "type": "runtime",
+        "version": "{{version}}"
+      },
+      "device": {
+        "arch": "{{arch}}",
+        "family": "Desktop",
+        "memory_size": 0,
+        "free_memory": 0,
+        "processor_count": 0,
+        "processor_frequency": 0,
+        "cpu_description": "{{cpu}}",
+        "screen_resolution": "{{screen}}",
+        "screen_density": 1
+      },
+      "culture": {
+        "locale": "{{locale}}",
+        "timezone": "{{timezone}}"
+      },
+      "node": {
+        "name": "Node",
+        "type": "runtime",
+        "version": "{{version}}"
+      },
+      "os": {
+        "name": "{{platform}}",
+        "version": "{{version}}"
+      },
+      "runtime": {
+        "name": "Electron",
+        "version": "{{version}}"
+      }
+    },
+    "spans": [
+      {
+        "description": "PBKDF2",
+        "origin": "manual",
+        "parent_span_id": "{{id}}",
+        "span_id": "{{id}}",
+        "start_timestamp": 0,
+        "timestamp": 0,
+        "trace_id": "{{id}}"
+      },
+      {
+        "description": "PBKDF2",
+        "origin": "manual",
+        "parent_span_id": "{{id}}",
+        "span_id": "{{id}}",
+        "start_timestamp": 0,
+        "timestamp": 0,
+        "trace_id": "{{id}}"
+      },
+      {
+        "description": "PBKDF2",
+        "origin": "manual",
+        "parent_span_id": "{{id}}",
+        "span_id": "{{id}}",
+        "start_timestamp": 0,
+        "timestamp": 0,
+        "trace_id": "{{id}}"
+      },
+      {
+        "description": "PBKDF2",
+        "origin": "manual",
+        "parent_span_id": "{{id}}",
+        "span_id": "{{id}}",
+        "start_timestamp": 0,
+        "timestamp": 0,
+        "trace_id": "{{id}}"
+      }
+    ],
+    "release": "some-release",
+    "environment": "development",
+    "event_id": "{{id}}",
+    "platform": "node",
+    "start_timestamp": 0,
+    "timestamp": 0,
+    "breadcrumbs": [],
+    "tags": {
+      "event.environment": "javascript",
+      "event.origin": "electron"
+    }
+  },
+  "profile": {
+    "event_id": "{{id}}",
+    "timestamp": "{{time}}",
+    "release": "some-release",
+    "environment": "development",
+    "profile": {
+      "samples": [
+        {
+          "stack_id": 0,
+          "thread_id": "0"
+        },
+        {
+          "stack_id": 1,
+          "thread_id": "0"
+        }
+      ],
+      "thread_metadata": { "0": { "name": "main" } }
+    },
+    "transaction": {
+        "name": "Long work"
+    }
+  }
+}

--- a/test/e2e/test-apps/other/node-profiling/package.json
+++ b/test/e2e/test-apps/other/node-profiling/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "node-profiling",
+  "version": "1.0.0",
+  "main": "src/main.js",
+  "scripts": {
+    "install": "electron-rebuild"
+  },
+  "dependencies": {
+    "@electron/rebuild":"^3.7.1",
+    "@sentry/electron": "5.6.0",
+    "@sentry/profiling-node": "9.0.0"
+  }
+}

--- a/test/e2e/test-apps/other/node-profiling/recipe.yml
+++ b/test/e2e/test-apps/other/node-profiling/recipe.yml
@@ -1,0 +1,2 @@
+description: Node Profiling
+command: yarn

--- a/test/e2e/test-apps/other/node-profiling/src/index.html
+++ b/test/e2e/test-apps/other/node-profiling/src/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <script>
+      const { init } = require('@sentry/electron/renderer');
+
+      init({
+        debug: true,
+      });
+    </script>
+  </body>
+</html>

--- a/test/e2e/test-apps/other/node-profiling/src/main.js
+++ b/test/e2e/test-apps/other/node-profiling/src/main.js
@@ -1,0 +1,50 @@
+const path = require('path');
+const crypto = require('crypto');
+
+const { app, BrowserWindow } = require('electron');
+const { init, startSpan } = require('@sentry/electron/main');
+const { nodeProfilingIntegration } = require('@sentry/profiling-node');
+
+
+init({
+  dsn: '__DSN__',
+  debug: true,
+  release: 'some-release',
+  integrations: (integrations) => [...integrations.filter((i) => i.name !== 'MainProcessSession'), nodeProfilingIntegration()],
+  tracesSampleRate: 1,
+  profilesSampleRate: 1,
+  onFatalError: () => { },
+});
+
+function pbkdf2() {
+  return new Promise((resolve) => {
+    const salt = crypto.randomBytes(128).toString('base64');
+    crypto.pbkdf2('myPassword', salt, 10000, 512, 'sha512', resolve);
+  });
+}
+
+async function longWork() {
+  for (let i = 0; i < 10; i++) {
+    await startSpan({ name: 'PBKDF2' }, async () => {
+      await pbkdf2();
+    });
+  }
+}
+
+app.on('ready', () => {
+  const mainWindow = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+
+  mainWindow.loadFile(path.join(__dirname, 'index.html'));
+
+  setTimeout(() => {
+    startSpan({ name: 'Long work' }, async () => {
+      await longWork();
+    });
+  }, 500);
+});


### PR DESCRIPTION
- Closes #1052

This PR:
- Ensures that paths in the profile are normalised to the app root
- Adds a test to ensure `@sentry/profiling-node` works with v6.0.0 of the Electron SDK