### PR TITLE
fix: Missing DSC envelope header for renderer tracing

### DIFF
--- a/test/e2e/test-apps/other/browser-tracing/event.json
+++ b/test/e2e/test-apps/other/browser-tracing/event.json
@@ -112,5 +112,8 @@
       "event.environment": "javascript",
       "event.origin": "electron"
     }
+  },
+  "dynamicSamplingContext": {
+    "sample_rate": "1"
   }
 }


### PR DESCRIPTION
- Closes #1114

Events and transactions from renderer (browser) processes are re-captured through the main (Node.js) process so that they include the same full app context as all other events. However, this meant that the `trace` context in the envelope header from the renderer was dropped and it always contained the DSC for the main process. If there was no active span in the main process, `sample_rate` would be missing from the DSC. Even if there was an active span in the main process, the `sample_rate` and other context would be for the main process.

This PR pulls the `trace` context from the envelope header from the renderer and passes it back through the event pipeline via `sdkProcessingMetadata` which is where it is pulled from when creating the envelope headers:
https://github.com/getsentry/sentry-javascript/blob/7f1087d3fb6a2be0aa7427c49d37dd352dba07da/packages/core/src/utils-hoist/envelope.ts#L254

All other envelope types (other than event/transaction) are sent complete without changes so only these types of envelopes require the pass through of DSC.