### PR TITLE
fix: Electron `app.getPath('crashDumps')` API can throw

### DIFF
--- a/src/main/integrations/sentry-minidump/index.ts
+++ b/src/main/integrations/sentry-minidump/index.ts
@@ -214,7 +214,14 @@ export const sentryMinidumpIntegration = defineIntegration((options: Options = {
         scope: new Scope().getScopeData(),
       });
       scopeLastRun = scopeStore.get();
-      minidumpLoader = getMinidumpLoader();
+
+      try {
+        minidumpLoader = getMinidumpLoader();
+      } catch (error) {
+        // This is rare but we've seen reports:
+        // https://github.com/getsentry/sentry-electron/issues/1102
+        logger.error('Failed to create minidump loader', error);
+      }
 
       const options = client.getOptions();
 


### PR DESCRIPTION
- Closes #1102