### PR TITLE
feat: Parse crashpad metadata from minidumps and include in `electron` context

### DIFF
--- a/src/main/integrations/sentry-minidump/index.ts
+++ b/src/main/integrations/sentry-minidump/index.ts
@@ -127,7 +127,7 @@ export const sentryMinidumpIntegration = defineIntegration((options: Options = {
             ...event.contexts?.electron,
             ...prependedAnnotations,
           },
-        }
+        };
       }
 
       if (minidumpsRemaining > 0) {

--- a/src/main/integrations/sentry-minidump/index.ts
+++ b/src/main/integrations/sentry-minidump/index.ts
@@ -109,7 +109,13 @@ export const sentryMinidumpIntegration = defineIntegration((options: Options = {
     await minidumpLoader?.(deleteAll, async (minidumpResult, attachment) => {
       minidumpFound = true;
 
-      const minidumpProcess = minidumpResult.crashpadAnnotations?.process_type;
+      let minidumpProcess = minidumpResult.crashpadAnnotations?.process_type;
+
+      // For backwards compatibility, we need to map 'gpu-process' to 'GPU'
+      // TODO (v7): Remove this
+      if (minidumpProcess === 'gpu-process') {
+        minidumpProcess = 'GPU';
+      }
 
       const event = await getEvent(minidumpProcess);
 

--- a/src/main/integrations/sentry-minidump/minidump-loader.ts
+++ b/src/main/integrations/sentry-minidump/minidump-loader.ts
@@ -77,8 +77,8 @@ export function createMinidumpLoader(getMinidumpPaths: () => Promise<string[]>):
                   data,
                 });
               } catch (e) {
-                const message = e instanceof Error ? e.message : 'Unknown error';
-                logger.warn(`Dropping minidump: ${message}`);
+                const message = e instanceof Error ? e.toString() : 'Unknown error';
+                logger.warn(`Dropping minidump:\n${message}`);
                 break;
               }
 

--- a/src/main/integrations/sentry-minidump/minidump-loader.ts
+++ b/src/main/integrations/sentry-minidump/minidump-loader.ts
@@ -66,20 +66,21 @@ export function createMinidumpLoader(getMinidumpPaths: () => Promise<string[]>):
 
             if (stats.mtimeMs < twoSecondsAgo) {
               const data = await fs.readFile(path);
-              const parsedMinidump = parseMinidump(data);
+              try {
+                const parsedMinidump = parseMinidump(data);
 
-              if (parsedMinidump === undefined) {
-                logger.warn('Dropping minidump as it appears invalid.');
+                logger.log('Sending minidump');
+
+                await callback(parsedMinidump, {
+                  attachmentType: 'event.minidump',
+                  filename: basename(path),
+                  data,
+                });
+              } catch (e) {
+                const message = e instanceof Error ? e.message : 'Unknown error';
+                logger.warn(`Dropping minidump: ${message}`);
                 break;
               }
-
-              logger.log('Sending minidump');
-
-              await callback(parsedMinidump, {
-                attachmentType: 'event.minidump',
-                filename: basename(path),
-                data,
-              });
 
               break;
             }

--- a/src/main/integrations/sentry-minidump/minidump-loader.ts
+++ b/src/main/integrations/sentry-minidump/minidump-loader.ts
@@ -75,14 +75,11 @@ export function createMinidumpLoader(getMinidumpPaths: () => Promise<string[]>):
 
               logger.log('Sending minidump');
 
-              await callback(
-                parsedMinidump,
-                 {
-                  attachmentType: 'event.minidump',
-                  filename: basename(path),
-                  data,
-                },
-              );
+              await callback(parsedMinidump, {
+                attachmentType: 'event.minidump',
+                filename: basename(path),
+                data,
+              });
 
               break;
             }

--- a/src/main/integrations/sentry-minidump/minidump-loader.ts
+++ b/src/main/integrations/sentry-minidump/minidump-loader.ts
@@ -1,9 +1,10 @@
-import { Attachment, basename, logger } from '@sentry/core';
+import { Attachment, logger } from '@sentry/core';
 import { app } from 'electron';
 import { promises as fs } from 'fs';
-import { join } from 'path';
+import { basename, join } from 'path';
 
 import { Mutex } from '../../mutex';
+import { MinidumpParseResult, parseMinidump } from './minidump-parser';
 
 /** Maximum number of days to keep a minidump before deleting it. */
 const MAX_AGE_DAYS = 30;
@@ -13,8 +14,6 @@ const NOT_MODIFIED_MS = 1_000;
 const MAX_RETRY_MS = 5_000;
 const RETRY_DELAY_MS = 500;
 const MAX_RETRIES = MAX_RETRY_MS / RETRY_DELAY_MS;
-
-const MINIDUMP_HEADER = 'MDMP';
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -27,7 +26,7 @@ function delay(ms: number): Promise<void> {
  */
 export type MinidumpLoader = (
   deleteAll: boolean,
-  callback: (processType: string | undefined, attachment: Attachment) => Promise<void>,
+  callback: (minidump: MinidumpParseResult, attachment: Attachment) => Promise<void>,
 ) => Promise<void>;
 
 /**
@@ -36,10 +35,7 @@ export type MinidumpLoader = (
  * @param preProcessFile A function that pre-processes the minidump file
  * @returns A function to fetch minidumps
  */
-export function createMinidumpLoader(
-  getMinidumpPaths: () => Promise<string[]>,
-  preProcessFile: (file: Buffer) => Buffer = (file) => file,
-): MinidumpLoader {
+export function createMinidumpLoader(getMinidumpPaths: () => Promise<string[]>): MinidumpLoader {
   // The mutex protects against a whole host of reentrancy issues and race conditions.
   const mutex = new Mutex();
 
@@ -69,23 +65,24 @@ export function createMinidumpLoader(
             const twoSecondsAgo = new Date().getTime() - NOT_MODIFIED_MS;
 
             if (stats.mtimeMs < twoSecondsAgo) {
-              const file = await fs.readFile(path);
-              const data = preProcessFile(file);
+              const data = await fs.readFile(path);
+              const parsedMinidump = parseMinidump(data);
 
-              if (data.length < 10_000 || data.subarray(0, 4).toString() !== MINIDUMP_HEADER) {
+              if (parsedMinidump === undefined) {
                 logger.warn('Dropping minidump as it appears invalid.');
                 break;
               }
 
-              const minidumpProcess = getMinidumpProcessType(data);
-
               logger.log('Sending minidump');
 
-              await callback(minidumpProcess, {
-                attachmentType: 'event.minidump',
-                filename: basename(path),
-                data,
-              });
+              await callback(
+                parsedMinidump,
+                 {
+                  attachmentType: 'event.minidump',
+                  filename: basename(path),
+                  data,
+                },
+              );
 
               break;
             }
@@ -168,53 +165,4 @@ export function getMinidumpLoader(): MinidumpLoader {
     const files = await readDirsAsync(dumpDirectories);
     return files.filter((file) => file.endsWith('.dmp'));
   });
-}
-
-/**
- * Crashpad includes it's own custom stream in the minidump file that can include metadata. Electron uses this to
- * include details about the app and process that caused the crash.
- *
- * Rather than parse the minidump by reading the header and parsing through all the streams, we can just look for the
- * 'process_type' key and then pick the string that comes after that.
- */
-function getMinidumpProcessType(buffer: Buffer): string | undefined {
-  const index = buffer.indexOf('process_type');
-
-  if (index < 0) {
-    return;
-  }
-
-  // start after 'process_type'
-  let start = index + 12;
-
-  // Move start to the first ascii character
-  while ((buffer[start] || 0) < 32) {
-    start++;
-
-    // If we can't find the start in the first 20 bytes, we assume it's not there
-    if (start - index > 20) {
-      return;
-    }
-  }
-
-  let end = start;
-
-  // Move the end of the ascii
-  while ((buffer[end] || -1) >= 32) {
-    end++;
-
-    // If we can't find the end in the first 20 bytes, we assume it's not there
-    if (end - start > 20) {
-      return;
-    }
-  }
-
-  const processType = buffer.subarray(start, end).toString().replace('-process', '');
-
-  // For backwards compatibility
-  if (processType === 'gpu') {
-    return 'GPU';
-  }
-
-  return processType;
 }

--- a/src/main/integrations/sentry-minidump/minidump-parser.ts
+++ b/src/main/integrations/sentry-minidump/minidump-parser.ts
@@ -133,7 +133,7 @@ type AnnotationObject = {
   name: string;
   /** `MinidumpByteArray` to the data for the annotation. */
   value: string;
-}
+};
 
 function readAnnotationObject(buf: Buffer, all: Buffer, offset: number): AnnotationObject | undefined {
   // pub struct MINIDUMP_ANNOTATION {

--- a/src/main/integrations/sentry-minidump/minidump-parser.ts
+++ b/src/main/integrations/sentry-minidump/minidump-parser.ts
@@ -1,4 +1,4 @@
-// This code takes a lot of inspiration and info from the rust-minidump crate at thins point:
+// This code takes a lot of inspiration and info from the rust-minidump crate at this point in time:
 // https://github.com/rust-minidump/rust-minidump/tree/760f84058b909ff0f980988bd09f3a0f0421d298
 //
 // rust-minidump has the following license:

--- a/src/main/integrations/sentry-minidump/minidump-parser.ts
+++ b/src/main/integrations/sentry-minidump/minidump-parser.ts
@@ -26,7 +26,6 @@
 // SOFTWARE.
 
 export const MINIDUMP_MAGIC_SIGNATURE = 'MDMP';
-export const MINIDUMP_VERSION = 42899;
 
 // https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_header
 type MinidumpHeader = {
@@ -216,10 +215,6 @@ export type MinidumpParseResult = {
   crashpadAnnotations?: CrashpadAnnotations;
 };
 
-function miniDumpLooksValid(header: MinidumpHeader, bufLen: number): boolean {
-  return header.signature === MINIDUMP_MAGIC_SIGNATURE && header.version === MINIDUMP_VERSION && bufLen > 10_000;
-}
-
 /** Parses an Electron minidump and extracts the header and crashpad annotations */
 export function parseMinidump(buf: Buffer): MinidumpParseResult | undefined {
   if (buf.length < 32) {
@@ -233,7 +228,7 @@ export function parseMinidump(buf: Buffer): MinidumpParseResult | undefined {
     return undefined;
   }
 
-  if (!miniDumpLooksValid(header, buf.length)) {
+  if (header.signature !== MINIDUMP_MAGIC_SIGNATURE || buf.length < 10_000) {
     return undefined;
   }
 

--- a/src/main/integrations/sentry-minidump/minidump-parser.ts
+++ b/src/main/integrations/sentry-minidump/minidump-parser.ts
@@ -1,0 +1,257 @@
+// This code takes a lot of inspiration and info from the rust-minidump crate at thins point:
+// https://github.com/rust-minidump/rust-minidump/tree/760f84058b909ff0f980988bd09f3a0f0421d298
+//
+// rust-minidump has the following license:
+//
+// MIT License
+//
+// Copyright (c) 2015-2023 rust-minidump contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+export const MINIDUMP_MAGIC_SIGNATURE = 'MDMP';
+export const MINIDUMP_VERSION = 42899;
+
+// https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_header
+type MinidumpHeader = {
+  signature: string;
+  version: number;
+  streamCount: number;
+  streamDirectoryRva: number;
+  checksum: number;
+  timeDateStamp: Date;
+  flags: bigint;
+};
+
+function readHeader(buf: Buffer): MinidumpHeader {
+  // pub struct MINIDUMP_HEADER {
+  //   pub signature: u32,
+  //   pub version: u32,
+  //   pub stream_count: u32,
+  //   pub stream_directory_rva: RVA,
+  //   pub checksum: u32,
+  //   pub time_date_stamp: u32,
+  //   pub flags: u64,
+  // }
+
+  return {
+    signature: buf.subarray(0, 4).toString(),
+    version: buf.readUInt32LE(4),
+    streamCount: buf.readUInt32LE(8),
+    streamDirectoryRva: buf.readUInt32LE(12),
+    checksum: buf.readUInt32LE(16),
+    timeDateStamp: new Date(buf.readUInt32LE(20) * 1000),
+    flags: buf.readBigUInt64LE(24),
+  };
+}
+
+type Location = {
+  dataSize: number;
+  rva: number;
+};
+
+// https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_location_descriptor
+function readLocationDescriptor(buf: Buffer, base: number): Location {
+  // pub struct MINIDUMP_LOCATION_DESCRIPTOR {
+  //   pub data_size: u32,
+  //   pub rva: RVA,
+  // }
+
+  return {
+    dataSize: buf.readUInt32LE(base),
+    rva: buf.readUInt32LE(base + 4),
+  };
+}
+
+type MinidumpStream = {
+  streamType: number;
+  location: Location;
+};
+
+// https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_directory
+function readDirectoryStream(buf: Buffer, rva: number): MinidumpStream {
+  // pub struct MINIDUMP_DIRECTORY {
+  //   pub stream_type: u32,
+  //   pub location: MINIDUMP_LOCATION_DESCRIPTOR,
+  // }
+
+  return {
+    streamType: buf.readUInt32LE(rva),
+    location: readLocationDescriptor(buf, rva + 4),
+  };
+}
+
+function readCrashpadInfoBuffer(buf: Buffer, location: Location): Buffer {
+  return buf.subarray(location.rva, location.rva + location.dataSize);
+}
+
+// https://crashpad.chromium.org/doxygen/structcrashpad_1_1MinidumpModuleCrashpadInfo.html
+function readCrashpadModuleInfoAnnotationObjectsLocation(buf: Buffer, base: number): Location {
+  // pub struct MINIDUMP_MODULE_CRASHPAD_INFO {
+  //   pub version: u32,
+  //   pub list_annotations: MINIDUMP_LOCATION_DESCRIPTOR,
+  //   pub simple_annotations: MINIDUMP_LOCATION_DESCRIPTOR,
+  //   pub annotation_objects: MINIDUMP_LOCATION_DESCRIPTOR,
+  // }
+
+  // const version = buf.readUInt32LE(base)
+  // const list_annotations = readLocationDescriptor(buf, base + 4)
+  // const simple_annotations = readLocationDescriptor(buf, base + 12)
+  const annotation_objects = readLocationDescriptor(buf, base + 20);
+
+  return annotation_objects;
+}
+
+function readStringUtf8Unterminated(buf: Buffer, rva: number): string {
+  const length = buf.readUInt32LE(rva);
+  return buf.toString('utf8', rva + 4, rva + 4 + length);
+}
+
+function readAnnotationObject(buf: Buffer, all: Buffer, offset: number): [string, string] | undefined {
+  // pub struct MINIDUMP_ANNOTATION {
+  //   pub name: u32,
+  //   pub ty: u16,
+  //   pub _reserved: u16,
+  //   pub value: u32,
+  // }
+
+  const name = buf.readUInt32LE(offset);
+  const ty = buf.readUInt16LE(offset + 4);
+  // const _reserved = buf.readUInt16LE(offset + 6)
+  const value = buf.readUInt32LE(offset + 8);
+
+  if (ty === 1) {
+    return [readStringUtf8Unterminated(all, name), readStringUtf8Unterminated(all, value)];
+  }
+
+  return undefined;
+}
+
+function readAnnotationObjects(buf: Buffer, location: Location): Record<string, string> {
+  const data = buf.subarray(location.rva, location.rva + location.dataSize);
+  if (data.length === 0) {
+    return {};
+  }
+
+  const annotationObjectsLocation = readCrashpadModuleInfoAnnotationObjectsLocation(data, 0);
+  const annotationObjectsData = buf.subarray(
+    annotationObjectsLocation.rva,
+    annotationObjectsLocation.rva + annotationObjectsLocation.dataSize,
+  );
+
+  const count = annotationObjectsData.readUInt32LE(0);
+  let offset = 4;
+
+  const annotationObjects: Record<string, string> = {};
+  for (let i = 0; i < count; i++) {
+    const annotation = readAnnotationObject(annotationObjectsData, buf, offset);
+    if (annotation) {
+      const [key, value] = annotation;
+      annotationObjects[key] = value;
+    }
+    offset += 12;
+  }
+
+  return annotationObjects;
+}
+
+function readCrashpadModuleLinks(buf: Buffer, location: Location): Record<string, string> {
+  const data = buf.subarray(location.rva, location.rva + location.dataSize);
+
+  if (data.length === 0) {
+    return {};
+  }
+
+  const count = data.readUInt32LE(0);
+  let offset = 4;
+
+  let annotationObjects = {};
+  for (let i = 0; i < count; i++) {
+    const annotationObjectsLocation = readLocationDescriptor(data, offset + 4);
+    annotationObjects = { ...annotationObjects, ...readAnnotationObjects(buf, annotationObjectsLocation) };
+    offset += 12;
+  }
+
+  return annotationObjects;
+}
+
+// https://crashpad.chromium.org/doxygen/structcrashpad_1_1MinidumpCrashpadInfo.html
+function parseCrashpadInfo(buf: Buffer, info: Buffer): Record<string, string> {
+  // This stream is of the following format:
+  // pub struct MINIDUMP_CRASHPAD_INFO {
+  //   pub version: u32,
+  //   pub report_id: GUID,
+  //   pub client_id: GUID,
+  //   pub simple_annotations: MINIDUMP_LOCATION_DESCRIPTOR,
+  //   pub module_list: MINIDUMP_LOCATION_DESCRIPTOR,
+  // }
+
+  const module_list = readLocationDescriptor(info, 44);
+
+  return readCrashpadModuleLinks(buf, module_list);
+}
+
+type CrashpadAnnotations = {
+  process_type?: string;
+} & Record<string, string>;
+
+export type MinidumpParseResult = {
+  header: MinidumpHeader;
+  crashpadAnnotations?: CrashpadAnnotations;
+};
+
+function looksValid(header: MinidumpHeader, bufLen: number): boolean {
+  return header.signature === MINIDUMP_MAGIC_SIGNATURE && header.version === MINIDUMP_VERSION && bufLen > 10_000;
+}
+
+/** Parses an Electron minidump and extracts the header and crashpad annotations */
+export function parseMinidump(buf: Buffer): MinidumpParseResult | undefined {
+  if (buf.length < 32) {
+    return undefined;
+  }
+
+  let header: MinidumpHeader | undefined;
+  try {
+    header = readHeader(buf);
+  } catch (_) {
+    return undefined;
+  }
+
+  if (looksValid(header, buf.length)) {
+    return undefined;
+  }
+
+  for (let i = 0; i < header.streamCount; i++) {
+    const stream = readDirectoryStream(buf, header.streamDirectoryRva + i * 12);
+
+    // Crashpad specific stream in Electron minidump files
+    // https://crashpad.chromium.org/doxygen/structcrashpad_1_1MinidumpCrashpadInfo.html
+    if (stream.streamType === 1_129_316_353) {
+      const crashpadInfo = readCrashpadInfoBuffer(buf, stream.location);
+      const crashpadAnnotations = parseCrashpadInfo(buf, crashpadInfo) as CrashpadAnnotations;
+
+      return {
+        header,
+        crashpadAnnotations,
+      };
+    }
+  }
+
+  return { header };
+}

--- a/test/e2e/test-apps/native-sentry/renderer/event.json
+++ b/test/e2e/test-apps/native-sentry/renderer/event.json
@@ -56,7 +56,8 @@
         "version": "{{version}}"
       },
       "electron": {
-        "crashed_url": "app:///src/index.html"
+        "crashed_url": "app:///src/index.html",
+        "crashpad.process_type": "renderer"
       }
     },
     "release": "native-sentry-renderer@1.0.0",

--- a/test/unit/minidump-loader.test.ts
+++ b/test/unit/minidump-loader.test.ts
@@ -36,7 +36,7 @@ describe('createMinidumpLoader', () => {
 
       const loader = createMinidumpLoader(() => Promise.resolve([dumpPath]));
 
-      void loader(false, (_, attachment) => {
+      void loader(false, async (_, attachment) => {
         expect(attachment).to.eql({
           data: VALID_LOOKING_MINIDUMP,
           filename: name,
@@ -60,7 +60,7 @@ describe('createMinidumpLoader', () => {
       const loader = createMinidumpLoader(() => Promise.resolve([missingHeaderDump, tooSmallDump]));
 
       let passedAttachment = false;
-      void loader(false, () => {
+      void loader(false, async () => {
         passedAttachment = true;
       });
 
@@ -82,7 +82,7 @@ describe('createMinidumpLoader', () => {
       const loader = createMinidumpLoader(() => Promise.resolve([dumpPath]));
 
       let passedAttachment = false;
-      void loader(false, () => {
+      void loader(false, async () => {
         passedAttachment = true;
       });
 
@@ -101,7 +101,7 @@ describe('createMinidumpLoader', () => {
       const loader = createMinidumpLoader(() => Promise.resolve([dumpPath]));
 
       let passedAttachment = false;
-      void loader(true, () => {
+      void loader(true, async () => {
         passedAttachment = true;
       });
 
@@ -134,7 +134,7 @@ describe('createMinidumpLoader', () => {
 
         const loader = createMinidumpLoader(() => Promise.resolve([dumpPath]));
 
-        void loader(false, (_) => {
+        void loader(false, async (_) => {
           expect(count).to.be.greaterThanOrEqual(3_000);
           done();
         });
@@ -151,7 +151,7 @@ describe('createMinidumpLoader', () => {
 
       const loader = createMinidumpLoader(() => Promise.resolve([missingPath, dumpPath]));
 
-      void loader(false, (_, attachment) => {
+      void loader(false, async (_, attachment) => {
         expect(attachment.filename).to.eql(name);
 
         setTimeout(() => {


### PR DESCRIPTION
- Closes #1094 

Previously we pulled the `process_type` value from the minidump via some crude parsing.

This PR adds a full parser to pull annotations from the crashpad stream in the minidumps and includes them in the event `electron` context but prepends `crashpad.` to all the keys. This allows users to use this context in `beforeSend` filters and in other sampling decisions.

Electron includes additional v8 context in the crashpad metadata (like `electron.v8-oom.detail` which gives details about the OOM reason):
https://github.com/electron/electron/blob/d987bee0073310c0bf114dd5e5c9db5e9c68ee59/shell/common/node_bindings.cc#L193

The parser code was mostly aided by the `rust-minidump` crate which has great documentation. I've credited it fully in the source because it would have been a lot more complicated without such a comprehensive library to test against. 

I was going to add unit tests for the parser but that would involve generating minidumps on every platform and adding them to the repository. This has the potential to leak environment variables. Instead, I'm leveraging the e2e tests because this actually tests all supported versions of Electron so we know the parser works across all versions and platforms.

