### PR TITLE
fix: Don't use `deepmerge` to merge events to remove circular ref. issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,8 +96,7 @@
   "dependencies": {
     "@sentry/browser": "9.43.0",
     "@sentry/core": "9.43.0",
-    "@sentry/node": "9.43.0",
-    "deepmerge": "4.3.1"
+    "@sentry/node": "9.43.0"
   },
   "peerDependencies": {
     "@sentry/node-native": "9.43.0"

--- a/src/main/merge.ts
+++ b/src/main/merge.ts
@@ -1,4 +1,4 @@
-import { Event } from '@sentry/core';
+import { Event, normalize } from '@sentry/core';
 import deepMerge from 'deepmerge';
 
 /** Removes private properties from event before merging */
@@ -17,7 +17,7 @@ function removePrivateProperties(event: Event): void {
 export function mergeEvents(defaults: Event, event: Event): Event {
   removePrivateProperties(event);
 
-  const newEvent: Event = deepMerge(defaults, event);
+  const newEvent: Event = deepMerge(normalize(defaults), normalize(event));
 
   // We need to copy spans across manually
   //

--- a/test/e2e/test-apps/other/circular-merge/package.json
+++ b/test/e2e/test-apps/other/circular-merge/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "circular-merge",
+  "description": "Handles circular references in event merging",
+  "version": "1.0.0",
+  "main": "src/main.js",
+  "dependencies": {
+    "@sentry/electron": "5.6.0"
+  }
+}

--- a/test/e2e/test-apps/other/circular-merge/src/main.js
+++ b/test/e2e/test-apps/other/circular-merge/src/main.js
@@ -1,0 +1,14 @@
+const { init, captureConsoleIntegration } = require('@sentry/electron/main');
+
+init({
+  dsn: '__DSN__',
+  debug: true,
+  integrations: [captureConsoleIntegration({ levels: ['error'] })],
+  onFatalError: () => {},
+});
+
+setTimeout(() => {
+  const obj = { data: 1 };
+  obj.self = obj;
+  console.error(obj);
+}, 2000);

--- a/test/e2e/test-apps/other/circular-merge/test.ts
+++ b/test/e2e/test-apps/other/circular-merge/test.ts
@@ -8,7 +8,7 @@ electronTestRunner(__dirname, async (ctx) => {
         platform: 'node',
         logger: 'console',
         message: '[object Object]',
-        extra: { arguments: [{ data: 1, self: '[Circular ~]' }] },
+        extra: { arguments: [{ data: 1, self: '[Object]' }] },
         tags: {
           'event.environment': 'javascript',
           'event.origin': 'electron',

--- a/test/e2e/test-apps/other/circular-merge/test.ts
+++ b/test/e2e/test-apps/other/circular-merge/test.ts
@@ -1,0 +1,20 @@
+import { electronTestRunner, eventEnvelope } from '../../..';
+
+electronTestRunner(__dirname, async (ctx) => {
+  await ctx
+    .expect({
+      envelope: eventEnvelope({
+        level: 'error',
+        platform: 'node',
+        logger: 'console',
+        message: '[object Object]',
+        extra: { arguments: [{ data: 1, self: '[Circular ~]' }] },
+        tags: {
+          'event.environment': 'javascript',
+          'event.origin': 'electron',
+          'event.process': 'browser',
+        },
+      }),
+    })
+    .run();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1964,7 +1964,7 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
-deepmerge@4.3.1, deepmerge@^4.2.2:
+deepmerge@^4.2.2:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
   integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==


### PR DESCRIPTION
- Closes #1206
