### PR TITLE
feat: Update JavaScript SDKs to v9.25.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,16 +60,16 @@
     "e2e": "xvfb-maybe vitest run --root=./test/e2e --silent=false --disable-console-intercept"
   },
   "dependencies": {
-    "@sentry/browser": "9.24.0",
-    "@sentry/core": "9.24.0",
-    "@sentry/node": "9.24.0",
+    "@sentry/browser": "9.25.0",
+    "@sentry/core": "9.25.0",
+    "@sentry/node": "9.25.0",
     "deepmerge": "4.3.1"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-typescript": "^11.1.6",
-    "@sentry-internal/eslint-config-sdk": "9.24.0",
-    "@sentry-internal/typescript": "9.24.0",
+    "@sentry-internal/eslint-config-sdk": "9.25.0",
+    "@sentry-internal/typescript": "9.25.0",
     "@types/busboy": "^1.5.4",
     "@types/form-data": "^2.5.0",
     "@types/koa": "^2.0.52",

--- a/src/main/integrations/electron-context.ts
+++ b/src/main/integrations/electron-context.ts
@@ -11,9 +11,6 @@ export const electronContextIntegration = defineIntegration(() => {
   return {
     name: 'ElectronContext',
     processEvent(event, _, client) {
-      // We don't want to send the server_name as it includes the machine name which is potentially PII
-      delete event.server_name;
-      delete event.tags?.server_name;
       // We delete the Node runtime context so our Electron runtime context is used instead
       delete event.contexts?.runtime;
 

--- a/src/main/sdk.ts
+++ b/src/main/sdk.ts
@@ -163,6 +163,7 @@ export function init(userOptions: ElectronMainOptions): void {
     getSessions: () => [session.defaultSession],
     ...userOptions,
     stackParser: stackParserFromStackParserOptions(userOptions.stackParser || defaultStackParser),
+    includeServerName: false,
   };
 
   const options = {
@@ -183,15 +184,6 @@ export function init(userOptions: ElectronMainOptions): void {
   scope.update(options.initialScope);
 
   const client = new NodeClient(options);
-
-  if (options._experiments?.enableLogs) {
-    // In Electron we don't want to capture the hostname in log attributes
-    client.on('beforeCaptureLog', (log) => {
-      if (log.attributes?.['server.address']) {
-        delete log.attributes['server.address'];
-      }
-    });
-  }
 
   if (options.sendDefaultPii === true) {
     client.on('postprocessEvent', addAutoIpAddressToUser);

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -61,6 +61,7 @@ export {
   getRootSpan,
   getSpanDescendants,
   getSpanStatusFromHttpCode,
+  getTraceData,
   globalHandlersIntegration,
   graphqlClientIntegration,
   httpClientIntegration,

--- a/src/renderer/sdk.ts
+++ b/src/renderer/sdk.ts
@@ -52,7 +52,7 @@ interface ElectronRendererOptions extends Omit<BrowserOptions, 'dsn' | 'environm
 export function init<O extends ElectronRendererOptions>(
   options: ElectronRendererOptions & O = {} as ElectronRendererOptions & O,
   // This parameter name ensures that TypeScript error messages contain a hint for fixing SDK version mismatches
-  originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v9_24_0: O) => void = browserInit,
+  originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v9_25_0: O) => void = browserInit,
 ): void {
   // Ensure the browser SDK is only init'ed once.
   if (window?.__SENTRY__RENDERER_INIT__) {

--- a/src/utility/sdk.ts
+++ b/src/utility/sdk.ts
@@ -54,6 +54,7 @@ export function init(userOptions: NodeOptions = {}): void {
     stackParser: stackParserFromStackParserOptions(userOptions.stackParser || defaultStackParser),
     // Events are sent via the main process but the Node SDK wont start without dsn
     dsn: 'https://12345@dummy.dsn/12345',
+    includeServerName: false,
   };
 
   const options = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -808,20 +808,20 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@sentry-internal/browser-utils@9.24.0":
-  version "9.24.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/browser-utils/-/browser-utils-9.24.0.tgz#039e31b4e198370cfd9e70f297d29b1d2a49b3d0"
-  integrity sha512-fWIrHyui8KKufnbqhGyDvvr+u9wiOEEzxXEjs/CKp+6fa+jej6Mk8K+su1f/mz7R3HVzhxvht/gZ+y193uK4qw==
+"@sentry-internal/browser-utils@9.25.0":
+  version "9.25.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/browser-utils/-/browser-utils-9.25.0.tgz#d4006c64c3c2e668875fa3b3c9787e8299d244a2"
+  integrity sha512-pPlIXHcXNKjVsN/hMeh6ujBkDBMKfxFSdPHHshMSj9tRNc5SI1A1pxWK6QaEMAXor74ICYWt/fazJDw9wE2shg==
   dependencies:
-    "@sentry/core" "9.24.0"
+    "@sentry/core" "9.25.0"
 
-"@sentry-internal/eslint-config-sdk@9.24.0":
-  version "9.24.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-9.24.0.tgz#1fdd332e5bfb842604cc44bbc5578412df9252d9"
-  integrity sha512-vlyLJS40kM1fMPn32S2sYg5XCXDN9yuQQyTUN6VBhg0R3vMjJ9YNp4YgAdQXgVI+aWqj1UYefxu/eV+Y7x/9Ng==
+"@sentry-internal/eslint-config-sdk@9.25.0":
+  version "9.25.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-9.25.0.tgz#946903eea82d7a3c5dd5000123c223fc7be550d0"
+  integrity sha512-7AF3pXadeIQjJ4fLTfhG+5QVGGgb6tDMVD2gPbKhtziFMCdy5NC1ubon4awOejxxdVEz150I9+zWGjCxO+C5jw==
   dependencies:
-    "@sentry-internal/eslint-plugin-sdk" "9.24.0"
-    "@sentry-internal/typescript" "9.24.0"
+    "@sentry-internal/eslint-plugin-sdk" "9.25.0"
+    "@sentry-internal/typescript" "9.25.0"
     "@typescript-eslint/eslint-plugin" "^5.48.0"
     "@typescript-eslint/parser" "^5.48.0"
     eslint-config-prettier "^6.11.0"
@@ -830,59 +830,59 @@
     eslint-plugin-jsdoc "^30.0.3"
     eslint-plugin-simple-import-sort "^6.0.0"
 
-"@sentry-internal/eslint-plugin-sdk@9.24.0":
-  version "9.24.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-9.24.0.tgz#efac37883caf35b951a9fbe3f4eca54707e557cf"
-  integrity sha512-iYkppEhPmpDjWKdxbchJzWyzLweojiLjMjaw9sK9D4HNLFN53o4DcVRYyg43glM19WFkSrn/KgdwIBjRRjmPZw==
+"@sentry-internal/eslint-plugin-sdk@9.25.0":
+  version "9.25.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-9.25.0.tgz#96945b9437a148de3917589f7562c79173f1b653"
+  integrity sha512-ANWn18/BIH0+GMjJTBHRgEkjAiouUktTmez+5JJJugbf6BDDw6nb3zgRfkeuHODDDU54wg6C/KkdZ4jTlxJvQg==
 
-"@sentry-internal/feedback@9.24.0":
-  version "9.24.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/feedback/-/feedback-9.24.0.tgz#c2f2e92ccf18301cd9eb28879294ec8081443eb6"
-  integrity sha512-Z9jQqKzRppwAEqiytLWNV8JOo52vlxcSGz52FjKx3KXG75PXwk0M3sBXh762WoGLisUIRLTp8LOk6304L/O8dg==
+"@sentry-internal/feedback@9.25.0":
+  version "9.25.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/feedback/-/feedback-9.25.0.tgz#8734e63e6a71aafbbd9e55b1785db4e25c8da0a7"
+  integrity sha512-myrU1H1IR3EjRPo/66+Jjy5xHq9xEuosI8iRKN/0dSMeS6TZQ+PF0ixNHlwtyxhJn3z0o1gobB1Oawi7W/EDeQ==
   dependencies:
-    "@sentry/core" "9.24.0"
+    "@sentry/core" "9.25.0"
 
-"@sentry-internal/replay-canvas@9.24.0":
-  version "9.24.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/replay-canvas/-/replay-canvas-9.24.0.tgz#a90786c850e7a10eb445e86c6d12375822f17785"
-  integrity sha512-506RdDF6iE8hMyzpzp9Vc0GM7kELxxs7UCoi/6KpvXFftcydWI3S2bru8dEZsxVoKh2hdle6SpbNgl+iPI0DSQ==
+"@sentry-internal/replay-canvas@9.25.0":
+  version "9.25.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/replay-canvas/-/replay-canvas-9.25.0.tgz#7e31006e744477e759ac1306506c986bd7412a25"
+  integrity sha512-eNjfS40OyU1Ca74YmDRm8PlLmwIH4N0EyIw7FScc92cr7ip+Y4UzRDEa2zJGwHPPuTRXexUI3vaZqmMQkWQP1g==
   dependencies:
-    "@sentry-internal/replay" "9.24.0"
-    "@sentry/core" "9.24.0"
+    "@sentry-internal/replay" "9.25.0"
+    "@sentry/core" "9.25.0"
 
-"@sentry-internal/replay@9.24.0":
-  version "9.24.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/replay/-/replay-9.24.0.tgz#470b11a07266df7896f5f615a441a5fb13c6cc29"
-  integrity sha512-312wMPeQI8K2vO/lA/CF6Uv5UReoZC7RarsNUJEoOKa9Bq1BXWUq929oTHzu/2NDv194H2u3eqSGsSp6xiuKTw==
+"@sentry-internal/replay@9.25.0":
+  version "9.25.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/replay/-/replay-9.25.0.tgz#1bd35bd9131146ed44d23c0d0dbe41ed7425268b"
+  integrity sha512-aSk4cUv8KasQd8Gb2NHDH/c6IHRZwTq4gx9oo5rCYzMAHRQGNjGU18ecHOtLKKueQGCfrmF1Xv76LgjJVYsVOw==
   dependencies:
-    "@sentry-internal/browser-utils" "9.24.0"
-    "@sentry/core" "9.24.0"
+    "@sentry-internal/browser-utils" "9.25.0"
+    "@sentry/core" "9.25.0"
 
-"@sentry-internal/typescript@9.24.0":
-  version "9.24.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-9.24.0.tgz#aadbb549bdad5c4dbe872370057f3c5dd6db4b28"
-  integrity sha512-ekUbDGY8nLc2MgYkSTslIAy3md1TR3CnHBkkZOOM5g2sJqiwniUjJFYAd166AHGQIiKs4ZqdJecfDX83t4znMw==
+"@sentry-internal/typescript@9.25.0":
+  version "9.25.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-9.25.0.tgz#ffd5ad6b09a23f99fe3b10946bbc13742751476a"
+  integrity sha512-lShl4NWZXbPRh7FXaOZ3w4c4GYUM4KCY2cdJGMi64PgrXoSH6gomJG4v+tS1J+dBGgU+GWPmRFEc9x4QeuBVjA==
 
-"@sentry/browser@9.24.0":
-  version "9.24.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-9.24.0.tgz#842075609edb55541bca914693a3732be1140157"
-  integrity sha512-RP+27/owvIqD4J0TibIHK1UcA7iObxLOXBEilDKjaJOZMLhv3JkpU8A+UI9pFzEYqeIGVDDaBzYgbCHrLWcoCA==
+"@sentry/browser@9.25.0":
+  version "9.25.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-9.25.0.tgz#26e31b517f935e4b030acc3479111b241e9007f3"
+  integrity sha512-IkeGKrTX2nX0POgZATLiYJEIyjcwtf5z40fvuSofVSnONrnSuJmlkDI2grRLX+OhQh4MJaq8gwPhTMqf9koRTQ==
   dependencies:
-    "@sentry-internal/browser-utils" "9.24.0"
-    "@sentry-internal/feedback" "9.24.0"
-    "@sentry-internal/replay" "9.24.0"
-    "@sentry-internal/replay-canvas" "9.24.0"
-    "@sentry/core" "9.24.0"
+    "@sentry-internal/browser-utils" "9.25.0"
+    "@sentry-internal/feedback" "9.25.0"
+    "@sentry-internal/replay" "9.25.0"
+    "@sentry-internal/replay-canvas" "9.25.0"
+    "@sentry/core" "9.25.0"
 
-"@sentry/core@9.24.0":
-  version "9.24.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-9.24.0.tgz#a8a8681df9818f7dbf23b27a319a1ef4e1c48076"
-  integrity sha512-uRWrB4Y49ZOWcDLCXqdjd2Fs6Onill0GQI+JgXMw7wa+i03+QRiQvUAUyde8O62jR4dvP3GDo9PDWnDNhi3z5A==
+"@sentry/core@9.25.0":
+  version "9.25.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-9.25.0.tgz#354b9d500075b0db1decc533c16fe0566a30c21b"
+  integrity sha512-k0AgzR6RIf6OEwkVz09zer8GcK1s7RothlS1R6Z4x1wAJ+brtx4HqWnbLp05LDNDNrjTzK30HXvuCGGusnZuig==
 
-"@sentry/node@9.24.0":
-  version "9.24.0"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-9.24.0.tgz#ade357634b535f2da86a81f704d0f8261e299160"
-  integrity sha512-rIe8rLCdPi/9VWkoRlXRCbjpNlKhHeS8EqlT40ZwlWxdJl5WOcktq3mIWcV2oTqupWogDImjQgeCeydXWt5aog==
+"@sentry/node@9.25.0":
+  version "9.25.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-9.25.0.tgz#20ac52988088a56d2d986fa2e8e131ee166f9c05"
+  integrity sha512-Z7nkj7kwH1/kbsETmNN12pMD3Npe9X0bCKV3jlTv6KkEdVvklc1+/pT7Bz+4iYqHUysZTrNomQxdzjcQbIb2aw==
   dependencies:
     "@opentelemetry/api" "^1.9.0"
     "@opentelemetry/context-async-hooks" "^1.30.1"
@@ -914,17 +914,17 @@
     "@opentelemetry/sdk-trace-base" "^1.30.1"
     "@opentelemetry/semantic-conventions" "^1.34.0"
     "@prisma/instrumentation" "6.8.2"
-    "@sentry/core" "9.24.0"
-    "@sentry/opentelemetry" "9.24.0"
+    "@sentry/core" "9.25.0"
+    "@sentry/opentelemetry" "9.25.0"
     import-in-the-middle "^1.13.1"
     minimatch "^9.0.0"
 
-"@sentry/opentelemetry@9.24.0":
-  version "9.24.0"
-  resolved "https://registry.yarnpkg.com/@sentry/opentelemetry/-/opentelemetry-9.24.0.tgz#57f2d99a95e4e54066894e84d52f4491f1bcdc43"
-  integrity sha512-bdXXwBLuIS127CjMveizBbgBKQEGlL3Ye8LxHCKqvifNK9BXgXGPnh6bHum/EgskWqx4ni/aET1h4f1kluql5A==
+"@sentry/opentelemetry@9.25.0":
+  version "9.25.0"
+  resolved "https://registry.yarnpkg.com/@sentry/opentelemetry/-/opentelemetry-9.25.0.tgz#fb8b2ef4ea7ffcb20cbe912155073764775a6ae9"
+  integrity sha512-yzl/DnlQMkpOsEHlZJeTXdJ8GJNyonUjM+d3jhAXDjsvG2yXXBrda0PhNkxCN+rScbP/sJEbvfGPtcnnysh7NA==
   dependencies:
-    "@sentry/core" "9.24.0"
+    "@sentry/core" "9.25.0"
 
 "@sindresorhus/is@^4.0.0":
   version "4.6.0"


### PR DESCRIPTION
This also uses the new `includeServerName` option so we no longer need to strip the `server_name` from events or logs.