### PR TITLE
ci(release): Bump Craft version to fix issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         token: ${{ steps.token.outputs.token }}
         fetch-depth: 0
     - name: Prepare release
-      uses: getsentry/craft@39ee616a6a58dc64797feecb145d66770492b66c # v2
+      uses: getsentry/craft@1c58bfd57bfd6a967b6f3fc92bead2c42ee698ce # v2
       env:
         GITHUB_TOKEN: ${{ steps.token.outputs.token }}
       with:


### PR DESCRIPTION
Updates the Craft action SHA to the latest version (`1c58bfd57bfd6a967b6f3fc92bead2c42ee698ce`).