### PR TITLE
fix: Truncate minidump extra parameters when updating

### DIFF
--- a/src/main/integrations/electron-minidump.ts
+++ b/src/main/integrations/electron-minidump.ts
@@ -96,6 +96,7 @@ export function minidumpUrlFromDsn(dsn: string): string | undefined {
 export const electronMinidumpIntegration = defineIntegration(() => {
   /** Counter used to ensure no race condition when updating extra params */
   let updateEpoch = 0;
+  let lastParamCount = 0;
 
   async function getNativeUploaderEvent(client: NodeClient, scope: ScopeData): Promise<Event> {
     const { sendDefaultPii = false } = client.getOptions();
@@ -128,9 +129,21 @@ export const electronMinidumpIntegration = defineIntegration(() => {
 
         // Update the extra parameters in the main process
         const mainParams = getNativeUploaderExtraParams(event);
+        const count = Object.keys(mainParams).length;
+
+        // Remove any extra parameters that extend beyond the current count
+        if (lastParamCount > count) {
+          for (let i = count + 1; i <= lastParamCount; i++) {
+            crashReporter.removeExtraParameter(`sentry__${i}`);
+          }
+        }
+
         for (const [key, value] of Object.entries(mainParams)) {
           crashReporter.addExtraParameter(key, value);
         }
+
+        // Track how many parameters we added so we can remove extras next time
+        lastParamCount = count;
       })
       .catch((error) => debug.error(error));
   }


### PR DESCRIPTION
When using the `electronMinidumpIntegration`, we store JSON stringified scope in what Crashpad calls "extra parameters". Because these parameters are limited in length, we save them to multiple parameters labelled `sentry__N`. On ingestion, [Relay concatenates these parameters](https://github.com/search?q=repo%3Agetsentry%2Frelay%20sentry__&type=code) to get the JSON payload.

This PR fixes a potential bug if the JSON payload ever gets shorter and extra parameters are left with Crashpad containing the end of the previous JSON in them.