### PR TITLE
ci: Add 'unlabeled' event to changelog preview workflow

### DIFF
--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -7,6 +7,7 @@ on:
     - reopened
     - edited
     - labeled
+    - unlabeled
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
The fixed version of #1289 