### PR TITLE
ci: Auto SDK update PRs now include SDK version in name for release notes

### DIFF
--- a/.github/workflows/new-sdk-versions-pr.yml
+++ b/.github/workflows/new-sdk-versions-pr.yml
@@ -26,7 +26,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: test/new-sdk-version
           delete-branch: true
-          title: 'test: New Sentry SDK version'
-          commit-message: 'test: New Sentry SDK version'
+          title: 'feat: Update Sentry SDKs to v${{ env.SENTRY_LATEST_VERSION }}'
+          commit-message: 'feat: Update Sentry SDKs to v${{ env.SENTRY_LATEST_VERSION }}'
           body: |
             Automatically generated PR to test new Sentry SDK version

--- a/scripts/update-sdk-versions.mjs
+++ b/scripts/update-sdk-versions.mjs
@@ -1,7 +1,8 @@
 import { spawnSync } from 'child_process';
-import { readFileSync, writeFileSync } from 'fs';
+import { appendFileSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { fileURLToPath } from 'url';
+import { EOL } from 'os';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
@@ -42,5 +43,11 @@ if (current !== latest) {
   spawnSync('yarn', ['install'], { stdio: 'inherit' });
   // Update parameter that has the version in it
   spawnSync('yarn', ['build'], { stdio: 'inherit' });
+
+  // If we're in a GH Action, add the version in GITHUB_ENV so it can be used to name the PR
+  const envFilePath = process.env.GITHUB_ENV;
+  if (envFilePath) {
+    appendFileSync(envFilePath, `SENTRY_LATEST_VERSION=${latest}${EOL}`, { encoding: 'utf8' });
+  }
 }
 


### PR DESCRIPTION
Since release notes are now automatically generated, it's important that the SDK update PRs contain the SDK version.

This PR changes the workflow and script so that the SDK version can be used in the PR commit/title.