### PR TITLE
feat: Optionally capture manufacturer and model device context

### DIFF
--- a/src/main/integrations/additional-context.ts
+++ b/src/main/integrations/additional-context.ts
@@ -11,7 +11,8 @@ export interface AdditionalContextOptions {
    */
   screen: boolean;
   /**
-   * Capture device model and manufacturer on Windows
+   * Capture device model and manufacturer.
+   * Only supported in Windows.
    * @default false
    */
   deviceModelManufacturer: boolean;

--- a/src/main/integrations/additional-context.ts
+++ b/src/main/integrations/additional-context.ts
@@ -1,28 +1,75 @@
 import { defineIntegration, DeviceContext } from '@sentry/core';
 import { app, screen as electronScreen } from 'electron';
+import { exec } from 'node:child_process';
 
 import { mergeEvents } from '../merge';
 
 export interface AdditionalContextOptions {
+  /**
+   * Capture dimensions and resolution of the primary display
+   * @default true
+   */
   screen: boolean;
+  /**
+   * Capture device model and manufacturer on Windows
+   * @default false
+   */
+  deviceModelManufacturer: boolean;
 }
 
 const DEFAULT_OPTIONS: AdditionalContextOptions = {
   screen: true,
+  deviceModelManufacturer: false,
 };
+
+/** The Key properties we're looking for in the JSON we get back from the powershell command */
+type CmiJson = {
+  Manufacturer?: string;
+  Model?: string;
+};
+
+function getWindowsDeviceModelManufacturer(): Promise<DeviceContext> {
+  return new Promise((resolve) => {
+    try {
+      exec(
+        'powershell -NoProfile "Get-CimInstance -ClassName Win32_ComputerSystem | ConvertTo-Json"',
+        (error, stdout) => {
+          if (error) {
+            resolve({});
+          }
+          try {
+            const details = JSON.parse(stdout) as CmiJson;
+            if (details.Manufacturer || details.Model) {
+              resolve({
+                manufacturer: details.Manufacturer,
+                model: details.Model,
+              });
+              return;
+            }
+          } catch (_) {
+            resolve({});
+          }
+        },
+      );
+    } catch (_) {
+      resolve({});
+    }
+  });
+}
 
 /**
  * Adds additional Electron context to events
  */
 export const additionalContextIntegration = defineIntegration((userOptions: Partial<AdditionalContextOptions> = {}) => {
   const _lazyDeviceContext: DeviceContext = {};
+  let shouldCaptureDeviceModelManufacturer = userOptions.deviceModelManufacturer;
 
   const options = {
     ...DEFAULT_OPTIONS,
     ...userOptions,
   };
 
-  function _setPrimaryDisplayInfo(): void {
+  function setPrimaryDisplayInfo(): void {
     const display = electronScreen.getPrimaryDisplay();
     const width = Math.floor(display.size.width * display.scaleFactor);
     const height = Math.floor(display.size.height * display.scaleFactor);
@@ -33,28 +80,37 @@ export const additionalContextIntegration = defineIntegration((userOptions: Part
   return {
     name: 'AdditionalContext',
     setup() {
+      if (!options.screen) {
+        return;
+      }
+
       // Some metrics are only available after app ready so we lazily load them
       app.whenReady().then(
         () => {
-          const { screen } = options;
-
-          if (screen) {
-            _setPrimaryDisplayInfo();
-
-            electronScreen.on('display-metrics-changed', () => {
-              _setPrimaryDisplayInfo();
-            });
-          }
+          setPrimaryDisplayInfo();
+          electronScreen.on('display-metrics-changed', () => {
+            setPrimaryDisplayInfo();
+          });
         },
         () => {
           // ignore
         },
       );
     },
-    processEvent(event) {
-      const device: DeviceContext = _lazyDeviceContext;
+    processEvent: async (event) => {
+      if (process.platform === 'win32' && shouldCaptureDeviceModelManufacturer) {
+        // Ensure we only fetch this once per session
+        shouldCaptureDeviceModelManufacturer = false;
 
-      return mergeEvents(event, { contexts: { device } });
+        const { manufacturer, model } = await getWindowsDeviceModelManufacturer();
+
+        if (manufacturer || model) {
+          _lazyDeviceContext.manufacturer = manufacturer;
+          _lazyDeviceContext.model = model;
+        }
+      }
+
+      return mergeEvents(event, { contexts: { device: _lazyDeviceContext } });
     },
   };
 });

--- a/test/e2e/recipe/normalize.ts
+++ b/test/e2e/recipe/normalize.ts
@@ -111,6 +111,14 @@ function normalizeEvent(event: Event & ReplayEvent): void {
     event.contexts.device.processor_count = 0;
   }
 
+  if (event.contexts?.device?.manufacturer) {
+    event.contexts.device.manufacturer = '{{manufacturer}}';
+  }
+
+  if (event.contexts?.device?.model) {
+    event.contexts.device.model = '{{model}}';
+  }
+
   if (event.contexts?.device?.processor_frequency) {
     event.contexts.device.processor_frequency = 0;
   }

--- a/test/e2e/test-apps/other/device-context/event.json
+++ b/test/e2e/test-apps/other/device-context/event.json
@@ -1,0 +1,98 @@
+{
+  "method": "envelope",
+  "sentryKey": "37f8a2ee37c0409d8970bc7559c7c7e4",
+  "appId": "277345",
+  "data": {
+    "sdk": {
+      "name": "sentry.javascript.electron",
+      "packages": [
+        {
+          "name": "npm:@sentry/electron",
+          "version": "{{version}}"
+        }
+      ],
+      "version": "{{version}}"
+    },
+    "contexts": {
+      "app": {
+        "app_name": "device-context",
+        "app_version": "1.0.0",
+        "app_start_time": "{{time}}"
+      },
+      "browser": {
+        "name": "Chrome"
+      },
+      "chrome": {
+        "name": "Chrome",
+        "type": "runtime",
+        "version": "{{version}}"
+      },
+      "device": {
+        "arch": "{{arch}}",
+        "family": "Desktop",
+        "memory_size": 0,
+        "free_memory": 0,
+        "processor_count": 0,
+        "processor_frequency": 0,
+        "cpu_description": "{{cpu}}",
+        "screen_resolution":"{{screen}}",
+        "screen_density": 1,
+        "manufacturer": "{{manufacturer}}",
+        "model": "{{model}}"
+      },
+      "culture": {
+        "locale": "{{locale}}",
+        "timezone": "{{timezone}}"
+      },
+      "node": {
+        "name": "Node",
+        "type": "runtime",
+        "version": "{{version}}"
+      },
+      "os": {
+        "name": "{{platform}}",
+        "version": "{{version}}"
+      },
+      "runtime": {
+        "name": "Electron",
+        "version": "{{version}}"
+      }
+    },
+    "release": "device-context@1.0.0",
+    "environment": "development",
+    "exception": {
+      "values": [
+        {
+          "type": "Error",
+          "value": "Some main error",
+          "stacktrace": {
+            "frames": [
+              {
+                "colno": 0,
+                "filename": "app:///src/main.js",
+                "function": "{{function}}",
+                "module": "src:main",
+                "in_app": true,
+                "lineno": 0
+              }
+            ]
+          },
+          "mechanism": {
+            "handled": false,
+            "type": "generic"
+          }
+        }
+      ]
+    },
+    "level": "fatal",
+    "event_id": "{{id}}",
+    "platform": "node",
+    "timestamp": 0,
+    "breadcrumbs": [],
+    "tags": {
+      "event.environment": "javascript",
+      "event.origin": "electron",
+      "event.process": "browser"
+    }
+  }
+}

--- a/test/e2e/test-apps/other/device-context/package.json
+++ b/test/e2e/test-apps/other/device-context/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "device-context",
+  "version": "1.0.0",
+  "main": "src/main.js",
+  "dependencies": {
+    "@sentry/electron": "5.6.0"
+  }
+}

--- a/test/e2e/test-apps/other/device-context/recipe.yml
+++ b/test/e2e/test-apps/other/device-context/recipe.yml
@@ -1,0 +1,3 @@
+description: Device Context
+command: yarn
+condition: platform === 'darwin'

--- a/test/e2e/test-apps/other/device-context/src/main.js
+++ b/test/e2e/test-apps/other/device-context/src/main.js
@@ -1,0 +1,18 @@
+const { app } = require('electron');
+const { init, additionalContextIntegration } = require('@sentry/electron/main');
+
+init({
+  dsn: '__DSN__',
+  debug: true,
+  integrations: (integrations) => [
+    additionalContextIntegration({ deviceModelManufacturer: true }),
+    ...integrations.filter((i) => i.name !== 'MainProcessSession')
+  ],
+  onFatalError: () => {},
+});
+
+app.on('ready', () => {
+  setTimeout(() => {
+    throw new Error('Some main error');
+  }, 500);
+});


### PR DESCRIPTION
- Closes #1112 

This PR adds to the `additionalContextIntegration` so you can optionally include the manufacturer and model in the device context:

```ts
import * as Sentry from '@sentry/electron/main';

Sentry.init({
  dsn: '__DSN__',
  integrations: [Sentry.additionalContextIntegration({ deviceModelManufacturer: true })]
});
```

It's worth noting that testing this on my Windows laptop, pulling this data via powershell takes around 400ms. This is a one-off cost as the result is cached. This data is captured asynchronously but it will delay sending of the first event.  

<img width="463" alt="image" src="https://github.com/user-attachments/assets/01a6beaa-391d-4009-bfd2-48dff0d3d8dc" />
