### PR TITLE
fix: Set TypeScript `moduleResolution` to `node16`

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -11,6 +11,7 @@
     "rootDir": "src",
     "target": "ES2020",
     "esModuleInterop": true,
-    "ignoreDeprecations": "5.0"
+    "ignoreDeprecations": "5.0",
+    "moduleResolution": "node16"
   }
 }


### PR DESCRIPTION
- Closes #1200

Although maybe we should change this here?
https://github.com/getsentry/sentry-javascript/blob/5bf18c47f775ca29683f03122bacab7616d92020/packages/typescript/tsconfig.json#L11