### PR TITLE
chore: Lint - Re-enable `typescript/no-explicit-any`

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -60,7 +60,7 @@
         "typescript/no-dynamic-delete": "error",
         "typescript/no-unsafe-member-access": "error",
         "typescript/unbound-method": "error",
-        // "typescript/no-explicit-any": "error", TODO: enable this
+        "typescript/no-explicit-any": "error",
         "typescript/no-empty-function": "off",
         "typescript/prefer-optional-chain": ["error"],
         "typescript/no-redundant-type-constituents": "off",
@@ -79,7 +79,8 @@
         "no-unused-expressions": "off",
         "no-unsafe-optional-chaining": "off",
         "max-lines": "off",
-        "vitest/no-conditional-tests": "off"
+        "vitest/no-conditional-tests": "off",
+        "typescript/no-explicit-any": "off"
       }
     }
   ]

--- a/src/main/integrations/electron-minidump.ts
+++ b/src/main/integrations/electron-minidump.ts
@@ -24,11 +24,9 @@ function getScope(options: NodeOptions): Event {
   return {
     release: options.release,
     environment: options.environment,
-    /* eslint-disable typescript/no-unsafe-member-access */
     ...(hasKeys(scope.user) && { user: scope.user }),
     ...(hasKeys(scope.tags) && { tags: scope.tags }),
     ...(hasKeys(scope.extra) && { extra: scope.extra }),
-    /* eslint-enable typescript/no-unsafe-member-access */
   };
 }
 

--- a/src/main/integrations/sentry-minidump/minidump-loader.ts
+++ b/src/main/integrations/sentry-minidump/minidump-loader.ts
@@ -119,9 +119,8 @@ async function deleteCrashpadMetadataFile(crashesDirectory: string, waitMs: numb
   try {
     await fs.unlink(metadataPath);
     debug.log('Deleted Crashpad metadata file', metadataPath);
-  } catch (e: any) {
-    // eslint-disable-next-line typescript/no-unsafe-member-access
-    if (e.code && e.code == 'EBUSY') {
+  } catch (e) {
+    if (typeof e === 'object' && e !== null && 'code' in e && e.code === 'EBUSY') {
       // Since Crashpad probably still has the metadata file open, we make a few attempts to delete it, backing
       // off and waiting longer each time.
       setTimeout(async () => {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -147,7 +147,7 @@ function handleEnvelope(
 }
 
 /** Is object defined and has keys */
-function hasKeys(obj: any): boolean {
+function hasKeys(obj: unknown): boolean {
   return obj != undefined && Object.keys(obj).length > 0;
 }
 

--- a/src/main/merge.ts
+++ b/src/main/merge.ts
@@ -7,8 +7,7 @@ function removePrivateProperties(event: Event): void {
   delete event.sdkProcessingMetadata?.capturedSpanIsolationScope;
 
   for (const span of event.spans || []) {
-    // eslint-disable-next-line typescript/no-unsafe-member-access
-    delete (span as any).spanRecorder;
+    delete (span as unknown as { spanRecorder?: unknown }).spanRecorder;
   }
 }
 

--- a/src/main/sessions.ts
+++ b/src/main/sessions.ts
@@ -36,8 +36,7 @@ function getSessionStore(): Store<SessionContext | undefined> {
 /** Copies a session and removes the toJSON function so it can be serialised without conversion */
 function makeSessionSafeToSerialize(session: Session): Session {
   const copy = { ...session };
-  // eslint-disable-next-line typescript/no-unsafe-member-access
-  delete (copy as any).toJSON;
+  delete (copy as unknown as { toJSON?: unknown }).toJSON;
   return copy;
 }
 

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -6,7 +6,7 @@ import { Mutex } from './mutex.js';
 const dateFormat = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.*\d{0,10}Z$/;
 
 /** JSON revive function to enable de-serialization of Date objects */
-function dateReviver(_: string, value: any): any {
+function dateReviver(_: string, value: unknown): unknown {
   if (typeof value === 'string' && dateFormat.test(value)) {
     return new Date(value);
   }


### PR DESCRIPTION
When migrating to oxlint, this was left disabled to keep the PR minimal. This PR re-enables the lint and fixes all the issues.