### PR TITLE
feat: 用于应对用户自行管理scheme privileged并无法保证sentry.init一定第一时间执行时使用

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -256,20 +256,22 @@ function configureProtocol(client: Client, ipcUtil: IpcUtils, options: ElectronM
     throw new Error("Sentry SDK should be initialized before the Electron app 'ready' event is fired");
   }
 
-  const scheme = {
-    scheme: ipcUtil.namespace,
-    privileges: { bypassCSP: true, corsEnabled: true, supportFetchAPI: true, secure: true },
-  };
+  if(options.registerSchemesAsPrivileged) {
+    const scheme = {
+      scheme: ipcUtil.namespace,
+      privileges: {bypassCSP: true, corsEnabled: true, supportFetchAPI: true, secure: true},
+    };
 
-  protocol.registerSchemesAsPrivileged([scheme]);
+    protocol.registerSchemesAsPrivileged([scheme]);
 
-  // We Proxy this function so that later user calls to registerSchemesAsPrivileged don't overwrite our custom scheme
-  // eslint-disable-next-line typescript/unbound-method
-  protocol.registerSchemesAsPrivileged = new Proxy(protocol.registerSchemesAsPrivileged, {
-    apply: (target, __, args: Parameters<typeof protocol.registerSchemesAsPrivileged>) => {
-      target([...args[0], scheme]);
-    },
-  });
+    // We Proxy this function so that later user calls to registerSchemesAsPrivileged don't overwrite our custom scheme
+    // eslint-disable-next-line typescript/unbound-method
+    protocol.registerSchemesAsPrivileged = new Proxy(protocol.registerSchemesAsPrivileged, {
+      apply: (target, __, args: Parameters<typeof protocol.registerSchemesAsPrivileged>) => {
+        target([...args[0], scheme]);
+      },
+    });
+  }
 
   const rendererStatusChanged = createRendererEventLoopBlockStatusHandler(client);
 

--- a/src/main/sdk.ts
+++ b/src/main/sdk.ts
@@ -144,6 +144,15 @@ export interface ElectronMainOptionsInternal
    * Enables injection of 'js-profiling' document policy headers and ensure profiles are forwarded with transactions
    */
   enableRendererProfiling?: boolean;
+
+  /**
+   * Enables of auto register schemes privileged.
+   *
+   * If set to false, you should call protocol.registerSchemesAsPrivileged by yourself
+   *
+   * @default true
+   * */
+  registerSchemesAsPrivileged?: boolean;
 }
 
 // getSessions and ipcMode properties are optional because they have defaults
@@ -174,6 +183,7 @@ export function init(userOptions: ElectronMainOptions): void {
     transport: makeElectronOfflineTransport(),
     transportOptions: {},
     getSessions: () => [session.defaultSession],
+    registerSchemesAsPrivileged: true,
     ...userOptions,
     stackParser: stackParserFromStackParserOptions(userOptions.stackParser || defaultStackParser),
     includeServerName: false,


### PR DESCRIPTION
当sentry的初始化采用插件的形式引入时，sentry.init 无法保证在第一时间执行，会出现用户调用protocol.registerSchemesAsPrivileged 后，才调用sentry.init。

添加配置，用户可手动调用 protocol.registerSchemesAsPrivileged 实现对sentry protocol的授权