### PR TITLE
feat: Add `gpuContextIntegration`

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -148,6 +148,7 @@ export { screenshotsIntegration } from './integrations/screenshots';
 export { rendererProfileFromIpc } from './integrations/renderer-profiling';
 export { normalizePathsIntegration } from './integrations/normalize-paths';
 export { electronContextIntegration } from './integrations/electron-context';
+export { gpuContextIntegration } from './integrations/gpu-context';
 export { anrIntegration } from './integrations/anr';
 
 export { makeElectronTransport } from './transports/electron-net';

--- a/src/main/integrations/gpu-context.ts
+++ b/src/main/integrations/gpu-context.ts
@@ -1,0 +1,76 @@
+import { defineIntegration, dropUndefinedKeys, Event } from '@sentry/core';
+import { app } from 'electron';
+
+interface Options {
+  infoLevel: 'basic' | 'complete';
+}
+
+interface GpuContext extends Record<string, unknown> {
+  name: string;
+  active?: boolean;
+  vendor_id?: string;
+  vendor_name?: string;
+  device_id?: string;
+  driver_version?: string;
+}
+
+interface GpuDevice {
+  active: boolean;
+  deviceId: number;
+  deviceString?: string;
+  driverVendor?: string;
+  driverVersion?: string;
+  vendorId: number;
+  vendorString?: string;
+}
+
+interface GpuInfoResult {
+  gpuDevice: GpuDevice[];
+}
+
+function gpuDeviceToGpuContext(device: GpuDevice): GpuContext {
+  return dropUndefinedKeys({
+    name: device.deviceString || 'GPU',
+    active: device.active,
+    vendor_id: `0x${device.vendorId.toString(16)}`,
+    vendor_name: device.vendorString,
+    device_id: `0x${device.deviceId.toString(16)}`,
+    driver_version: device.driverVersion,
+  });
+}
+
+/**
+ * Adds additional Electron context to events
+ */
+export const gpuContextIntegration = defineIntegration((options: Options = { infoLevel: 'basic' }) => {
+  let gpuContextsPromise: Promise<GpuContext[]> | undefined;
+
+  return {
+    name: 'GpuContext',
+    setup() {
+      app.on('gpu-info-update', async () => {
+        gpuContextsPromise = (app.getGPUInfo(options.infoLevel) as Promise<GpuInfoResult>).then((result) =>
+          result.gpuDevice.map(gpuDeviceToGpuContext),
+        );
+      });
+    },
+    processEvent: async (event): Promise<Event> => {
+      if (gpuContextsPromise) {
+        const gpuContexts = await gpuContextsPromise;
+
+        if (gpuContexts.length === 1) {
+          event.contexts = { ...event.contexts, gpu: gpuContexts[0] };
+        } else if (gpuContexts.length > 1) {
+          event.contexts = { ...event.contexts };
+          for (let i = 0; i < gpuContexts.length; i++) {
+            const gpuContext = gpuContexts[i] as GpuContext;
+            gpuContext.type = 'gpu';
+            event.contexts[`gpu_${i + 1}`] = gpuContext;
+          }
+        }
+      }
+
+      return event;
+    },
+  };
+});

--- a/src/main/integrations/gpu-context.ts
+++ b/src/main/integrations/gpu-context.ts
@@ -32,9 +32,9 @@ function gpuDeviceToGpuContext(device: GpuDevice): GpuContext {
   return dropUndefinedKeys({
     name: device.deviceString || 'GPU',
     active: device.active,
-    vendor_id: `0x${device.vendorId.toString(16)}`,
+    vendor_id: `0x${device.vendorId.toString(16).padStart(4, '0')}`,
     vendor_name: device.vendorString,
-    device_id: `0x${device.deviceId.toString(16)}`,
+    device_id: `0x${device.deviceId.toString(16).padStart(4, '0')}`,
     driver_version: device.driverVersion,
   });
 }

--- a/src/main/sdk.ts
+++ b/src/main/sdk.ts
@@ -31,6 +31,7 @@ import { additionalContextIntegration } from './integrations/additional-context'
 import { childProcessIntegration } from './integrations/child-process';
 import { electronBreadcrumbsIntegration } from './integrations/electron-breadcrumbs';
 import { electronContextIntegration } from './integrations/electron-context';
