### PR TITLE
fix: Only capture logs if `enableLogs` is true

### DIFF
--- a/src/main/integrations/child-process.ts
+++ b/src/main/integrations/child-process.ts
@@ -80,6 +80,7 @@ export const childProcessIntegration = defineIntegration((userOptions: Partial<O
       // only hook these events if we're after more than just the unresponsive event
       if (allReasons.length > 0) {
         const clientOptions = client.getOptions() as ElectronMainOptions;
+        const enableLogs = !!clientOptions?.enableLogs;
 
         app.on('child-process-gone', (_, details) => {
           const { reason } = details;
@@ -100,11 +101,13 @@ export const childProcessIntegration = defineIntegration((userOptions: Partial<O
               data: details,
             });
 
-            log(messageFmt, {
-              exitCode: details.exitCode,
-              name: details.name,
-              serviceName: details.serviceName,
-            });
+            if (enableLogs) {
+              log(messageFmt, {
+                exitCode: details.exitCode,
+                name: details.name,
+                serviceName: details.serviceName,
+              });
+            }
           }
         });
 
@@ -128,9 +131,11 @@ export const childProcessIntegration = defineIntegration((userOptions: Partial<O
               data: details,
             });
 
-            log(messageFmt, {
-              exitCode: details.exitCode,
-            });
+            if (enableLogs) {
+              log(messageFmt, {
+                exitCode: details.exitCode,
+              });
+            }
           }
         });
       }


### PR DESCRIPTION
Sone integrations now capture logs but this results in warnings being logged if logs are not enabled:
```
logging option not enabled, log will not be captured
```

This PR changes it so we only attempt to capture logs if `enableLogs` has been set to true.