### PR TITLE
feat: Use `registerPreloadScript` in Electron >= v35

### DIFF
--- a/src/main/electron-normalize.ts
+++ b/src/main/electron-normalize.ts
@@ -74,17 +74,17 @@ export function registerProtocol(
 }
 
 type PreloadScriptRegistration = {
-  // Context type where the preload script will be executed. Possible values include frame or service-worker.
+  // Context type where the preload script will be executed.
   type: 'frame' | 'service-worker';
   // Unique ID of preload script. Defaults to a random UUID.
   id?: string;
   // Path of the script file. Must be an absolute path.
-  filePath: string
-}
+  filePath: string;
+};
 
 type SessionMaybeSupportingRegisterPreloadScript = Session & {
   registerPreloadScript?: (script: PreloadScriptRegistration) => void;
-}
+};
 
 /**
  * Adds a preload script to the session.

--- a/src/main/integrations/preload-injection.ts
+++ b/src/main/integrations/preload-injection.ts
@@ -5,6 +5,7 @@ import { isAbsolute, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
 import { IPCMode } from '../../common/ipc';
+import { setPreload } from '../electron-normalize';
 import { ElectronMainOptionsInternal } from '../sdk';
 
 // After bundling with webpack, require.resolve can return number so we include that in the types
@@ -48,9 +49,7 @@ export const preloadInjectionIntegration = defineIntegration(() => {
 
         if (path && typeof path === 'string' && isAbsolute(path) && existsSync(path)) {
           for (const sesh of options.getSessions()) {
-            // Fetch any existing preloads so we don't overwrite them
-            const existing = sesh.getPreloads();
-            sesh.setPreloads([path, ...existing]);
+            setPreload(sesh, path);
           }
         } else {
           logger.log(


### PR DESCRIPTION
- Closes #1096

This removes the deprecation warning when using Electron v35