### PR TITLE
feat: Parse JavaScript stack frames from renderer OOM minidump

### DIFF
--- a/src/main/integrations/sentry-minidump/index.ts
+++ b/src/main/integrations/sentry-minidump/index.ts
@@ -1,6 +1,7 @@
 import type { Event, ScopeData, Session } from '@sentry/core';
-import { applyScopeDataToEvent, captureEvent, debug, defineIntegration, Scope } from '@sentry/core';
+import { applyScopeDataToEvent, captureEvent, createStackParser, debug, defineIntegration, Scope } from '@sentry/core';
 import type { NodeClient } from '@sentry/node';
+import { chromeStackLineParser } from '@sentry/browser';
 import { app, crashReporter } from 'electron';
 import { addScopeListener, getScopeData } from '../../../common/scope.js';
 import { getEventDefaults } from '../../context.js';
@@ -11,6 +12,8 @@ import { previousSessionWasAbnormal, restorePreviousSession, setPreviousSessionA
 import { BufferedWriteStore } from '../../store.js';
 import type { MinidumpLoader } from './minidump-loader.js';
 import { getMinidumpLoader } from './minidump-loader.js';
+
+const chromeStackParser = createStackParser(chromeStackLineParser);
 
 interface PreviousRun {
   scope: ScopeData;
@@ -119,6 +122,26 @@ export const sentryMinidumpIntegration = defineIntegration((options: Options = {
             ...prependedAnnotations,
           },
         };
+
+        if (minidumpResult.crashpadAnnotations['electron.v8-oom.stack']) {
+          // Remove the unparsed stack from the annotations as we are going to parse it here
+          delete event?.contexts?.electron?.['crashpad.electron.v8-oom.stack'];
+          delete event?.contexts?.electron?.['crashpad.v8-oom-stack'];
+
+          const stack = minidumpResult.crashpadAnnotations['electron.v8-oom.stack'].replace(/^ *#\d+/gm, '  at');
+
+          event.exception = {
+            values: [
+              {
+                type: 'OutOfMemoryError',
+                value: 'Renderer reached heap limit',
+                stacktrace: {
+                  frames: chromeStackParser(stack),
+                },
+              },
+            ],
+          };
+        }
       }
 
       if (minidumpsRemaining > 0) {

--- a/src/main/integrations/sentry-minidump/minidump-parser.ts
+++ b/src/main/integrations/sentry-minidump/minidump-parser.ts
@@ -249,6 +249,7 @@ function parseCrashpadInfo(buf: Buffer, info: Buffer): Record<string, string> {
 
 type CrashpadAnnotations = {
   process_type?: string;
+  'electron.v8-oom.stack'?: string;
 } & Record<string, string>;
 
 export type MinidumpParseResult = {

--- a/test/e2e/context.ts
+++ b/test/e2e/context.ts
@@ -41,6 +41,7 @@ export class TestContext {
     private readonly _electronPath: string,
     private readonly _appPath: string,
     private readonly _appName: string,
+    private readonly _args: string[],
   ) {
     this._started = false;
   }
@@ -63,7 +64,7 @@ export class TestContext {
       this._clearAppUserData();
     }
 
-    const args = [this._appPath];
+    const args = [this._appPath, ...this._args];
     // Electron no longer work correctly on Github Actions 'ubuntu-latest' with sandbox
     if (process.platform === 'linux') {
       args.push('--no-sandbox');

--- a/test/e2e/runner.ts
+++ b/test/e2e/runner.ts
@@ -45,6 +45,7 @@ interface ElectronTestOptions {
   waitAfterExpectedEvents?: number;
   packageManager?: 'npm' | 'yarn';
   appExecutionPath?: string;
+  electronArgs?: string[];
   skip?: (electronVersion: Version) => boolean;
 }
 
@@ -193,7 +194,7 @@ export function electronTestRunner(
       ? join(testExecutionRoot, options.appExecutionPath)
       : testExecutionRoot;
 
-    context = new TestContext(logger, electronPath, executionPath, name);
+    context = new TestContext(logger, electronPath, executionPath, name, options.electronArgs || []);
   }, 120_000);
 
   afterEach(async () => {

--- a/test/e2e/test-apps/native-sentry/renderer-oom/package.json
+++ b/test/e2e/test-apps/native-sentry/renderer-oom/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "native-sentry-renderer-oom",
+  "description": "Renderer OOM",
+  "version": "1.0.0",
+  "main": "src/main.js",
+  "dependencies": {
+    "@sentry/electron": "5.6.0"
+  }
+}

--- a/test/e2e/test-apps/native-sentry/renderer-oom/src/index.html
+++ b/test/e2e/test-apps/native-sentry/renderer-oom/src/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <script>
+      const { init } = require('@sentry/electron/renderer');
+
+      init({
+        debug: true,
+      });
+
+      function oomTrigger() {
+        const arr = [];
+        while (true) arr.push(new Array(10000).fill('x'.repeat(100)));
+      }
+
+      setTimeout(() => {
+        oomTrigger();
+      }, 500);
+    </script>
+  </body>
+</html>

--- a/test/e2e/test-apps/native-sentry/renderer-oom/src/main.js
+++ b/test/e2e/test-apps/native-sentry/renderer-oom/src/main.js
@@ -1,0 +1,22 @@
+const path = require('path');
+
+const { app, BrowserWindow } = require('electron');
+const { init } = require('@sentry/electron/main');
+
+init({
+  dsn: '__DSN__',
+  debug: true,
+  onFatalError: () => {},
+});
+
+app.on('ready', () => {
+  const mainWindow = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+
+  mainWindow.loadFile(path.join(__dirname, 'index.html'));
+});

--- a/test/e2e/test-apps/native-sentry/renderer-oom/test.ts
+++ b/test/e2e/test-apps/native-sentry/renderer-oom/test.ts
@@ -1,0 +1,65 @@
+import { expect } from 'vitest';
+import { electronTestRunner, eventEnvelope } from '../../..';
+
+electronTestRunner(
+  __dirname,
+  {
+    // Ensure we can OOM without killing whatever machine we're running on
+    electronArgs: ['--js-flags=--max-old-space-size=128'],
+    // This feature was only added in Electron 42
+    skip: (electronVersion) => electronVersion.major < 42,
+  },
+  async (ctx) => {
+    await ctx
+      .expect({
+        envelope: eventEnvelope(
+          {
+            level: 'fatal',
+            platform: 'native',
+            exception: {
+              values: [
+                {
+                  type: 'OutOfMemoryError',
+                  value: 'Renderer reached heap limit',
+                  stacktrace: {
+                    frames: [
+                      {
+                        filename: 'app:///src/index.html',
+                        function: '(anonymous)',
+                        in_app: true,
+                        lineno: expect.any(Number),
+                        colno: expect.any(Number),
+                      },
+                      {
+                        filename: 'app:///src/index.html',
+                        function: 'oomTrigger',
+                        in_app: true,
+                        lineno: expect.any(Number),
+                        colno: expect.any(Number),
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+            tags: {
+              'event.environment': 'native',
+              'event.origin': 'electron',
+              'event.process': 'renderer',
+              'exit.reason': 'crashed',
+            },
+          },
+          [
+            {
+              type: 'attachment',
+              length: expect.any(Number),
+              filename: expect.stringMatching(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.dmp$/),
+              attachment_type: 'event.minidump',
+            },
+            expect.any(Buffer),
+          ],
+        ),
+      })
+      .run();
+  },
+);

--- a/test/e2e/test-apps/native-sentry/renderer-oom/test.ts
+++ b/test/e2e/test-apps/native-sentry/renderer-oom/test.ts
@@ -46,7 +46,7 @@ electronTestRunner(
               'event.environment': 'native',
               'event.origin': 'electron',
               'event.process': 'renderer',
-              'exit.reason': 'crashed',
+              'exit.reason': expect.stringMatching(/(oom|crashed)/),
             },
           },
           [


### PR DESCRIPTION
- Closes #1353

This PR adds parsing of JavaScript stack traces which are included in Out Of Memory minidumps. We include them in the `event.exceptions` along with the minidump attachement.

Currently this gets stripped out by Relay when the minidump is parsed during ingestion, but a workaround can be applied per org and this could eventually become the default:
- https://github.com/getsentry/relay/issues/6046

The resulting error has both the native and JavaScript stack traces:
https://sentry-sdks.sentry.io/issues/7584221824/?project=5650507

<img width="1062" height="680" alt="image" src="https://github.com/user-attachments/assets/a98c9552-21e9-4366-8e97-3d32efe63206" />
