### PR TITLE
fix: GPU context should use `id` rather than `device_id`

### DIFF
--- a/src/main/integrations/gpu-context.ts
+++ b/src/main/integrations/gpu-context.ts
@@ -16,7 +16,7 @@ interface GpuContext extends Record<string, unknown> {
   active?: boolean;
   vendor_id?: string;
   vendor_name?: string;
-  device_id?: string;
+  id?: string;
   driver_version?: string;
 }
 
@@ -38,9 +38,9 @@ function gpuDeviceToGpuContext(device: GpuDevice): GpuContext {
   return {
     name: device.deviceString || 'GPU',
     active: device.active,
+    id: `0x${device.deviceId.toString(16).padStart(4, '0')}`,
     vendor_id: `0x${device.vendorId.toString(16).padStart(4, '0')}`,
     vendor_name: device.vendorString,
-    device_id: `0x${device.deviceId.toString(16).padStart(4, '0')}`,
     driver_version: device.driverVersion,
   };
 }

--- a/src/main/integrations/gpu-context.ts
+++ b/src/main/integrations/gpu-context.ts
@@ -5,7 +5,7 @@ interface Options {
   /**
    * How much GPU information to request from Electron `app.getGPUInfo` API.
    * `complete` can take much longer to resolve so the default is `basic`.
-   * - 'basic': Usually only the `vendor_id` and `device_id` but some platforms supply more.
+   * - 'basic': Usually only the `vendor_id` and `id` but some platforms supply more.
    * - 'complete': More detailed information including full names and driver_version.
    */
   infoLevel: 'basic' | 'complete';

--- a/test/e2e/recipe/normalize.ts
+++ b/test/e2e/recipe/normalize.ts
@@ -79,8 +79,8 @@ function normalizeEvent(event: Event & ReplayEvent): void {
     event.contexts.gpu.vendor_id = '0x0000';
   }
 
-  if (event.contexts?.gpu?.device_id) {
-    event.contexts.gpu.device_id = '0x0000';
+  if (event.contexts?.gpu?.id) {
+    event.contexts.gpu.id = '0x0000';
   }
 
   if (event.contexts?.chrome?.version) {

--- a/test/e2e/test-apps/native-sentry/gpu/event.json
+++ b/test/e2e/test-apps/native-sentry/gpu/event.json
@@ -22,8 +22,8 @@
         "name": "Chrome"
       },
       "gpu":{
-        "vendor_id": "0x0000",
-        "device_id": "0x0000"
+        "id": "0x0000",
+        "vendor_id": "0x0000"
       },
       "chrome": {
         "name": "Chrome",


### PR DESCRIPTION
I added `device_id` to the GPU context but when I went to PR to the develop docs, I noticed this should just be `id`!