### PR TITLE
feat: Update JavaScript SDKs to v9.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,16 +60,16 @@
     "e2e": "xvfb-maybe vitest run --root=./test/e2e --silent=false --disable-console-intercept"
   },
   "dependencies": {
-    "@sentry/browser": "9.12.0",
-    "@sentry/core": "9.12.0",
-    "@sentry/node": "9.12.0",
+    "@sentry/browser": "9.13.0",
+    "@sentry/core": "9.13.0",
+    "@sentry/node": "9.13.0",
     "deepmerge": "4.3.1"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-typescript": "^11.1.6",
-    "@sentry-internal/eslint-config-sdk": "9.12.0",
-    "@sentry-internal/typescript": "9.12.0",
+    "@sentry-internal/eslint-config-sdk": "9.13.0",
+    "@sentry-internal/typescript": "9.13.0",
     "@types/busboy": "^1.5.4",
     "@types/form-data": "^2.5.0",
     "@types/koa": "^2.0.52",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -35,6 +35,7 @@ export {
   continueTrace,
   createGetModuleFromFilename,
   createTransport,
+  createSentryWinstonTransport,
   cron,
   dataloaderIntegration,
   dedupeIntegration,

--- a/src/main/transports/electron-offline-net.ts
+++ b/src/main/transports/electron-offline-net.ts
@@ -1,44 +1,11 @@
-import { BaseTransportOptions, Envelope, makeOfflineTransport, OfflineTransportOptions, Transport } from '@sentry/core';
+import { BaseTransportOptions, makeOfflineTransport, OfflineTransportOptions, Transport } from '@sentry/core';
 
 import { ElectronNetTransportOptions, makeElectronTransport } from './electron-net';
 import { createOfflineStore, OfflineStoreOptions } from './offline-store';
 
 export type ElectronOfflineTransportOptions = ElectronNetTransportOptions &
   OfflineTransportOptions &
-  Partial<OfflineStoreOptions> & {
-    /**
-     * Should we attempt to send the envelope to Sentry.
-     * If this function returns false, `shouldStore` will be called to determine if the envelope should be stored.
-     *
-     * Default: () => true
-     *
-     * @param envelope The envelope that will be sent.
-     * @returns Whether we should attempt to send the envelope
-     */
-    shouldSend?: (envelope: Envelope) => boolean | Promise<boolean>;
-  };
-
-// Transport that throws if the `shouldSend` callback returns false
-function makeShouldSendTransport<T extends BaseTransportOptions>(
-  baseTransport: (opt: T & ElectronOfflineTransportOptions) => Transport,
-): (options: T & ElectronOfflineTransportOptions) => Transport {
-  return (options: T & ElectronOfflineTransportOptions) => {
-    const transport = baseTransport(options);
-
-    return {
-      ...transport,
-      send: async (envelope) => {
-        const shouldAttemptSend = options.shouldSend === undefined || (await options.shouldSend(envelope));
-
-        if (shouldAttemptSend) {
-          return transport.send(envelope);
-        }
-
-        throw new Error("'shouldSend' callback returned false. Skipped sending.");
-      },
-    };
-  };
-}
+  Partial<OfflineStoreOptions>;
 
 /**
  * Creates a Transport that uses Electrons net module to send events to Sentry. When they fail to send they are
@@ -48,13 +15,11 @@ export function makeElectronOfflineTransport<T extends BaseTransportOptions>(
   baseTransport: (opt: T & ElectronOfflineTransportOptions) => Transport = makeElectronTransport,
 ): (options: T & ElectronOfflineTransportOptions) => Transport {
   return (userOptions: T & ElectronOfflineTransportOptions): Transport => {
-    // `makeElectronOfflineTransport` is a combination of three transports.
+    // `makeElectronOfflineTransport` is a combination of two transports.
     //
-    // The base Electron transport (`makeElectronTransport`) is first wrapped by `makeShouldSendTransport` which skips
-    // sending events and throws when the `shouldSend` callback returns false.
-    //
-    // This is then wrapped again by `makeOfflineTransport` which stores events to disk when they fail to send.
-    return makeOfflineTransport(makeShouldSendTransport(baseTransport))({
+    // The base Electron transport (`makeElectronTransport`) is wrapped by `makeOfflineTransport` which stores events to
+    // disk when they fail to send.
+    return makeOfflineTransport(baseTransport)({
       flushAtStartup: true,
       createStore: createOfflineStore,
       ...userOptions,

--- a/src/renderer/sdk.ts
+++ b/src/renderer/sdk.ts
@@ -53,7 +53,7 @@ interface ElectronRendererOptions extends Omit<BrowserOptions, 'dsn' | 'environm
 export function init<O extends ElectronRendererOptions>(
   options: ElectronRendererOptions & O = {} as ElectronRendererOptions & O,
   // This parameter name ensures that TypeScript error messages contain a hint for fixing SDK version mismatches
-  originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v9_12_0: O) => void = browserInit,
+  originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v9_13_0: O) => void = browserInit,
 ): void {
   // Ensure the browser SDK is only init'ed once.
   if (window?.__SENTRY__RENDERER_INIT__) {

--- a/src/utility/index.ts
+++ b/src/utility/index.ts
@@ -36,6 +36,7 @@ export {
   continueTrace,
   createGetModuleFromFilename,
   createTransport,
+  createSentryWinstonTransport,
   cron,
   dataloaderIntegration,
   dedupeIntegration,

--- a/yarn.lock
+++ b/yarn.lock
@@ -817,20 +817,20 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@sentry-internal/browser-utils@9.12.0":
-  version "9.12.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/browser-utils/-/browser-utils-9.12.0.tgz#6efef1489cbe7cb19b5227ab4c37b015fde1fbc4"
-  integrity sha512-GXuDEG2Ix8DmVtTkjsItWdusk2CvJ6EPWKYVqFKifxt+IAT3ZbhGZd99Rg3wdRmt9xhCNuS4QrDzDTPMPgfdCw==
+"@sentry-internal/browser-utils@9.13.0":
+  version "9.13.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/browser-utils/-/browser-utils-9.13.0.tgz#886e6c1dcf706624d98166c389aadcbf9681bd71"
+  integrity sha512-uZcbwcGI49oPC/YDEConJ+3xi2mu0TsVsDiMQKb6JoSc33KH37wq2IwXJb9nakzKJXxyMNemb44r8irAswjItw==
   dependencies:
-    "@sentry/core" "9.12.0"
+    "@sentry/core" "9.13.0"
 
-"@sentry-internal/eslint-config-sdk@9.12.0":
-  version "9.12.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-9.12.0.tgz#7ad6b4ecbf8290e1b1225a040eeddc9c7bb32b4d"
-  integrity sha512-cN6f4QY0KVV1/yyDWLP1XQgMGRFbIjYRF02JNV/TPMfFyHGP9Y0m+lBccHAGKfp/NfGW5C6lZHSn96oc/fMoNA==
+"@sentry-internal/eslint-config-sdk@9.13.0":
+  version "9.13.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-9.13.0.tgz#e1b3e82c4a98a5deb88da7fa3e2997c6e83cbbed"
+  integrity sha512-HJvHnldBqNhFi6BAI0+AmNl1HIy+COZfzNmem2+Vv4PIK2bEj7c4b/y0cPawY/ofIQ0ArKmWWCo0riaVX12CdQ==
   dependencies:
-    "@sentry-internal/eslint-plugin-sdk" "9.12.0"
-    "@sentry-internal/typescript" "9.12.0"
+    "@sentry-internal/eslint-plugin-sdk" "9.13.0"
+    "@sentry-internal/typescript" "9.13.0"
     "@typescript-eslint/eslint-plugin" "^5.48.0"
     "@typescript-eslint/parser" "^5.48.0"
     eslint-config-prettier "^6.11.0"
@@ -839,59 +839,59 @@
     eslint-plugin-jsdoc "^30.0.3"
     eslint-plugin-simple-import-sort "^5.0.3"
 
-"@sentry-internal/eslint-plugin-sdk@9.12.0":
-  version "9.12.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-9.12.0.tgz#a46fe8ea84d738c802f1205e2556f0bc831c70d5"
-  integrity sha512-0MDPhryFwKReoIje/LP2wN7jkFIZ/LfwOpAnOilVcskxNWvrO6q1r/MkDenfCJeVLkyfrTRSLyLlrY91/tT2Pg==
+"@sentry-internal/eslint-plugin-sdk@9.13.0":
+  version "9.13.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-9.13.0.tgz#654b68b162306e412cdaec474eb37cd715190bc9"
+  integrity sha512-nTip89v2Vp8SOIMjA//njO1wpxew9mzDsM7EbXZzXCpuopih3jDhjhq3WRM8YGpMM4IxxQg2shJ+ZSXZlqJoKg==
 
-"@sentry-internal/feedback@9.12.0":
-  version "9.12.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/feedback/-/feedback-9.12.0.tgz#fc26bf1cd0abfeb249b941c1c943469775d056ad"
-  integrity sha512-3+UxoT97QIXNSUQS4ATL1FFws0RkUb6PeaQN8CPndI6mFlqTW5tuVVLNg9Eo1seNg7R/dfk6WHCWrYN1NbFFKQ==
+"@sentry-internal/feedback@9.13.0":
+  version "9.13.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/feedback/-/feedback-9.13.0.tgz#235bea4cd8c7dd4151725467a64b1c0f05b9788a"
+  integrity sha512-fOhMnhEbOR5QVPtn5Gc5+UKQHjvAN/LmtYE6Qya3w2FDh3ZlnIXNFJWqwOneuICV3kCWjN4lLckwmzzwychr7A==
   dependencies:
-    "@sentry/core" "9.12.0"
+    "@sentry/core" "9.13.0"
 
-"@sentry-internal/replay-canvas@9.12.0":
-  version "9.12.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/replay-canvas/-/replay-canvas-9.12.0.tgz#41d4b0e85bad8f5491f0168a0396ae54d8128142"
-  integrity sha512-p8LuKZgWT/CoQBbDOXkSGjWWnc8WsnAayWgna8M/ZFWNITCNEM2rCuqZOyWOElIlrni+M7qoEA3jS7MZe8Ejxw==
+"@sentry-internal/replay-canvas@9.13.0":
+  version "9.13.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/replay-canvas/-/replay-canvas-9.13.0.tgz#1821377b9587b61f080c8a21617ebdeef26b2580"
+  integrity sha512-5muW2BmEfWP1fpVWDNcIsph/WgqOqpHaXC1QMr4hk8/BWgt1/S2KPy85YiGVtM5lJJr0VhASKK8rBXG+9zm9IQ==
   dependencies:
-    "@sentry-internal/replay" "9.12.0"
-    "@sentry/core" "9.12.0"
+    "@sentry-internal/replay" "9.13.0"
+    "@sentry/core" "9.13.0"
 
-"@sentry-internal/replay@9.12.0":
-  version "9.12.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/replay/-/replay-9.12.0.tgz#fa20b509dc534d57a19500690c2141e9cec4c767"
-  integrity sha512-njEQosFeO/UX+gG+DMRANkPUuz6OIJLb+A1GVylhq9adUgFQydQ9Ay3v7/x1gMhdfHVP6Jeb27qkti0BWYbzBQ==
+"@sentry-internal/replay@9.13.0":
+  version "9.13.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/replay/-/replay-9.13.0.tgz#0266a5ff990f371f25154e85950d6a6e6da77c93"
+  integrity sha512-l+Atwab/bqI1N8+PSG1WWTCVmiOl7swL85Z9ntwS39QBnd66CTyzt/+j/n/UbAs8GienJK6FIfX1dvG1WmvUhA==
   dependencies:
-    "@sentry-internal/browser-utils" "9.12.0"
-    "@sentry/core" "9.12.0"
+    "@sentry-internal/browser-utils" "9.13.0"
+    "@sentry/core" "9.13.0"
 
-"@sentry-internal/typescript@9.12.0":
-  version "9.12.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-9.12.0.tgz#be40e4f7ef9bb8d947c878a49365fcd2abb2f809"
-  integrity sha512-MFvS7HDY08lh1bv9C6r7DNjeqWkvgdz06mwr76yTuZu9VFPxazgZD6YWnLcTKjs3MqsTgBg+NVi3CVfq1z3+KQ==
+"@sentry-internal/typescript@9.13.0":
+  version "9.13.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-9.13.0.tgz#3528546821b3bdcda75d66d8e362392ac17336ef"
+  integrity sha512-U3mVLx3bf0UrRtAxo53CFtHbgR4CZJz8bPM2cINcD/nqevrBvSAAWK+oXsJD83ucYEhwVMDe6l7nOIKwa5tS4A==
 
-"@sentry/browser@9.12.0":
-  version "9.12.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-9.12.0.tgz#f39c5e05ea9dd31b54ccf27a9d49f8de9d9ff7f2"
-  integrity sha512-4xQYoZqi+VVhNvlhWiwRd57+SMr3Og4sLjuayAA+zIp1Wx/bDcIld697cugLwml/BR+mVJI2eokkgh1CBl6zag==
+"@sentry/browser@9.13.0":
+  version "9.13.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-9.13.0.tgz#76cf662656c7c7ddfd36081b6e8ba05c385fe823"
+  integrity sha512-KiC8s9/6HvdlfCRqA420YbiBiXMBif7GYESJ8VQqOKUmlPczn8V2CRrEZjMqxhlHdIGiR0PS6jb2VSgeJBchJQ==
   dependencies:
-    "@sentry-internal/browser-utils" "9.12.0"
-    "@sentry-internal/feedback" "9.12.0"
-    "@sentry-internal/replay" "9.12.0"
-    "@sentry-internal/replay-canvas" "9.12.0"
-    "@sentry/core" "9.12.0"
+    "@sentry-internal/browser-utils" "9.13.0"
+    "@sentry-internal/feedback" "9.13.0"
+    "@sentry-internal/replay" "9.13.0"
+    "@sentry-internal/replay-canvas" "9.13.0"
+    "@sentry/core" "9.13.0"
 
-"@sentry/core@9.12.0":
-  version "9.12.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-9.12.0.tgz#164a88af070cd77191ca14c88914e008c7ce7716"
-  integrity sha512-jOqQK/90uzHmsBvkPTj/DAEFvA5poX4ZRyC7LE1zjg4F5jdOp3+M4W3qCy0CkSTu88Zu5VWBoppCU2Bs34XEqg==
+"@sentry/core@9.13.0":
+  version "9.13.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-9.13.0.tgz#3269cab4ba34fa0928f04936ddb82182069cb568"
+  integrity sha512-Zn1Qec5XNkNRE/M5QjL6YJLghETg6P188G/v2OzdHdHIRf0Y58/SnJilu3louF+ogos6kaSqqdMgzqKgZ8tCdg==
 
-"@sentry/node@9.12.0":
-  version "9.12.0"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-9.12.0.tgz#1973bd457a0b1ce82ae843290bc86ca2eb88532a"
-  integrity sha512-NZHneJovlLOdde85vJAIs7vIki36EfJ234d6YXHUE+874sxKMknB/wrzAZi5XS5nqT3kqIXD5KgjgDTjrhAENQ==
+"@sentry/node@9.13.0":
+  version "9.13.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-9.13.0.tgz#5b345c3400e88415617ba52a03b269c3a621a928"
+  integrity sha512-75UVkrED5b0BaazNQKCmF8NqeqjErxildPojDyC037JN+cVFMPr/kFFGGm7E+eCvA/j2pAPUzqifHp/PjykPcw==
   dependencies:
     "@opentelemetry/api" "^1.9.0"
     "@opentelemetry/context-async-hooks" "^1.30.1"
@@ -924,16 +924,16 @@
     "@opentelemetry/sdk-trace-base" "^1.30.1"
     "@opentelemetry/semantic-conventions" "^1.30.0"
     "@prisma/instrumentation" "6.5.0"
-    "@sentry/core" "9.12.0"
-    "@sentry/opentelemetry" "9.12.0"
+    "@sentry/core" "9.13.0"
+    "@sentry/opentelemetry" "9.13.0"
     import-in-the-middle "^1.13.0"
 
-"@sentry/opentelemetry@9.12.0":
-  version "9.12.0"
-  resolved "https://registry.yarnpkg.com/@sentry/opentelemetry/-/opentelemetry-9.12.0.tgz#5e7692b992a6af26a3bcbc840e8ca8d1180750f0"
-  integrity sha512-jQfI/UmgDDbcWY439r1Jz0Y4mqNn3a2JwruWfCHWzIqQMOgBzkzcp9lbZMx9iU+x1iZTTp9s80Dy5F9nG4KKMQ==
+"@sentry/opentelemetry@9.13.0":
+  version "9.13.0"
+  resolved "https://registry.yarnpkg.com/@sentry/opentelemetry/-/opentelemetry-9.13.0.tgz#5c04e9b391cf4085aa05b5e7a08b5c6220ac5dd4"
+  integrity sha512-TLSP0n+sXKVcVkAM2ttVmXcAT2K3e9D5gdPfr6aCnW+KIGJuD7wzla/TIcTWFaVwUejbvXAB6IFpZ/qA8HFwyA==
   dependencies:
-    "@sentry/core" "9.12.0"
+    "@sentry/core" "9.13.0"
 
 "@sindresorhus/is@^4.0.0":
   version "4.6.0"


### PR DESCRIPTION
The `shouldSend` callback handling has been removed from the Electron SDK as this feature is now included in the Core offline support.