### PR TITLE
feat: Log os and device attributes

### DIFF
--- a/src/main/log.ts
+++ b/src/main/log.ts
@@ -1,0 +1,68 @@
+import { Client, Event } from '@sentry/core';
+
+interface Attributes {
+  'os.name'?: string;
+  'os.version'?: string;
+  'device.brand'?: string;
+  'device.model'?: string;
+  'device.family'?: string;
+}
+
+/**
+ * Fetch os and device attributes from the Context and AdditionalContext integrations
+ */
+async function getAttributes(client: Client): Promise<Attributes> {
+  const contextIntegration = client.getIntegrationByName('Context');
+  const additionalContextIntegration = client.getIntegrationByName('AdditionalContext');
+
+  let event: Event = {};
+  const hint = {};
+
+  event = (await contextIntegration?.processEvent?.(event, hint, client)) || event;
+  event = (await additionalContextIntegration?.processEvent?.(event, hint, client)) || event;
+
+  const attrs: Attributes = {};
+  if (event.contexts?.os?.name) {
+    attrs['os.name'] = event.contexts.os.name;
+  }
+  if (event.contexts?.os?.version) {
+    attrs['os.version'] = event.contexts.os.version;
+  }
+  if (event.contexts?.device?.brand) {
+    attrs['device.brand'] = event.contexts.device.brand;
+  }
+  if (event.contexts?.device?.model) {
+    attrs['device.model'] = event.contexts.device.model;
+  }
+  if (event.contexts?.device?.family) {
+    attrs['device.family'] = event.contexts.device.family;
+  }
+  return attrs;
+}
+
+// Cached attributes
+let attributes: Attributes | undefined;
+
+/**
+ * Get OS and device attributes for logs
+ *
+ * Some of this context is only available asynchronously, so we fetch it once
+ * and cache it for future logs. Logs before the attributes are resolved will not
+ * have this context.
+ */
+export function getOsDeviceLogAttributes(client: Client): Attributes {
+  if (attributes === undefined) {
+    // We set attributes to an empty object to indicate that we are already fetching them
+    attributes = {};
+
+    getAttributes(client)
+      .then((attrs) => {
+        attributes = attrs;
+      })
+      .catch(() => {
+        // ignore
+      });
+  }
+
+  return attributes || {};
+}

--- a/src/main/sdk.ts
+++ b/src/main/sdk.ts
@@ -40,6 +40,7 @@ import { rendererProfilingIntegration } from './integrations/renderer-profiling.
 import { screenshotsIntegration } from './integrations/screenshots.js';
 import { sentryMinidumpIntegration } from './integrations/sentry-minidump/index.js';
 import { configureIPC } from './ipc.js';
+import { getOsDeviceLogAttributes } from './log.js';
 import { defaultStackParser } from './stack-parse.js';
 import { ElectronOfflineTransportOptions, makeElectronOfflineTransport } from './transports/electron-offline-net.js';
 import { configureUtilityProcessIPC } from './utility-processes.js';
@@ -201,6 +202,14 @@ export function init(userOptions: ElectronMainOptions): void {
   if (options.sendDefaultPii === true) {
     client.on('beforeSendSession', addAutoIpAddressToSession);
   }
+
+  client.on('beforeCaptureLog', (log) => {
+    log.attributes = {
+      ...log.attributes,
+      'log.process': 'browser',
+      ...getOsDeviceLogAttributes(client),
+    };
+  });
 
   scope.setClient(client);
   client.init();

--- a/test/e2e/test-apps/other/renderer-error/src/index.html
+++ b/test/e2e/test-apps/other/renderer-error/src/index.html
@@ -12,15 +12,13 @@
         enableLogs: true,
       });
 
-      logger.trace('User clicked submit button', {
-        buttonId: 'submit-form',
-        formId: 'user-profile',
-        timestamp: Date.now()
-      });
-
-      // setTimeout(() => {
-      //   throw new Error('Some renderer error');
-      // }, 500);
+      setTimeout(() => {
+        logger.trace('User clicked submit button', {
+          buttonId: 'submit-form',
+          formId: 'user-profile',
+          timestamp: Date.now()
+        });
+      }, 500);
     </script>
   </body>
 </html>

--- a/test/e2e/test-apps/other/renderer-error/src/main.js
+++ b/test/e2e/test-apps/other/renderer-error/src/main.js
@@ -11,11 +11,6 @@ init({
 });
 
 app.on('ready', () => {
-  logger.info('User profile updated', {
-    userId: 'user_123',
-    updatedFields: ['email', 'preferences'],
-  });
-
   const mainWindow = new BrowserWindow({
     show: false,
     webPreferences: {
@@ -25,8 +20,15 @@ app.on('ready', () => {
   });
 
   mainWindow.loadFile(path.join(__dirname, 'index.html'));
+
+  setTimeout(() => {
+    logger.info('User profile updated', {
+      userId: 'user_123',
+      updatedFields: ['email', 'preferences'],
+    });
+  }, 500);
 });
 
 setTimeout(() => {
   app.quit();
-}, 2000);
+}, 4000);

--- a/test/e2e/test-apps/other/renderer-error/test.ts
+++ b/test/e2e/test-apps/other/renderer-error/test.ts
@@ -31,6 +31,7 @@ electronTestRunner(__dirname, async (ctx) => {
                     'sentry.message.template': { value: 'electron.%s.%s', type: 'string' },
                     'sentry.message.parameter.0': { value: 'app', type: 'string' },
                     'sentry.message.parameter.1': { value: 'ready', type: 'string' },
+                    'log.process': { value: 'browser', type: 'string' },
                   },
                 },
                 {
@@ -46,6 +47,9 @@ electronTestRunner(__dirname, async (ctx) => {
                     'sentry.environment': { value: 'development', type: 'string' },
                     'sentry.sdk.name': { value: 'sentry.javascript.electron', type: 'string' },
                     'sentry.sdk.version': { value: SDK_VERSION, type: 'string' },
+                    'os.name': { value: expect.any(String), type: 'string' },
+                    'os.version': { value: expect.any(String), type: 'string' },
+                    'log.process': { value: 'browser', type: 'string' },
                   },
                 },
                 {
@@ -62,6 +66,9 @@ electronTestRunner(__dirname, async (ctx) => {
                     'sentry.environment': { value: 'development', type: 'string' },
                     'sentry.sdk.name': { value: 'sentry.javascript.electron', type: 'string' },
                     'sentry.sdk.version': { value: SDK_VERSION, type: 'string' },
+                    'os.name': { value: expect.any(String), type: 'string' },
+                    'os.version': { value: expect.any(String), type: 'string' },
+                    'log.process': { value: 'renderer', type: 'string' },
                   },
                 },
               ]),


### PR DESCRIPTION
- Closes #1171

These attributes will only be included with logs once the async loading of the context is complete. 

- Also added `log.process` attribute which logs whether the log was from the main (`browser`) or renderer process.