### PR TITLE
chore: Remove unused IPC method

### DIFF
--- a/src/common/ipc.ts
+++ b/src/common/ipc.ts
@@ -18,8 +18,6 @@ export const PROTOCOL_SCHEME = 'sentry-ipc';
 export enum IPCChannel {
   /** IPC to check main process is listening */
   RENDERER_START = 'sentry-electron.renderer-start',
-  /** IPC to send a captured event to Sentry. */
-  EVENT = 'sentry-electron.event',
   /** IPC to pass scope changes to main process. */
   SCOPE = 'sentry-electron.scope',
   /** IPC to pass envelopes to the main process. */
@@ -59,7 +57,6 @@ export interface RendererStatus {
 export interface IPCInterface {
   sendRendererStart: () => void;
   sendScope: (scope: string) => void;
-  sendEvent: (event: string) => void;
   sendEnvelope: (evn: Uint8Array | string) => void;
   sendStatus: (state: RendererStatus) => void;
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -172,8 +172,6 @@ function configureProtocol(options: ElectronMainOptionsInternal): void {
           const data = request.body;
           if (request.url.startsWith(`${PROTOCOL_SCHEME}://${IPCChannel.RENDERER_START}`)) {
             newProtocolRenderer();
-          } else if (request.url.startsWith(`${PROTOCOL_SCHEME}://${IPCChannel.EVENT}`) && data) {
-            handleEvent(options, data.toString(), getWebContents());
           } else if (request.url.startsWith(`${PROTOCOL_SCHEME}://${IPCChannel.SCOPE}`) && data) {
             handleScope(options, data.toString());
           } else if (request.url.startsWith(`${PROTOCOL_SCHEME}://${IPCChannel.ENVELOPE}`) && data) {
@@ -213,7 +211,6 @@ function configureClassic(options: ElectronMainOptionsInternal): void {
       });
     }
   });
-  ipcMain.on(IPCChannel.EVENT, ({ sender }, jsonEvent: string) => handleEvent(options, jsonEvent, sender));
   ipcMain.on(IPCChannel.SCOPE, (_, jsonScope: string) => handleScope(options, jsonScope));
   ipcMain.on(IPCChannel.ENVELOPE, ({ sender }, env: Uint8Array | string) => handleEnvelope(options, env, sender));
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -67,18 +67,6 @@ function captureEventFromRenderer(
   captureEvent(mergeEvents(event, { tags: { 'event.process': process } }), { attachments });
 }
 
-function handleEvent(options: ElectronMainOptionsInternal, jsonEvent: string, contents?: WebContents): void {
-  let event: Event;
-  try {
-    event = JSON.parse(jsonEvent) as Event;
-  } catch {
-    logger.warn('sentry-electron received an invalid event message');
-    return;
-  }
-
-  captureEventFromRenderer(options, event, [], contents);
-}
-
 function handleEnvelope(options: ElectronMainOptionsInternal, env: Uint8Array | string, contents?: WebContents): void {
   const envelope = parseEnvelope(env);
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -14,7 +14,6 @@ if (window.__SENTRY_IPC__) {
   const ipcObject = {
     sendRendererStart: () => ipcRenderer.send(IPCChannel.RENDERER_START),
     sendScope: (scopeJson: string) => ipcRenderer.send(IPCChannel.SCOPE, scopeJson),
-    sendEvent: (eventJson: string) => ipcRenderer.send(IPCChannel.EVENT, eventJson),
     sendEnvelope: (envelope: Uint8Array | string) => ipcRenderer.send(IPCChannel.ENVELOPE, envelope),
     sendStatus: (status: RendererStatus) => ipcRenderer.send(IPCChannel.STATUS, status),
   };

--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -37,11 +37,6 @@ function getImplementation(): IPCInterface {
           // ignore
         });
       },
-      sendEvent: (body: string) => {
-        fetch(buildUrl(IPCChannel.EVENT), { method: 'POST', body, headers }).catch(() => {
-          // ignore
-        });
-      },
       sendEnvelope: (body: string | Uint8Array) => {
         fetch(buildUrl(IPCChannel.ENVELOPE), { method: 'POST', body, headers }).catch(() => {
           // ignore


### PR DESCRIPTION
While working on #1117 I found that we have a `sentEvent` IPC method that is no longer used!