+import { gpuContextIntegration } from './integrations/gpu-context';
 import { mainProcessSessionIntegration } from './integrations/main-process-session';
 import { electronNetIntegration } from './integrations/net-breadcrumbs';
 import { normalizePathsIntegration } from './integrations/normalize-paths';
@@ -57,6 +58,7 @@ export function getDefaultIntegrations(options: ElectronMainOptions): Integratio
     preloadInjectionIntegration(),
     additionalContextIntegration(),
     screenshotsIntegration(),
+    gpuContextIntegration(),
 
     // Main process sessions
     mainProcessSessionIntegration(),

--- a/test/e2e/recipe/normalize.ts
+++ b/test/e2e/recipe/normalize.ts
@@ -70,6 +70,14 @@ function normalizeEvent(event: Event & ReplayEvent): void {
     event.contexts.app.app_start_time = '{{time}}';
   }
 
+  if (event.contexts?.gpu?.vendor_id) {
+    event.contexts.gpu.vendor_id = '0x0000';
+  }
+
+  if (event.contexts?.gpu?.device_id) {
+    event.contexts.gpu.device_id = '0x0000';
+  }
+
   if (event.contexts?.chrome?.version) {
     event.contexts.chrome.version = '{{version}}';
   }

--- a/test/e2e/recipe/normalize.ts
+++ b/test/e2e/recipe/normalize.ts
@@ -70,6 +70,11 @@ function normalizeEvent(event: Event & ReplayEvent): void {
     event.contexts.app.app_start_time = '{{time}}';
   }
 
+  // Windows e2e tests have two GPU contexts for some reason so we copy one over to the default
+  if (event.contexts?.gpu_1) {
+    event.contexts.gpu = event.contexts.gpu_1;
+  }
+
   if (event.contexts?.gpu?.vendor_id) {
     event.contexts.gpu.vendor_id = '0x0000';
   }

--- a/test/e2e/test-apps/native-sentry/gpu/event.json
+++ b/test/e2e/test-apps/native-sentry/gpu/event.json
@@ -22,8 +22,6 @@
         "name": "Chrome"
       },
       "gpu":{
-        "name": "GPU",
-        "active": true,
         "vendor_id": "0x0000",
         "device_id": "0x0000"
       },

--- a/test/e2e/test-apps/native-sentry/gpu/event.json
+++ b/test/e2e/test-apps/native-sentry/gpu/event.json
@@ -21,6 +21,12 @@
       "browser": {
         "name": "Chrome"
       },
+      "gpu":{
+        "name": "GPU",
+        "active": true,
+        "vendor_id": "0x0000",
+        "device_id": "0x0000"
+      },
       "chrome": {
         "name": "Chrome",
         "type": "runtime",

--- a/test/e2e/test-apps/native-sentry/gpu/src/main.js
+++ b/test/e2e/test-apps/native-sentry/gpu/src/main.js
@@ -1,14 +1,17 @@
 const path = require('path');
 
 const { app, BrowserWindow } = require('electron');
-const { init } = require('@sentry/electron/main');
+const { init, gpuContextIntegration } = require('@sentry/electron/main');
 
 app.commandLine.appendSwitch('enable-crashpad');
 
 init({
   dsn: '__DSN__',
   debug: true,
-  integrations: (integrations) => integrations.filter((i) => i.name !== 'MainProcessSession'),
+  integrations: (integrations) => [
+    ...integrations.filter((i) => i.name !== 'MainProcessSession'),
+    gpuContextIntegration({ infoLevel: 'complete' })
+  ],
   onFatalError: () => {},
 });
 


### PR DESCRIPTION
- Closes #1091

If you want full GPU information to be included, you should add the integration with `infoLevel: 'complete'`:
```ts
import * as Sentry from '@sentry/electron/main';

Sentry.init({
  dsn: '__DSN__',
  integrations: [gpuContextIntegration({ infoLevel: 'complete' })],
});
```

<img width="458" alt="image" src="https://github.com/user-attachments/assets/48f44e0d-2f09-4fe8-9151-39769ad2a2a3" />