### PR TITLE
test: add breaking electron-vite esm example

### DIFF
--- a/examples/electron-vite-esm/electron.vite.config.mjs
+++ b/examples/electron-vite-esm/electron.vite.config.mjs
@@ -1,0 +1,17 @@
+import { resolve } from 'path';
+import { defineConfig } from 'electron-vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  main: {
+    plugins: [],
+  },
+  renderer: {
+    resolve: {
+      alias: {
+        '@renderer': resolve('src/renderer/src'),
+      },
+    },
+    plugins: [vue()],
+  },
+});

--- a/examples/electron-vite-esm/package.json
+++ b/examples/electron-vite-esm/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "electron-vite-esm",
+  "description": "Electron Vite ESM main-process example",
+  "version": "1.0.0",
+  "main": "out/main/index.js",
+  "type": "module",
+  "scripts": {
+    "build": "electron-vite build"
+  },
+  "dependencies": {
+    "electron-squirrel-startup": "^1.0.0"
+  },
+  "devDependencies": {
+    "@sentry/electron": "5.6.0",
+    "@sentry/vue": "8.35.0",
+    "@vitejs/plugin-vue": "^5.0.3",
+    "electron": "^33.0.2",
+    "electron-vite": "^2.0.0",
+    "vite": "^5.0.12",
+    "vue": "^3.4.15"
+  }
+}

--- a/examples/electron-vite-esm/src/main/index.js
+++ b/examples/electron-vite-esm/src/main/index.js
@@ -1,0 +1,48 @@
+import { app, BrowserWindow } from 'electron';
+import { init } from '@sentry/electron/main';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+init({
+  dsn: '__DSN__',
+  debug: true,
+  onFatalError: () => {},
+});
+
+const createWindow = () => {
+  const require = createRequire(import.meta.url);
+  const squirrelStartup = require('electron-squirrel-startup');
+
+  if (typeof squirrelStartup !== 'boolean') {
+    throw new Error('createRequire package load returned an unexpected value');
+  }
+
+  const mainWindow = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+
+  const rendererEntryPath = fileURLToPath(new URL('../renderer/index.html', import.meta.url));
+  void mainWindow.loadFile(rendererEntryPath);
+
+  setTimeout(() => {
+    throw new Error('Some ESM main error');
+  }, 500);
+};
+
+app.on('ready', createWindow);
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});
+
+app.on('activate', () => {
+  if (BrowserWindow.getAllWindows().length === 0) {
+    createWindow();
+  }
+});

--- a/examples/electron-vite-esm/src/renderer/App.vue
+++ b/examples/electron-vite-esm/src/renderer/App.vue
@@ -1,0 +1,10 @@
+<script setup>
+setTimeout(() => {
+  throw new Error('Some renderer error');
+}, 500);
+</script>
+
+<template>
+  <h1>💖 Hello World!</h1>
+  <p>Welcome to your Electron application.</p>
+</template>

--- a/examples/electron-vite-esm/src/renderer/index.html
+++ b/examples/electron-vite-esm/src/renderer/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Hello World!</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./index.mjs"></script>
+  </body>
+</html>

--- a/examples/electron-vite-esm/src/renderer/index.mjs
+++ b/examples/electron-vite-esm/src/renderer/index.mjs
@@ -1,0 +1,14 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+import { init } from '@sentry/electron/renderer';
+import { init as initVue } from '@sentry/vue';
+
+init(
+  {
+    debug: true,
+  },
+  initVue,
+);
+
+const app = createApp(App);
+app.mount('#app');

--- a/examples/electron-vite-esm/test.ts
+++ b/examples/electron-vite-esm/test.ts
@@ -1,0 +1,53 @@
+import { expect } from 'vitest';
+
+import { electronTestRunner, eventEnvelope } from '../../test/e2e';
+
+electronTestRunner(__dirname, { skipEsmAutoTransform: true }, async (ctx) => {
+  await ctx
+    .expect({
+      envelope: (event) => {
+        const payload = eventEnvelope({
+          level: 'fatal',
+          platform: 'node',
+          tags: {
+            'event.environment': 'javascript',
+            'event.origin': 'electron',
+            'event.process': 'browser',
+          },
+          sdk: {
+            settings: {
+              infer_ip: 'never',
+            },
+          },
+        });
+
+        expect(event[0]).toEqual(payload[0]);
+
+        const actualEvent = event[1][0][1] as Record<string, any>;
+        expect(actualEvent.level).toBe('fatal');
+        expect(actualEvent.platform).toBe('node');
+        expect(actualEvent.tags['event.process']).toBe('browser');
+
+        const firstException = actualEvent.exception.values[0];
+        expect(firstException.type).toBe('ReferenceError');
+        expect(firstException.value).toBe('require is not defined');
+
+        const frames = firstException.stacktrace.frames as Array<Record<string, any>>;
+        expect(
+          frames.some(
+            (frame) =>
+              frame.function === 'ExportsCache.has' &&
+              frame.context_line === '      const mod = require.cache[filename];',
+          ),
+        ).toBe(true);
+        expect(
+          frames.some(
+            (frame) =>
+              frame.function === 'Module.require' &&
+              frame.filename === 'app:///out/main/index.js',
+          ),
+        ).toBe(true);
+      },
+    })
+    .run();
+});


### PR DESCRIPTION
Adds a new `examples/electron-vite-esm` fixture to reproduce the current ESM failure path in an `electron-vite` app.

This PR:
- adds a minimal Electron + Vite + Vue example with `"type": "module"`
- initializes Sentry in both the Electron main process and renderer
- loads `electron-squirrel-startup` via `createRequire(import.meta.url)` in the ESM main entry
- adds an e2e test that runs with `skipEsmAutoTransform: true` and asserts the captured fatal event

This example will fail until https://github.com/open-telemetry/opentelemetry-js/pull/6590 is merged in, but I think there's value in adding it here since #1043 and #1007 seem like the same underlying issue. Maybe after https://github.com/open-telemetry/opentelemetry-js/pull/6590 is merged in?