### PR TITLE
fix: Preload `contextIsolation` issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 7.1.1
 
 - fix: Preload injection path (#1243)
+- fix: Preload `contextIsolation` issues (#1244)
 
 ## 7.1.0
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -37,7 +37,8 @@ export function hookupIpc(namespace: string = 'sentry-ipc'): void {
     if (contextBridge) {
       // This will fail if contextIsolation is not enabled
       try {
-        contextBridge.exposeInMainWorld(ipcUtil.namespace, ipcObject);
+        // eslint-disable-next-line no-restricted-globals
+        contextBridge.exposeInMainWorld('__SENTRY_IPC__', window.__SENTRY_IPC__);
       } catch (e) {
         //
       }

--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -8,10 +8,8 @@ import { ElectronRendererOptionsInternal } from './sdk.js';
 function getImplementation(ipcKey: string): IPCInterface {
   const ipcUtil = ipcChannelUtils(ipcKey);
 
-  window.__SENTRY_IPC__ = window.__SENTRY_IPC__ || {};
-
   // Favour IPC if it's been exposed by a preload script
-  if (window.__SENTRY_IPC__[ipcUtil.namespace]) {
+  if (window.__SENTRY_IPC__?.[ipcUtil.namespace]) {
     return window.__SENTRY_IPC__[ipcUtil.namespace] as IPCInterface;
   } else {
     debug.log('IPC was not configured in preload script, falling back to custom protocol and fetch');

--- a/test/e2e/test-apps/other/preload-injection/main.js
+++ b/test/e2e/test-apps/other/preload-injection/main.js
@@ -1,12 +1,13 @@
 // eslint-disable-next-line import/no-unresolved
-import { init } from '@sentry/electron/main';
-import { app, BrowserWindow } from 'electron';
-import * as path from 'path';
-import * as url from 'url';
+const { init, IPCMode } = require('@sentry/electron/main');
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+const url = require('url');
 
 init({
   dsn: '__DSN__',
   debug: true,
+  ipcMode: IPCMode.Classic,
   onFatalError: () => {},
 });
 
@@ -22,13 +23,9 @@ app.on('ready', () => {
 
   window.loadURL(
     url.format({
-      pathname: path.join(__dirname, 'index.html'),
+      pathname: path.join(__dirname, 'dist', 'index.html'),
       protocol: 'file:',
       slashes: true,
     }),
   );
-
-  setTimeout(() => {
-    throw new Error('Some main error');
-  }, 2000);
 });

--- a/test/e2e/test-apps/other/preload-injection/package.json
+++ b/test/e2e/test-apps/other/preload-injection/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "webpack-main-process",
-  "description": "Webpack app with error in main process",
+  "name": "preload-injection",
+  "description": "Preload injection",
   "version": "1.0.0",
   "scripts": {
     "start": "electron .",
     "build": "webpack"
   },
-  "main": "dist/main.js",
+  "main": "main.js",
   "devDependencies": {
     "@sentry/webpack-plugin": "^2.2.0",
     "csp-html-webpack-plugin": "^5.1.0",

--- a/test/e2e/test-apps/other/preload-injection/renderer.js
+++ b/test/e2e/test-apps/other/preload-injection/renderer.js
@@ -8,3 +8,7 @@ init({
 console.log('renderer logging');
 
 getCurrentScope().setUser({ id: 'abc-123' });
+
+setTimeout(() => {
+  throw new Error('Some renderer error');
+}, 2000);

--- a/test/e2e/test-apps/other/preload-injection/test.ts
+++ b/test/e2e/test-apps/other/preload-injection/test.ts
@@ -5,12 +5,12 @@ electronTestRunner(__dirname, { skipEsmAutoTransform: true, skip: () => process.
   await ctx
     .expect({
       envelope: eventEnvelope({
-        level: 'fatal',
-        platform: 'node',
+        level: 'error',
+        platform: 'javascript',
         debug_meta: {
           images: [
             {
-              code_file: 'app:///dist/main.js',
+              code_file: 'app:///dist/renderer.js',
               type: 'sourcemap',
               debug_id: UUID_V4_MATCHER,
             },
@@ -20,30 +20,36 @@ electronTestRunner(__dirname, { skipEsmAutoTransform: true, skip: () => process.
           values: [
             {
               type: 'Error',
-              value: 'Some main error',
+              value: 'Some renderer error',
               stacktrace: {
                 frames: expect.arrayContaining([
                   {
                     colno: expect.any(Number),
-                    filename: 'app:///dist/main.js',
+                    filename: 'app:///dist/renderer.js',
                     function: expect.any(String),
                     in_app: true,
                     lineno: expect.any(Number),
-                    module: 'dist:main',
                   },
                 ]),
               },
               mechanism: {
                 handled: false,
-                type: 'generic',
+                type: 'auto.browser.browserapierrors.setTimeout',
               },
             },
           ],
         },
+        request: {
+          headers: {},
+          url: 'app:///dist/index.html',
+        },
+        extra: {
+          arguments: [],
+        },
         tags: {
           'event.environment': 'javascript',
           'event.origin': 'electron',
-          'event.process': 'browser',
+          'event.process': 'renderer',
         },
         user: {
           id: 'abc-123',

--- a/test/e2e/test-apps/other/preload-injection/webpack.config.js
+++ b/test/e2e/test-apps/other/preload-injection/webpack.config.js
@@ -20,32 +20,20 @@ const sentryWebpackPluginOptions = {
   },
 };
 
-module.exports = [
-  {
-    mode: 'production',
-    entry: './src/main.js',
-    target: 'electron-main',
-    output: {
-      libraryTarget: 'commonjs2',
-      filename: 'main.js',
-    },
-    plugins: [/* new WarningsToErrorsPlugin(), */ sentryWebpackPlugin(sentryWebpackPluginOptions)],
+module.exports = {
+  mode: 'production',
+  entry: './renderer.js',
+  target: 'web',
+  output: {
+    filename: 'renderer.js',
   },
-  {
-    mode: 'production',
-    entry: './src/renderer.js',
-    target: 'web',
-    output: {
-      filename: 'renderer.js',
-    },
-    plugins: [
-      new HtmlWebpackPlugin(),
-      // new WarningsToErrorsPlugin(),
-      new CspHtmlWebpackPlugin({
-        'default-src': "'self'",
-        'script-src': "'self'",
-      }),
-      sentryWebpackPlugin(sentryWebpackPluginOptions),
-    ],
-  },
-];
+  plugins: [
+    new HtmlWebpackPlugin(),
+    // new WarningsToErrorsPlugin(),
+    new CspHtmlWebpackPlugin({
+      'default-src': "'self'",
+      'script-src': "'self'",
+    }),
+    sentryWebpackPlugin(sentryWebpackPluginOptions),
+  ],
+};


### PR DESCRIPTION
- Closes #1242

This was a classic example of why you shouldn't try get a quick fix out (#1243) before fixing the tests that caused the bug to be missed 🫠

After ensuring we had a test that covers this specific scenario, I found a couple of other issues.

Rather than add new test, I repurposed an existing bundler test which has become redundant since we added so many bundling examples. 

