### PR TITLE
fix: Don't capture stack traces from destroyed renderers

### DIFF
--- a/src/main/integrations/renderer-anr.ts
+++ b/src/main/integrations/renderer-anr.ts
@@ -109,6 +109,10 @@ function debuggerStackTraceCapture(contents: WebContents, pausedStack: StackFram
   });
 
   return () => {
+    if (contents.isDestroyed()) {
+      return;
+    }
+
     log('Pausing debugger to capture stack trace');
     return contents.debugger.sendCommand('Debugger.pause');
   };

--- a/src/main/stack-parse.ts
+++ b/src/main/stack-parse.ts
@@ -26,6 +26,10 @@ export async function captureRendererStackFrames(webContents: WebContents): Prom
     throw new Error('Electron >= 34 required to capture stack frames via `frame.collectJavaScriptCallStack()`');
   }
 
+  if (webContents.isDestroyed()) {
+    return undefined;
+  }
+
   const frame = webContents.mainFrame as ElectronV34Frame;
 
   const stack = await frame.collectJavaScriptCallStack();


### PR DESCRIPTION
- Reported here https://github.com/getsentry/sentry-electron/issues/1150#issuecomment-2936945459

We should check if the webContents has been destroyed before attempting to contact the debugger.