### PR TITLE
docs: Fix minimum supported version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Test](https://github.com/getsentry/sentry-electron/actions/workflows/build.yml/b
   [`@sentry/browser`](https://github.com/getsentry/sentry-javascript/tree/master/packages/browser))
 - Captures **native crashes** (Minidump crash reports) from renderers and the main process
 - Collects **breadcrumbs and context** information along with events across renderers and the main process
-- Supports `electron >= v15`
+- Supports `electron >= v23`
 
 ## Usage
 


### PR DESCRIPTION
I just noticed that the minimum supported Electron version was not updated at the last major!