### PR TITLE
chore: Lint - Re-enable `typescript/consistent-type-imports`

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -53,7 +53,7 @@
       "files": ["**/*.ts", "**/*.tsx", "**/*.d.ts"],
       "rules": {
         "typescript/ban-ts-comment": "error",
-        // "typescript/consistent-type-imports": "error",  TODO: enable this
+        "typescript/consistent-type-imports": "error",
         "typescript/no-unnecessary-type-assertion": "error",
         "typescript/prefer-for-of": "error",
         "typescript/no-floating-promises": ["error", { "ignoreVoid": true }],

--- a/src/common/envelope.ts
+++ b/src/common/envelope.ts
@@ -1,13 +1,5 @@
-import {
-  Attachment,
-  AttachmentItem,
-  Envelope,
-  Event,
-  EventItem,
-  forEachEnvelopeItem,
-  Profile,
-  ProfileChunk,
-} from '@sentry/core';
+import type { Attachment, AttachmentItem, Envelope, Event, EventItem, Profile, ProfileChunk } from '@sentry/core';
+import { forEachEnvelopeItem } from '@sentry/core';
 
 /** Pulls an event and additional envelope items out of an envelope. Returns undefined if there was no event */
 export function eventFromEnvelope(envelope: Envelope): [Event, Attachment[], Profile | undefined] | undefined {

--- a/src/common/ipc.ts
+++ b/src/common/ipc.ts
@@ -1,4 +1,4 @@
-import { SerializedLog, SerializedMetric } from '@sentry/core';
+import type { SerializedLog, SerializedMetric } from '@sentry/core';
 
 /** Ways to communicate between the renderer and main process  */
 export enum IPCMode {

--- a/src/common/scope.ts
+++ b/src/common/scope.ts
@@ -1,4 +1,5 @@
-import { getCurrentScope, getGlobalScope, getIsolationScope, mergeScopeData, Scope, ScopeData } from '@sentry/core';
+import type { Scope, ScopeData } from '@sentry/core';
+import { getCurrentScope, getGlobalScope, getIsolationScope, mergeScopeData } from '@sentry/core';
 
 /** Gets the merged scope data */
 export function getScopeData(): ScopeData {

--- a/src/main/context.ts
+++ b/src/main/context.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
-import { Event, EventHint, SdkInfo } from '@sentry/core';
-import { NodeClient } from '@sentry/node';
+import type { Event, EventHint, SdkInfo } from '@sentry/core';
+import type { NodeClient } from '@sentry/node';
 import { app } from 'electron';
 import { SDK_VERSION } from './version.js';
 

--- a/src/main/electron-normalize.ts
+++ b/src/main/electron-normalize.ts
@@ -1,5 +1,6 @@
 import { parseSemver } from '@sentry/core';
-import { app, Session } from 'electron';
+import type { Session } from 'electron';
+import { app } from 'electron';
 import { join } from 'path';
 import { RENDERER_ID_HEADER } from '../common/ipc.js';
 

--- a/src/main/header-injection.ts
+++ b/src/main/header-injection.ts
@@ -1,4 +1,4 @@
-import { Session } from 'electron';
+import type { Session } from 'electron';
 
 function addHeader(
   responseHeaders: Record<string, string | string[]> = {},

--- a/src/main/integrations/additional-context.ts
+++ b/src/main/integrations/additional-context.ts
@@ -1,5 +1,6 @@
 import { exec } from 'node:child_process';
-import { defineIntegration, DeviceContext } from '@sentry/core';
+import type { DeviceContext } from '@sentry/core';
+import { defineIntegration } from '@sentry/core';
 import { app, screen as electronScreen } from 'electron';
 import { mergeEvents } from '../merge.js';
 

--- a/src/main/integrations/child-process.ts
+++ b/src/main/integrations/child-process.ts
@@ -1,15 +1,11 @@
-import {
-  addBreadcrumb,
-  captureMessage,
-  defineIntegration,
-  Log,
-  ParameterizedString,
-  SeverityLevel,
-} from '@sentry/core';
-import { childProcessIntegration as nodeChildProcessIntegration, logger, NodeClient } from '@sentry/node';
+import type { Log, ParameterizedString, SeverityLevel } from '@sentry/core';
+import { addBreadcrumb, captureMessage, defineIntegration } from '@sentry/core';
+import type { NodeClient } from '@sentry/node';
+import { childProcessIntegration as nodeChildProcessIntegration, logger } from '@sentry/node';
 import { app } from 'electron';
-import { EXIT_REASONS, ExitReason } from '../electron-normalize.js';
-import { ElectronMainOptions } from '../sdk.js';
+import type { ExitReason } from '../electron-normalize.js';
+import { EXIT_REASONS } from '../electron-normalize.js';
+import type { ElectronMainOptions } from '../sdk.js';
 
 type NodeChildProcessOptions = NonNullable<Parameters<typeof nodeChildProcessIntegration>[0]>;
 

--- a/src/main/integrations/electron-breadcrumbs.ts
+++ b/src/main/integrations/electron-breadcrumbs.ts
@@ -1,8 +1,11 @@
-import { addBreadcrumb, Breadcrumb, defineIntegration } from '@sentry/core';
-import { logger, NodeClient } from '@sentry/node';
-import { app, autoUpdater, BrowserWindow, powerMonitor, screen, WebContents } from 'electron';
+import type { Breadcrumb } from '@sentry/core';
+import { addBreadcrumb, defineIntegration } from '@sentry/core';
+import type { NodeClient } from '@sentry/node';
+import { logger } from '@sentry/node';
+import type { BrowserWindow, WebContents } from 'electron';
+import { app, autoUpdater, powerMonitor, screen } from 'electron';
 import { getRendererProperties, trackRendererProperties } from '../renderers.js';
-import { ElectronMainOptions } from '../sdk.js';
+import type { ElectronMainOptions } from '../sdk.js';
 
 /** A function that returns true if the named event should create breadcrumbs */
 type EventFunction = (name: string) => boolean;

--- a/src/main/integrations/electron-minidump.ts
+++ b/src/main/integrations/electron-minidump.ts
@@ -1,5 +1,6 @@
-import { applyScopeDataToEvent, debug, defineIntegration, Event, makeDsn, ScopeData, uuid4 } from '@sentry/core';
-import { NodeClient, NodeOptions } from '@sentry/node';
+import type { Event, ScopeData } from '@sentry/core';
+import { applyScopeDataToEvent, debug, defineIntegration, makeDsn, uuid4 } from '@sentry/core';
+import type { NodeClient, NodeOptions } from '@sentry/node';
 import { app, crashReporter } from 'electron';
 import { addScopeListener, getScopeData } from '../../common/scope.js';
 import { getEventDefaults, getSdkInfo } from '../context.js';

--- a/src/main/integrations/gpu-context.ts
+++ b/src/main/integrations/gpu-context.ts
@@ -1,4 +1,5 @@
-import { defineIntegration, Event } from '@sentry/core';
+import type { Event } from '@sentry/core';
+import { defineIntegration } from '@sentry/core';
 import { app } from 'electron';
 
 interface Options {

--- a/src/main/integrations/net-breadcrumbs.ts
+++ b/src/main/integrations/net-breadcrumbs.ts
@@ -1,6 +1,6 @@
+import type { ClientOptions } from '@sentry/core';
 import {
   addBreadcrumb,
-  ClientOptions,
   debug,
   defineIntegration,
   fill,
@@ -15,8 +15,10 @@ import {
   stringMatchesSomePattern,
 } from '@sentry/core';
 import { logger } from '@sentry/node';
-import { ClientRequest, ClientRequestConstructorOptions, IncomingMessage, net as electronNet } from 'electron';
-import { format as urlFormat, UrlObject } from 'url';
+import type { ClientRequest, ClientRequestConstructorOptions, IncomingMessage } from 'electron';
+import { net as electronNet } from 'electron';
+import type { UrlObject } from 'url';
+import { format as urlFormat } from 'url';
 
 type ShouldTraceFn = (method: string, url: string) => boolean;
 

--- a/src/main/integrations/normalize-paths.ts
+++ b/src/main/integrations/normalize-paths.ts
@@ -1,4 +1,5 @@
-import { defineIntegration, forEachEnvelopeItem, Profile } from '@sentry/core';
+import type { Profile } from '@sentry/core';
+import { defineIntegration, forEachEnvelopeItem } from '@sentry/core';
 import { app } from 'electron';
 import { normaliseProfile, normalizePaths } from '../normalize.js';
 

--- a/src/main/integrations/onuncaughtexception.ts
+++ b/src/main/integrations/onuncaughtexception.ts
@@ -1,5 +1,5 @@
 import { captureException, defineIntegration } from '@sentry/core';
-import { NodeClient } from '@sentry/node';
+import type { NodeClient } from '@sentry/node';
 import { dialog } from 'electron';
 
 /** Capture unhandled errors. */

--- a/src/main/integrations/preload-injection.ts
+++ b/src/main/integrations/preload-injection.ts
@@ -5,7 +5,7 @@ import { isAbsolute, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { IPCMode } from '../../common/ipc.js';
 import { setPreload } from '../electron-normalize.js';
-import { ElectronMainOptionsInternal } from '../sdk.js';
+import type { ElectronMainOptionsInternal } from '../sdk.js';
 
 // After bundling with webpack, require.resolve can return number so we include that in the types
 // to ensure we check for that!

--- a/src/main/integrations/renderer-anr.ts
+++ b/src/main/integrations/renderer-anr.ts
@@ -1,21 +1,19 @@
+import type { Client, Event, Integration, StackFrame } from '@sentry/core';
 import {
   callFrameToStackFrame,
   captureEvent,
-  Client,
   debug,
   defineIntegration,
-  Event,
-  Integration,
-  StackFrame,
   stripSentryFramesAndReverse,
   watchdogTimer,
 } from '@sentry/core';
 import { createGetModuleFromFilename } from '@sentry/node';
-import { app, powerMonitor, WebContents } from 'electron';
-import { RendererStatus } from '../../common/ipc.js';
+import type { WebContents } from 'electron';
+import { app, powerMonitor } from 'electron';
+import type { RendererStatus } from '../../common/ipc.js';
 import { ELECTRON_MAJOR_VERSION } from '../electron-normalize.js';
 import { addHeaderToSession } from '../header-injection.js';
-import { ElectronMainOptionsInternal } from '../sdk.js';
+import type { ElectronMainOptionsInternal } from '../sdk.js';
 import { sessionAnr } from '../sessions.js';
 import { captureRendererStackFrames } from '../stack-parse.js';
 

--- a/src/main/integrations/renderer-profiling.ts
+++ b/src/main/integrations/renderer-profiling.ts
@@ -1,9 +1,10 @@
-import { defineIntegration, Event, forEachEnvelopeItem, LRUMap, Profile } from '@sentry/core';
+import type { Event, Profile } from '@sentry/core';
+import { defineIntegration, forEachEnvelopeItem, LRUMap } from '@sentry/core';
 import { app } from 'electron';
 import { getDefaultEnvironment, getDefaultReleaseName } from '../context.js';
 import { addHeaderToSession } from '../header-injection.js';
 import { normaliseProfile } from '../normalize.js';
-import { ElectronMainOptionsInternal } from '../sdk.js';
+import type { ElectronMainOptionsInternal } from '../sdk.js';
 
 // A cache of renderer profiles which need attaching to events
 let RENDERER_PROFILES: LRUMap<string, Profile> | undefined;

--- a/src/main/integrations/screenshots.ts
+++ b/src/main/integrations/screenshots.ts
@@ -1,6 +1,6 @@
 import { debug, defineIntegration } from '@sentry/core';
 import { BrowserWindow } from 'electron';
-import { ElectronMainOptions } from '../sdk.js';
+import type { ElectronMainOptions } from '../sdk.js';
 
 /**
  * Captures and attaches screenshots to events

--- a/src/main/integrations/sentry-minidump/index.ts
+++ b/src/main/integrations/sentry-minidump/index.ts
@@ -1,23 +1,16 @@
-import {
-  applyScopeDataToEvent,
-  captureEvent,
-  debug,
-  defineIntegration,
-  Event,
-  Scope,
-  ScopeData,
-  Session,
-} from '@sentry/core';
-import { NodeClient } from '@sentry/node';
+import type { Event, ScopeData, Session } from '@sentry/core';
+import { applyScopeDataToEvent, captureEvent, debug, defineIntegration, Scope } from '@sentry/core';
+import type { NodeClient } from '@sentry/node';
 import { app, crashReporter } from 'electron';
 import { addScopeListener, getScopeData } from '../../../common/scope.js';
 import { getEventDefaults } from '../../context.js';
 import { EXIT_REASONS, getSentryCachePath } from '../../electron-normalize.js';
 import { getRendererProperties, trackRendererProperties } from '../../renderers.js';
-import { ElectronMainOptions } from '../../sdk.js';
+import type { ElectronMainOptions } from '../../sdk.js';
 import { previousSessionWasAbnormal, restorePreviousSession, setPreviousSessionAsCurrent } from '../../sessions.js';
 import { BufferedWriteStore } from '../../store.js';
-import { getMinidumpLoader, MinidumpLoader } from './minidump-loader.js';
+import type { MinidumpLoader } from './minidump-loader.js';
+import { getMinidumpLoader } from './minidump-loader.js';
 
 interface PreviousRun {
   scope: ScopeData;

--- a/src/main/integrations/sentry-minidump/minidump-loader.ts
+++ b/src/main/integrations/sentry-minidump/minidump-loader.ts
@@ -1,9 +1,11 @@
-import { Attachment, debug } from '@sentry/core';
+import type { Attachment } from '@sentry/core';
+import { debug } from '@sentry/core';
 import { app } from 'electron';
 import { promises as fs } from 'fs';
 import { basename, join } from 'path';
 import { Mutex } from '../../mutex.js';
-import { MinidumpParseResult, parseMinidump } from './minidump-parser.js';
+import type { MinidumpParseResult } from './minidump-parser.js';
+import { parseMinidump } from './minidump-parser.js';
 
 /** Maximum number of days to keep a minidump before deleting it. */
 const MAX_AGE_DAYS = 30;

--- a/src/main/integrations/startup-tracing.ts
+++ b/src/main/integrations/startup-tracing.ts
@@ -1,12 +1,9 @@
+import type { Event, Span, SpanStatus, StartSpanOptions } from '@sentry/core';
 import {
   defineIntegration,
-  Event,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   setMeasurement,
-  Span,
-  SpanStatus,
   startSpanManual,
-  StartSpanOptions,
   timestampInSeconds,
 } from '@sentry/core';
 import { app } from 'electron';

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,29 +1,27 @@
 // oxlint-disable max-lines
 import { EventEmitter } from 'node:events';
+import type { Attachment, Client, DynamicSamplingContext, Event, ScopeData } from '@sentry/core';
 import {
   _INTERNAL_captureSerializedLog,
   _INTERNAL_captureSerializedMetric,
-  Attachment,
-  Client,
   debug,
-  DynamicSamplingContext,
-  Event,
   parseEnvelope,
-  ScopeData,
   type SerializedLog,
   type SerializedMetric,
 } from '@sentry/core';
 import { captureEvent, getClient, getCurrentScope } from '@sentry/node';
-import { app, ipcMain, protocol, WebContents, webContents } from 'electron';
+import type { WebContents } from 'electron';
+import { app, ipcMain, protocol, webContents } from 'electron';
 import { eventFromEnvelope, profileChunkFromEnvelope } from '../common/envelope.js';
-import { ipcChannelUtils, IPCMode, IpcUtils, RendererStatus } from '../common/ipc.js';
+import type { IpcUtils, RendererStatus } from '../common/ipc.js';
+import { ipcChannelUtils, IPCMode } from '../common/ipc.js';
 import { registerProtocol } from './electron-normalize.js';
 import { createRendererEventLoopBlockStatusHandler } from './integrations/renderer-anr.js';
 import { rendererProfileFromIpc } from './integrations/renderer-profiling.js';
 import { getOsDeviceLogAttributes } from './log.js';
 import { mergeEvents } from './merge.js';
 import { normalizeProfileChunkEnvelope, normalizeReplayEnvelope } from './normalize.js';
-import { ElectronMainOptionsInternal } from './sdk.js';
+import type { ElectronMainOptionsInternal } from './sdk.js';
 import { SDK_VERSION } from './version.js';
 
 interface IpcMainEvents {

--- a/src/main/log.ts
+++ b/src/main/log.ts
@@ -1,4 +1,4 @@
-import { Client, Event } from '@sentry/core';
+import type { Client, Event } from '@sentry/core';
 
 interface Attributes {
   'os.name'?: string;

--- a/src/main/merge.ts
+++ b/src/main/merge.ts
@@ -1,4 +1,4 @@
-import { Event } from '@sentry/core';
+import type { Event } from '@sentry/core';
 
 /** Removes private properties from event before merging */
 function removePrivateProperties(event: Event): void {

--- a/src/main/normalize.ts
+++ b/src/main/normalize.ts
@@ -1,18 +1,14 @@
+import type { Envelope, Event, Profile, ProfileChunk, ReplayEvent } from '@sentry/core';
 import {
   addItemToEnvelope,
   createEnvelope,
-  Envelope,
-  Event,
   forEachEnvelopeItem,
   getCurrentScope,
   normalizeUrlToBase,
-  Profile,
-  ProfileChunk,
-  ReplayEvent,
 } from '@sentry/core';
 import { createGetModuleFromFilename } from '@sentry/node';
 import { app } from 'electron';
-import { ElectronMainOptionsInternal } from './sdk.js';
+import type { ElectronMainOptionsInternal } from './sdk.js';
 import { SDK_VERSION } from './version.js';
 
 const getModuleFromFilename = createGetModuleFromFilename(app.getAppPath());

--- a/src/main/sdk.ts
+++ b/src/main/sdk.ts
@@ -1,11 +1,11 @@
+import type { Integration, Options } from '@sentry/core';
 import {
   addAutoIpAddressToSession,
   debug,
   getIntegrationsToSetup,
-  Integration,
-  Options,
   stackParserFromStackParserOptions,
 } from '@sentry/core';
+import type { NodeOptions } from '@sentry/node';
 import {
   consoleIntegration,
   contextLinesIntegration,
@@ -18,11 +18,11 @@ import {
   nativeNodeFetchIntegration,
   NodeClient,
   nodeContextIntegration,
-  NodeOptions,
   onUnhandledRejectionIntegration,
   setNodeAsyncContextStrategy,
 } from '@sentry/node';
-import { Session, session, WebContents } from 'electron';
+import type { Session, WebContents } from 'electron';
+import { session } from 'electron';
 import { IPCMode } from '../common/ipc.js';
 import { getDefaultEnvironment, getDefaultReleaseName, getSdkInfo } from './context.js';
 import { additionalContextIntegration } from './integrations/additional-context.js';
@@ -42,7 +42,8 @@ import { sentryMinidumpIntegration } from './integrations/sentry-minidump/index.
 import { configureIPC } from './ipc.js';
 import { getOsDeviceLogAttributes } from './log.js';
 import { defaultStackParser } from './stack-parse.js';
-import { ElectronOfflineTransportOptions, makeElectronOfflineTransport } from './transports/electron-offline-net.js';
+import type { ElectronOfflineTransportOptions } from './transports/electron-offline-net.js';
+import { makeElectronOfflineTransport } from './transports/electron-offline-net.js';
 import { configureUtilityProcessIPC } from './utility-processes.js';
 
 /** Get the default integrations for the main process SDK. */

--- a/src/main/sessions.ts
+++ b/src/main/sessions.ts
@@ -1,3 +1,4 @@
+import type { SerializedSession, Session, SessionContext, SessionStatus } from '@sentry/core';
 import {
   captureSession,
   debug,
@@ -5,14 +6,11 @@ import {
   getClient,
   getIsolationScope,
   makeSession,
-  SerializedSession,
-  Session,
-  SessionContext,
-  SessionStatus,
   startSession as startSessionCore,
   updateSession,
 } from '@sentry/core';
-import { flush, NodeClient } from '@sentry/node';
+import type { NodeClient } from '@sentry/node';
+import { flush } from '@sentry/node';
 import { app } from 'electron';
 import { getSentryCachePath } from './electron-normalize.js';
 import { Store } from './store.js';

--- a/src/main/stack-parse.ts
+++ b/src/main/stack-parse.ts
@@ -1,6 +1,8 @@
-import { createStackParser, debug, nodeStackLineParser, StackFrame, StackParser } from '@sentry/core';
+import type { StackFrame, StackParser } from '@sentry/core';
+import { createStackParser, debug, nodeStackLineParser } from '@sentry/core';
 import { createGetModuleFromFilename } from '@sentry/node';
-import { app, WebContents, WebFrameMain } from 'electron';
+import type { WebContents, WebFrameMain } from 'electron';
+import { app } from 'electron';
 import { electronRendererStackParser } from '../renderer/stack-parse.js';
 import { ELECTRON_MAJOR_VERSION } from './electron-normalize.js';
 

--- a/src/main/transports/electron-net.ts
+++ b/src/main/transports/electron-net.ts
@@ -1,13 +1,14 @@
-import {
+import type {
   BaseTransportOptions,
-  createTransport,
   Transport,
   TransportMakeRequestResponse,
   TransportRequest,
   TransportRequestExecutor,
 } from '@sentry/core';
+import { createTransport } from '@sentry/core';
 import { app, net } from 'electron';
-import { Readable, Writable } from 'stream';
+import type { Writable } from 'stream';
+import { Readable } from 'stream';
 import { URL } from 'url';
 import { createGzip } from 'zlib';
 

--- a/src/main/transports/electron-offline-net.ts
+++ b/src/main/transports/electron-offline-net.ts
@@ -1,6 +1,9 @@
-import { BaseTransportOptions, makeOfflineTransport, OfflineTransportOptions, Transport } from '@sentry/core';
-import { ElectronNetTransportOptions, makeElectronTransport } from './electron-net.js';
-import { createOfflineStore, OfflineStoreOptions } from './offline-store.js';
+import type { BaseTransportOptions, OfflineTransportOptions, Transport } from '@sentry/core';
+import { makeOfflineTransport } from '@sentry/core';
+import type { ElectronNetTransportOptions } from './electron-net.js';
+import { makeElectronTransport } from './electron-net.js';
+import type { OfflineStoreOptions } from './offline-store.js';
+import { createOfflineStore } from './offline-store.js';
 
 export type ElectronOfflineTransportOptions = ElectronNetTransportOptions &
   OfflineTransportOptions &

--- a/src/main/transports/offline-store.ts
+++ b/src/main/transports/offline-store.ts
@@ -1,4 +1,5 @@
-import { debug, Envelope, OfflineStore, parseEnvelope, serializeEnvelope, uuid4 } from '@sentry/core';
+import type { Envelope, OfflineStore } from '@sentry/core';
+import { debug, parseEnvelope, serializeEnvelope, uuid4 } from '@sentry/core';
 import { promises as fs } from 'fs';
 import { join } from 'path';
 import { getSentryCachePath } from '../electron-normalize.js';

--- a/src/main/utility-processes.ts
+++ b/src/main/utility-processes.ts
@@ -1,4 +1,5 @@
-import { Attachment, debug, Event, parseEnvelope } from '@sentry/core';
+import type { Attachment, Event } from '@sentry/core';
+import { debug, parseEnvelope } from '@sentry/core';
 import { captureEvent, getClient } from '@sentry/node';
 import * as electron from 'electron';
 import { eventFromEnvelope } from '../common/envelope.js';

--- a/src/native/event-loop-blocked-integration.ts
+++ b/src/native/event-loop-blocked-integration.ts
@@ -1,4 +1,5 @@
-import { defineIntegration, Integration } from '@sentry/core';
+import type { Integration } from '@sentry/core';
+import { defineIntegration } from '@sentry/core';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import {
   disableBlockDetectionForCallback,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2,9 +2,10 @@
  * This preload script may be used with sandbox mode enabled which means regular require is not available.
  */
 
-import { SerializedLog, SerializedMetric } from '@sentry/core';
+import type { SerializedLog, SerializedMetric } from '@sentry/core';
 import { contextBridge, ipcRenderer } from 'electron';
-import { ipcChannelUtils, RendererStatus } from '../common/ipc.js';
+import type { RendererStatus } from '../common/ipc.js';
+import { ipcChannelUtils } from '../common/ipc.js';
 
 /**
  * Hook up IPC to the window object and uses contextBridge if available.

--- a/src/renderer/integrations/event-loop-block.ts
+++ b/src/renderer/integrations/event-loop-block.ts
@@ -1,5 +1,5 @@
 import { defineIntegration } from '@sentry/core';
-import { RendererProcessAnrOptions } from '../../common/ipc.js';
+import type { RendererProcessAnrOptions } from '../../common/ipc.js';
 import { getIPC } from '../ipc.js';
 
 interface Options {

--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -1,8 +1,10 @@
 /* eslint-disable no-restricted-globals */
 /* eslint-disable no-console */
-import { Client, debug, getClient, SerializedLog, SerializedMetric, uuid4 } from '@sentry/core';
-import { ipcChannelUtils, IPCInterface, RENDERER_ID_HEADER, RendererStatus } from '../common/ipc.js';
-import { ElectronRendererOptionsInternal } from './sdk.js';
+import type { Client, SerializedLog, SerializedMetric } from '@sentry/core';
+import { debug, getClient, uuid4 } from '@sentry/core';
+import type { IPCInterface, RendererStatus } from '../common/ipc.js';
+import { ipcChannelUtils, RENDERER_ID_HEADER } from '../common/ipc.js';
+import type { ElectronRendererOptionsInternal } from './sdk.js';
 
 /** Gets the available IPC implementation */
 function getImplementation(ipcKey: string): IPCInterface {

--- a/src/renderer/log.ts
+++ b/src/renderer/log.ts
@@ -1,12 +1,5 @@
-import {
-  _INTERNAL_captureLog,
-  getClient,
-  getCurrentScope,
-  Log,
-  LogSeverityLevel,
-  ParameterizedString,
-  SerializedLog,
-} from '@sentry/core';
+import type { Log, LogSeverityLevel, ParameterizedString, SerializedLog } from '@sentry/core';
+import { _INTERNAL_captureLog, getClient, getCurrentScope } from '@sentry/core';
 import { getIPC } from './ipc.js';
 
 function captureLog(

--- a/src/renderer/metric.ts
+++ b/src/renderer/metric.ts
@@ -1,11 +1,5 @@
-import {
-  _INTERNAL_captureMetric,
-  getClient,
-  getCurrentScope,
-  MetricOptions,
-  MetricType,
-  SerializedMetric,
-} from '@sentry/core';
+import type { MetricOptions, MetricType, SerializedMetric } from '@sentry/core';
+import { _INTERNAL_captureMetric, getClient, getCurrentScope } from '@sentry/core';
 import { getIPC } from './ipc.js';
 
 function captureMetric(type: MetricType, name: string, value: number, options?: MetricOptions): void {

--- a/src/renderer/sdk.ts
+++ b/src/renderer/sdk.ts
@@ -1,11 +1,9 @@
 /* eslint-disable deprecation/deprecation */
 /* eslint-disable no-restricted-globals */
-import {
-  BrowserOptions,
-  getDefaultIntegrations as getDefaultBrowserIntegrations,
-  init as browserInit,
-} from '@sentry/browser';
-import { debug, Integration } from '@sentry/core';
+import type { BrowserOptions } from '@sentry/browser';
+import { getDefaultIntegrations as getDefaultBrowserIntegrations, init as browserInit } from '@sentry/browser';
+import type { Integration } from '@sentry/core';
+import { debug } from '@sentry/core';
 import { scopeToMainIntegration } from './integrations/scope-to-main.js';
 import { electronRendererStackParser } from './stack-parse.js';
 import { makeRendererTransport } from './transport.js';

--- a/src/renderer/stack-parse.ts
+++ b/src/renderer/stack-parse.ts
@@ -1,5 +1,6 @@
 import { chromeStackLineParser } from '@sentry/browser';
-import { nodeStackLineParser, StackFrame, StackParser, stripSentryFramesAndReverse } from '@sentry/core';
+import type { StackFrame, StackParser } from '@sentry/core';
+import { nodeStackLineParser, stripSentryFramesAndReverse } from '@sentry/core';
 
 const STACKTRACE_FRAME_LIMIT = 50;
 

--- a/src/renderer/transport.ts
+++ b/src/renderer/transport.ts
@@ -1,11 +1,6 @@
-import {
-  BaseTransportOptions,
-  createTransport,
-  Transport,
-  TransportMakeRequestResponse,
-  TransportRequest,
-} from '@sentry/core';
-import { IPCInterface } from '../common/ipc.js';
+import type { BaseTransportOptions, Transport, TransportMakeRequestResponse, TransportRequest } from '@sentry/core';
+import { createTransport } from '@sentry/core';
+import type { IPCInterface } from '../common/ipc.js';
 import { getIPC } from './ipc.js';
 
 /**

--- a/src/utility/sdk.ts
+++ b/src/utility/sdk.ts
@@ -1,12 +1,12 @@
+import type { Integration, StackParser } from '@sentry/core';
 import {
   createStackParser,
   debug,
   getIntegrationsToSetup,
-  Integration,
   nodeStackLineParser,
-  StackParser,
   stackParserFromStackParserOptions,
 } from '@sentry/core';
+import type { NodeOptions } from '@sentry/node';
 import {
   consoleIntegration,
   createGetModuleFromFilename,
@@ -17,7 +17,6 @@ import {
   linkedErrorsIntegration,
   nativeNodeFetchIntegration,
   NodeClient,
-  NodeOptions,
   onUncaughtExceptionIntegration,
   onUnhandledRejectionIntegration,
   setNodeAsyncContextStrategy,

--- a/src/utility/transport.ts
+++ b/src/utility/transport.ts
@@ -1,10 +1,5 @@
-import {
-  BaseTransportOptions,
-  createTransport,
-  Transport,
-  TransportMakeRequestResponse,
-  TransportRequest,
-} from '@sentry/core';
+import type { BaseTransportOptions, Transport, TransportMakeRequestResponse, TransportRequest } from '@sentry/core';
+import { createTransport } from '@sentry/core';
 import { getMagicMessage, isMagicMessage } from '../common/ipc.js';
 
 /**

--- a/test/e2e/context.ts
+++ b/test/e2e/context.ts
@@ -1,9 +1,10 @@
-import { ChildProcess, spawn, spawnSync } from 'child_process';
+import type { ChildProcess } from 'child_process';
+import { spawn, spawnSync } from 'child_process';
 import { rmSync } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
 import { delay } from '../helpers';
-import { TestLogger } from './utils';
+import type { TestLogger } from './utils';
 
 function getDeleteDirectories(appName: string): string[] {
   switch (process.platform) {

--- a/test/e2e/prepare.ts
+++ b/test/e2e/prepare.ts
@@ -6,7 +6,8 @@ import { SDK_VERSION as JS_SDK_VERSION } from '@sentry/core';
 import { dirname, join, sep } from 'path';
 import { SDK_VERSION } from '../../src/main/version';
 import { ERROR_ID, HANG_ID, RATE_LIMIT_ID } from './server';
-import { TestLogger, walkSync } from './utils';
+import type { TestLogger } from './utils';
+import { walkSync } from './utils';
 
 const exec = promisify(child_process.exec);
 

--- a/test/e2e/runner.ts
+++ b/test/e2e/runner.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { Envelope } from '@sentry/core';
+import type { Envelope } from '@sentry/core';
 import { readFileSync } from 'fs';
 import { inspect } from 'util';
 import { afterEach, beforeEach, expect, onTestFailed, test } from 'vitest';
@@ -7,7 +7,8 @@ import { delay } from '../helpers';
 import { TestContext } from './context';
 import { downloadElectron } from './download';
 import { installDepsAndBuild, prepareTestFiles } from './prepare';
-import { createSentryTestServer, MinidumpResult, TestServer } from './server';
+import type { MinidumpResult, TestServer } from './server';
+import { createSentryTestServer } from './server';
 import { createTestLogger, getCurrentElectronVersion, isSessionEnvelope } from './utils';
 
 function getTestMeta(path: string) {

--- a/test/e2e/server.ts
+++ b/test/e2e/server.ts
@@ -1,12 +1,13 @@
-import { Envelope, Event, parseEnvelope } from '@sentry/core';
+import type { Envelope, Event } from '@sentry/core';
+import { parseEnvelope } from '@sentry/core';
 import Busboy from 'busboy';
 import Koa from 'koa';
 import bodyParser from 'koa-bodyparser';
 import Router from 'koa-tree-router';
-import { Readable } from 'stream';
+import type { Readable } from 'stream';
 import { createGunzip, gunzipSync } from 'zlib';
 import { delay } from '../helpers';
-import { TestLogger } from './utils';
+import type { TestLogger } from './utils';
 
 export const SERVER_PORT = 8123;
 export const RATE_LIMIT_ID = 666;

--- a/test/e2e/test-apps/sessions/abnormal-exit-electron-uploader/test.ts
+++ b/test/e2e/test-apps/sessions/abnormal-exit-electron-uploader/test.ts
@@ -1,4 +1,4 @@
-import { Envelope } from '@sentry/core';
+import type { Envelope } from '@sentry/core';
 import { expect } from 'vitest';
 import { electronTestRunner, getSessionFromEnvelope, ISO_DATE_MATCHER, sessionEnvelope, UUID_MATCHER } from '../../..';
 

--- a/test/e2e/test-apps/sessions/native-crash-main-electron-uploader/test.ts
+++ b/test/e2e/test-apps/sessions/native-crash-main-electron-uploader/test.ts
@@ -1,4 +1,4 @@
-import { Envelope } from '@sentry/core';
+import type { Envelope } from '@sentry/core';
 import { expect } from 'vitest';
 import {
   electronTestRunner,

--- a/test/e2e/test-apps/sessions/native-crash-main/test.ts
+++ b/test/e2e/test-apps/sessions/native-crash-main/test.ts
@@ -1,4 +1,4 @@
-import { Envelope } from '@sentry/core';
+import type { Envelope } from '@sentry/core';
 import { expect } from 'vitest';
 import {
   electronTestRunner,

--- a/test/e2e/utils.ts
+++ b/test/e2e/utils.ts
@@ -1,16 +1,16 @@
-import {
+import type {
   AttachmentItem,
   Contexts,
   Envelope,
   Event,
   FeedbackEvent,
-  parseSemver,
   ProfileChunk,
   ProfileItem,
   SdkInfo,
   SerializedSession,
   TransactionEvent,
 } from '@sentry/core';
+import { parseSemver } from '@sentry/core';
 import { readdirSync } from 'fs';
 import { join } from 'path';
 import { inspect } from 'util';

--- a/test/unit/offline-store.test.ts
+++ b/test/unit/offline-store.test.ts
@@ -1,5 +1,6 @@
 import '../../scripts/electron-shim.mjs';
-import { createEventEnvelope, Envelope, Event } from '@sentry/core';
+import type { Envelope, Event } from '@sentry/core';
+import { createEventEnvelope } from '@sentry/core';
 import * as tmp from 'tmp';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { delay, expectFilesInDirectory } from '../helpers';

--- a/test/unit/offline-transport.test.ts
+++ b/test/unit/offline-transport.test.ts
@@ -1,14 +1,13 @@
 import '../../scripts/electron-shim.mjs';
-import {
-  createEventEnvelope,
-  createTransport,
+import type {
   Envelope,
   InternalBaseTransportOptions,
   OfflineTransportOptions,
   TransportMakeRequestResponse,
 } from '@sentry/core';
+import { createEventEnvelope, createTransport } from '@sentry/core';
 import { describe, expect, test } from 'vitest';
-import { ElectronOfflineTransportOptions } from '../../src/main/transports/electron-offline-net';
+import type { ElectronOfflineTransportOptions } from '../../src/main/transports/electron-offline-net';
 
 const { makeElectronOfflineTransport } = await import('../../src/main/transports/electron-offline-net');
 


### PR DESCRIPTION
When migrating to oxlint, this was left disabled to keep the PR minimal. This PR re-enables the lint and fixes all the issues.