### PR TITLE
feat: Update SDKs and migrate to `dataCollection`

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -4,7 +4,7 @@
   "jsPlugins": [
     {
       "name": "sdk",
-      "specifier": "@sentry-internal/eslint-plugin-sdk"
+      "specifier": "@sentry/eslint-plugin-sdk"
     }
   ],
   "env": {

--- a/package.json
+++ b/package.json
@@ -105,12 +105,12 @@
     "e2e": "xvfb-maybe vitest run --root=./test/e2e --silent=false --disable-console-intercept"
   },
   "dependencies": {
-    "@sentry/browser": "10.56.0",
-    "@sentry/core": "10.56.0",
-    "@sentry/node": "10.56.0"
+    "@sentry/browser": "10.58.0",
+    "@sentry/core": "10.58.0",
+    "@sentry/node": "10.58.0"
   },
   "peerDependencies": {
-    "@sentry/node-native": "10.56.0"
+    "@sentry/node-native": "10.58.0"
   },
   "peerDependenciesMeta": {
     "@sentry/node-native": {
@@ -119,8 +119,8 @@
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^12.1.3",
-    "@sentry-internal/eslint-plugin-sdk": "10.56.0",
-    "@sentry/node-native": "10.56.0",
+    "@sentry/eslint-plugin-sdk": "10.58.0",
+    "@sentry/node-native": "10.58.0",
     "@types/busboy": "^1.5.4",
     "@types/koa": "^2.0.52",
     "@types/koa-bodyparser": "^4.3.0",

--- a/src/main/context.ts
+++ b/src/main/context.ts
@@ -7,7 +7,7 @@ import { SDK_VERSION } from './version.js';
 export const SDK_NAME = 'sentry.javascript.electron';
 
 /** Gets SDK info */
-export function getSdkInfo(sendDefaultPii: boolean): SdkInfo {
+export function getSdkInfo(inferIp: boolean): SdkInfo {
   return {
     name: SDK_NAME,
     packages: [
@@ -17,7 +17,7 @@ export function getSdkInfo(sendDefaultPii: boolean): SdkInfo {
       },
     ],
     version: SDK_VERSION,
-    settings: { infer_ip: sendDefaultPii ? 'auto' : 'never' },
+    settings: { infer_ip: inferIp ? 'auto' : 'never' },
   };
 }
 

--- a/src/main/integrations/electron-minidump.ts
+++ b/src/main/integrations/electron-minidump.ts
@@ -98,10 +98,10 @@ export const electronMinidumpIntegration = defineIntegration(() => {
   let lastParamCount = 0;
 
   async function getNativeUploaderEvent(client: NodeClient, scope: ScopeData): Promise<Event> {
-    const { sendDefaultPii = false } = client.getOptions();
+    const { userInfo: inferIpAddress } = client.getDataCollectionOptions();
 
     const event = mergeEvents(await getEventDefaults(client), {
-      sdk: getSdkInfo(sendDefaultPii),
+      sdk: getSdkInfo(inferIpAddress),
       event_id: uuid4(),
       level: 'fatal',
       platform: 'native',

--- a/src/main/sdk.ts
+++ b/src/main/sdk.ts
@@ -155,6 +155,12 @@ export type ElectronMainOptions = Pick<
   Omit<ElectronMainOptionsInternal, 'getSessions' | 'ipcMode' | 'ipcNamespace'> &
   NodeOptions;
 
+function resolveUserInfo(options: ElectronMainOptions): boolean {
+  const base = options.dataCollection != null ? true : !!options.sendDefaultPii;
+  const dc = options.dataCollection ?? {};
+  return dc.userInfo ?? base;
+}
+
 /**
  * Initialize Sentry in the Electron main process
  */
@@ -165,8 +171,10 @@ export function init(userOptions: ElectronMainOptions): void {
     throw new Error('Sentry Electron SDK requires Electron 23 or higher');
   }
 
+  const inferIpAddress = resolveUserInfo(userOptions);
+
   const optionsWithDefaults = {
-    _metadata: { sdk: getSdkInfo(!!userOptions.sendDefaultPii) },
+    _metadata: { sdk: getSdkInfo(inferIpAddress) },
     ipcMode: IPCMode.Both,
     ipcNamespace: 'sentry-ipc',
     release: getDefaultReleaseName(),
@@ -199,7 +207,7 @@ export function init(userOptions: ElectronMainOptions): void {
 
   const client = new NodeClient(options);
 
-  if (options.sendDefaultPii === true) {
+  if (inferIpAddress) {
     client.on('beforeSendSession', addAutoIpAddressToSession);
   }
 

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -143,6 +143,7 @@ export {
   uiProfiler,
   unleashIntegration,
   updateSpanName,
+  webVitalsIntegration,
   webWorkerIntegration,
   withActiveSpan,
   withIsolationScope,

--- a/src/renderer/sdk.ts
+++ b/src/renderer/sdk.ts
@@ -49,7 +49,7 @@ interface ElectronRendererOptions extends Partial<ElectronRendererOptionsInterna
 export function init<O extends ElectronRendererOptions>(
   options: ElectronRendererOptions & O = {} as ElectronRendererOptions & O,
   // This parameter name ensures that TypeScript error messages contain a hint for fixing SDK version mismatches
-  originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v10_56_0: O) => void = browserInit,
+  originalInit: (if_you_get_a_typescript_error_ensure_sdks_use_version_v10_58_0: O) => void = browserInit,
 ): void {
   // Ensure the browser SDK is only init'ed once.
   if (window?.__SENTRY__RENDERER_INIT__) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -569,112 +569,112 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz#4584a8a87b29188a4c1fe987a9fcf701e256d86c"
   integrity sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==
 
-"@sentry-internal/browser-utils@10.56.0":
-  version "10.56.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/browser-utils/-/browser-utils-10.56.0.tgz#40ede96ed444934dd6d360164cfe94a75179f89e"
-  integrity sha512-I8tZWAFg8SZpD8BFUpglEtSTzhZjacmcThB5/Mlq/iFiiT8mBPG4ZWDWssSfmIBKvZywJZJ83uDA0+uiJU73Tw==
+"@sentry/browser-utils@10.58.0":
+  version "10.58.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser-utils/-/browser-utils-10.58.0.tgz#e5d17e78f54ecd9c671c312b8ac0823b92e9c98b"
+  integrity sha512-TzXrhZq3Llj6qPSv0ZVG5N5c7C6qNN/aRKJXhq2LombJrLwiQrWdgizp7zdHA0FGlZ7F5YpyRA2JIpkhvrFqYA==
   dependencies:
-    "@sentry/core" "10.56.0"
+    "@sentry/core" "10.58.0"
 
-"@sentry-internal/eslint-plugin-sdk@10.56.0":
-  version "10.56.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-10.56.0.tgz#47bdb7a5cfc1b6e32cbf06ced4447b22d466f057"
-  integrity sha512-s60tfZEMm3GprqGelc5ooI4ykP5SQBHZmurp0HTUxD57Aivb9XisxfQAj9jW3NeB87MXh+rGkQ3V6e4NhMEIjg==
-
-"@sentry-internal/feedback@10.56.0":
-  version "10.56.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/feedback/-/feedback-10.56.0.tgz#f2bb9620e70dd2f993869337c0d099c225a7d99c"
-  integrity sha512-fkRR9JroESTIlErkht3OrH4DXKd/DbPozr2KLdX7boMo31hPu4cL9fuqzwOrwyDPRq9B4j+qEgIWB8JrTbgvmg==
+"@sentry/browser@10.58.0":
+  version "10.58.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-10.58.0.tgz#bd6243c9b3c20d4d04eecc0623237b05c723e344"
+  integrity sha512-Syf6h6HDwC15fk86+/0ql8ebwwJFw2wp+lvOX9GfLTJVOqrSILCrtLKNI+f4v/3w8mzImsv9ttJGGbUugLNvcA==
   dependencies:
-    "@sentry/core" "10.56.0"
+    "@sentry/browser-utils" "10.58.0"
+    "@sentry/core" "10.58.0"
+    "@sentry/feedback" "10.58.0"
+    "@sentry/replay" "10.58.0"
+    "@sentry/replay-canvas" "10.58.0"
 
-"@sentry-internal/node-native-stacktrace@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/node-native-stacktrace/-/node-native-stacktrace-0.5.0.tgz#834a5326fd45a97d1abe3b6110e9b268c7a2fa4e"
-  integrity sha512-vi+yY8D0TgUdpd8ja2BPqm689N+WZPWfXNkx0fzKYlVRGymUpQeyUrz2b6dscYE8Qr3ZiA6sz8RtXeQy1r9ZTQ==
+"@sentry/core@10.58.0":
+  version "10.58.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-10.58.0.tgz#66180ae40b341b352e3932753d5eb71157a00d0e"
+  integrity sha512-bkIbh2c6dzwhrWn/FGWu7j8hf6TAat2XxpkGM91LiN09fLYUXIMwcohVsXqze5l2cq35TnvqmSROAbRNr27GVw==
+
+"@sentry/eslint-plugin-sdk@10.58.0":
+  version "10.58.0"
+  resolved "https://registry.yarnpkg.com/@sentry/eslint-plugin-sdk/-/eslint-plugin-sdk-10.58.0.tgz#50f8a1cb526a5aa92f4a535ea7dabd725c8bc342"
+  integrity sha512-myNyhVtW2oQuaIXXrJ4kcpWe77pOIBKwtGg/1ihoEG8wUPQ3wsmH74h0mLDvmqQR1IXWTnyz7ppyxdDVdkhTZA==
+
+"@sentry/feedback@10.58.0":
+  version "10.58.0"
+  resolved "https://registry.yarnpkg.com/@sentry/feedback/-/feedback-10.58.0.tgz#7d74a2750433c5e6420f1804c5deaf2f6cd71d63"
+  integrity sha512-VmIlR/0O0GXITbvgjPkQqd6yM0JDEk52WXv6Rs1kTdaIDU5h3Y64VDVN4MAbYVRHqSz7F1arjRRk2FkaKC7ZOQ==
+  dependencies:
+    "@sentry/core" "10.58.0"
+
+"@sentry/node-core@10.58.0":
+  version "10.58.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node-core/-/node-core-10.58.0.tgz#956cd6d5d661cc4c40222ddd4da2de9199fead91"
+  integrity sha512-7dTbYuoaSwSmF2GWDl7KK+sXQL8iqaZeZ2I/aFm+SvPZLckZF3OGFb2VsluWsSXQLnxtxPX9QP93viyK+VZsuA==
+  dependencies:
+    "@sentry/core" "10.58.0"
+    "@sentry/opentelemetry" "10.58.0"
+    import-in-the-middle "^3.0.0"
+
+"@sentry/node-native-stacktrace@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@sentry/node-native-stacktrace/-/node-native-stacktrace-0.5.1.tgz#bb2309b3c9c3902b536613e29e3e6c5d44f4f22d"
+  integrity sha512-tF8eI4Z5YP6l7piLcy4BeGv6J96Y2ttssAAVFPgdzxzsT9i+S2olqGWgA9qav6+Gzs6E5pC9PAkObp2eDftabQ==
   dependencies:
     detect-libc "^2.0.4"
     node-abi "^3.89.0"
 
-"@sentry-internal/replay-canvas@10.56.0":
-  version "10.56.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/replay-canvas/-/replay-canvas-10.56.0.tgz#621a1878bc567b1eba4d4f8d49dd589f100c61c8"
-  integrity sha512-SDg2K0CAZT/TnhrixQGwXoi6ZsWUB+DQy3UUk0bSQm6c/5k5zFBpGOiughQN+DYsDilKREfPKmUEEnqvUjm1HQ==
+"@sentry/node-native@10.58.0":
+  version "10.58.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node-native/-/node-native-10.58.0.tgz#59b42d3427f3c37506d30b41a4b163e1ab8f9a70"
+  integrity sha512-F/p+iXLPLZLyUBnIcpP4M1gZCLwlRV+Dd5LvbIwCU0/eh+lHpRSedVww3PlEzUXU2/7Tz4Zn01bLtqf+bqVa5w==
   dependencies:
-    "@sentry-internal/replay" "10.56.0"
-    "@sentry/core" "10.56.0"
+    "@sentry/core" "10.58.0"
+    "@sentry/node" "10.58.0"
+    "@sentry/node-native-stacktrace" "^0.5.1"
 
-"@sentry-internal/replay@10.56.0":
-  version "10.56.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/replay/-/replay-10.56.0.tgz#c00f8a815f7a226e246fa704eb274170fa724d3c"
-  integrity sha512-DjF09hpy3TF7Km/kOZc73YJmBqcbPCxuZ5rtRs+KtVHu3Vq48xeW83qKUcFEZv20ur9UD99OAJ/gaEt//1Qbwg==
-  dependencies:
-    "@sentry-internal/browser-utils" "10.56.0"
-    "@sentry/core" "10.56.0"
-
-"@sentry-internal/server-utils@10.56.0":
-  version "10.56.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/server-utils/-/server-utils-10.56.0.tgz#b727a83b6b996ece37ad59ea5ce2d6656ab2e5b9"
-  integrity sha512-6kuZI/vAjyVKMm1cTzc2pdUmVR4Px4etMG6wnCPyFnwEaGbUKQnTynUBFpTuo/q6Js6QBQvhLNoAnO4YsOfW4w==
-  dependencies:
-    "@sentry/core" "10.56.0"
-
-"@sentry/browser@10.56.0":
-  version "10.56.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-10.56.0.tgz#dd503c36718ec7f77c85cc808af1f964b58b1799"
-  integrity sha512-80X3NmsGB6tLmfzXYdjzWWdVAdL5CRukGKLcRWIcNhgGjtskOmnzaGb93egEZGI5bUTbtONJ0oyscQ3Z9yoAtQ==
-  dependencies:
-    "@sentry-internal/browser-utils" "10.56.0"
-    "@sentry-internal/feedback" "10.56.0"
-    "@sentry-internal/replay" "10.56.0"
-    "@sentry-internal/replay-canvas" "10.56.0"
-    "@sentry/core" "10.56.0"
-
-"@sentry/core@10.56.0":
-  version "10.56.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-10.56.0.tgz#61159a5879d7937b6509cf4e6a680b991ef82001"
-  integrity sha512-L+u1dIz5SANrmST5jhIwETtt4apILgKrylv12X4hKJU0PvZl+NorjeV/ty3MwzpKQPg6b6q6qMOSLc1rLpy3iQ==
-
-"@sentry/node-core@10.56.0":
-  version "10.56.0"
-  resolved "https://registry.yarnpkg.com/@sentry/node-core/-/node-core-10.56.0.tgz#a2ea62e3ec843fe93454589bde00c2bafbadbb58"
-  integrity sha512-61lD2Wjtv5Lw2F3lJarcD0ORjR4GlVxrEd6w6Of/uF3DH73dD6K3n/3wXEeCIRfV/kgiCFIrCIq76nz0LVgE5g==
-  dependencies:
-    "@sentry/core" "10.56.0"
-    "@sentry/opentelemetry" "10.56.0"
-    import-in-the-middle "^3.0.0"
-
-"@sentry/node-native@10.56.0":
-  version "10.56.0"
-  resolved "https://registry.yarnpkg.com/@sentry/node-native/-/node-native-10.56.0.tgz#bce43c59a42f27e6cb5f3b33db2ed752618cb3e3"
-  integrity sha512-MmS918YBGwzLpkS9+YhmEID0A338IWh2jZijwTC1g3+pWa4aqGnqMRuRknHBLAZn8ojFSIB0Ryh42DKDK8KXUw==
-  dependencies:
-    "@sentry-internal/node-native-stacktrace" "^0.5.0"
-    "@sentry/core" "10.56.0"
-    "@sentry/node" "10.56.0"
-
-"@sentry/node@10.56.0":
-  version "10.56.0"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-10.56.0.tgz#aead92604a138cb7e5a6ff82c34896cbfcb5bba0"
-  integrity sha512-qvgtXHkcR4CH3fh0VEVyw4Ysc6MMiAnm727NdTTm0yU5e53erCeo2521+yfJkqmRTGiOSgwA7B5Bs+ot9j0vFQ==
+"@sentry/node@10.58.0":
+  version "10.58.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-10.58.0.tgz#0304b8c91fadadad8fab7df17adacfbef4901a52"
+  integrity sha512-KICgacBS+I/eWzFlAembutSwFwy0WVSrGp8UMV9n1XZqqu4EBTlALRsbLNlDSv61UgH85L9L3vk91tgq6nJXAA==
   dependencies:
     "@opentelemetry/api" "^1.9.1"
     "@opentelemetry/core" "^2.6.1"
     "@opentelemetry/instrumentation" "^0.214.0"
     "@opentelemetry/sdk-trace-base" "^2.6.1"
     "@opentelemetry/semantic-conventions" "^1.40.0"
-    "@sentry-internal/server-utils" "10.56.0"
-    "@sentry/core" "10.56.0"
-    "@sentry/node-core" "10.56.0"
-    "@sentry/opentelemetry" "10.56.0"
+    "@sentry/core" "10.58.0"
+    "@sentry/node-core" "10.58.0"
+    "@sentry/opentelemetry" "10.58.0"
+    "@sentry/server-utils" "10.58.0"
     import-in-the-middle "^3.0.0"
 
-"@sentry/opentelemetry@10.56.0":
-  version "10.56.0"
-  resolved "https://registry.yarnpkg.com/@sentry/opentelemetry/-/opentelemetry-10.56.0.tgz#89851b41c95d4da9dbadb015c9db69bcbafb7578"
-  integrity sha512-PtMudApHMHvttjos3b7JZ2gJ+nstHAOYE3vKPYB5o0WQO95ldiaYnpLKMCRIGZWF3Dk7ynrqqnBpn8LZLt+Mrg==
+"@sentry/opentelemetry@10.58.0":
+  version "10.58.0"
+  resolved "https://registry.yarnpkg.com/@sentry/opentelemetry/-/opentelemetry-10.58.0.tgz#eff391f6e2aabcd0680f8946e7802008e0bdd55d"
+  integrity sha512-qKOGVmt02wDaq7E70VekG8Z9XM641trJPoTHSeVUfGaXVcmGc46ZldTNtfWbxJq/8f/fge2pap60gn066ido2Q==
   dependencies:
-    "@sentry/core" "10.56.0"
+    "@sentry/core" "10.58.0"
+
+"@sentry/replay-canvas@10.58.0":
+  version "10.58.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay-canvas/-/replay-canvas-10.58.0.tgz#a1ce955549738e815f2ffba5f4b86eb692ca98ba"
+  integrity sha512-ufFmaJ968DXGe6u9W/UqNVjCCTtAqT2bNtSu1jHAjIFFpWIuM80lcR33grK6SuGnFxceu5iJFaIW6JRyfbM0Sw==
+  dependencies:
+    "@sentry/core" "10.58.0"
+    "@sentry/replay" "10.58.0"
+
+"@sentry/replay@10.58.0":
+  version "10.58.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-10.58.0.tgz#347eb26b86a458065172d880dc953d5a049eab42"
+  integrity sha512-EVasQNUenpwJksK9DI1TQ78YytpjLAhxn0UTiHqA3sU/s1fHK5XZdZJPr/9uEGedRoInIP0UIWmbOtOEX8HHDg==
+  dependencies:
+    "@sentry/browser-utils" "10.58.0"
+    "@sentry/core" "10.58.0"
+
+"@sentry/server-utils@10.58.0":
+  version "10.58.0"
+  resolved "https://registry.yarnpkg.com/@sentry/server-utils/-/server-utils-10.58.0.tgz#4c2584c1094486a38dfbf8594b6e2340ec6e1983"
+  integrity sha512-PywIl2jvl+tO5R4j+n72Lcf3ItanHcaMN/oL1U9ZHE8icaT2zpo2W4uOaslpQeQvqPC24HGZ3BW2etzsCFQbag==
+  dependencies:
+    "@sentry/core" "10.58.0"
 
 "@sindresorhus/is@^4.0.0":
   version "4.6.0"


### PR DESCRIPTION
This PR updates to v10.58.0 of the JavaScript SDKs and migrates internal usages of `sendDefaultPii` to `dataCollection`.