### PR TITLE
CI: Remove Ubuntu 20.04 usage in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
     needs: [build, lint, test, e2e]
     # Always run this, even if a dependent job failed
     if: always()
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check for failures
         if: contains(needs.*.result, 'failure')


### PR DESCRIPTION
Ubuntu 20.04 has been deprecated in GHA