### PR TITLE
fix(net): Propagate correct distributed tracing IDs

### DIFF
--- a/src/main/integrations/net-breadcrumbs.ts
+++ b/src/main/integrations/net-breadcrumbs.ts
@@ -13,6 +13,7 @@ import {
   setHttpStatus,
   startInactiveSpan,
   stringMatchesSomePattern,
+  withActiveSpan,
 } from '@sentry/core';
 import { logger } from '@sentry/node';
 import type { ClientRequest, ClientRequestConstructorOptions, IncomingMessage } from 'electron';
@@ -221,9 +222,17 @@ function createWrappedRequestFactory(
       span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, 'auto.http.electron.net');
 
       if (shouldAttachTraceData(method, url)) {
-        for (const [key, value] of Object.entries(getTraceData({ span, propagateTraceparent }))) {
-          debug.log(`[Tracing] Adding ${key} header ${value} to outgoing request to "${url}": `);
-          request.setHeader(key, value);
+        const inject = (): void => {
+          for (const [key, value] of Object.entries(getTraceData({ propagateTraceparent }))) {
+            debug.log(`[Tracing] Adding ${key} header ${value} to outgoing request to "${url}": `);
+            request.setHeader(key, value);
+          }
+        };
+
+        if (span.isRecording()) {
+          withActiveSpan(span, inject);
+        } else {
+          inject();
         }
       }
 

--- a/test/unit/net-trace-propagation.test.ts
+++ b/test/unit/net-trace-propagation.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+function createMockClientRequest(): any {
+  const headers: Record<string, string> = {};
+  return {
+    getHeader: (name: string) => headers[name],
+    setHeader: (name: string, value: string) => {
+      headers[name] = value;
+    },
+    once: vi.fn().mockReturnThis(),
+    _capturedHeaders: headers,
+  };
+}
+
+let latestMockRequest: ReturnType<typeof createMockClientRequest>;
+
+vi.mock('electron', () => ({
+  net: {
+    request: () => {
+      latestMockRequest = createMockClientRequest();
+      return latestMockRequest;
+    },
+  },
+}));
+
+import { net } from 'electron';
+import { context, propagation, trace } from '@opentelemetry/api';
+import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
+import {
+  createTransport,
+  getActiveSpan,
+  getCurrentScope,
+  getGlobalScope,
+  getIsolationScope,
+  resolvedSyncPromise,
+  startSpan,
+} from '@sentry/core';
+import { getSentryResource, SentryPropagator, SentrySampler, SentrySpanProcessor } from '@sentry/opentelemetry';
+import { NodeClient, SentryContextManager, setNodeAsyncContextStrategy } from '@sentry/node';
+import { electronNetIntegration } from '../../src/main/integrations/net-breadcrumbs';
+
+const TEST_DSN = 'https://username@domain/123';
+const NIL_TRACE_ID = '00000000000000000000000000000000';
+
+function resetGlobals(): void {
+  getCurrentScope().clear();
+  getCurrentScope().setClient(undefined);
+  getIsolationScope().clear();
+  getGlobalScope().clear();
+}
+
+function setupSdk(options: Record<string, any> = {}): NodeClient {
+  resetGlobals();
+  setNodeAsyncContextStrategy();
+
+  const client = new NodeClient({
+    dsn: TEST_DSN,
+    integrations: [electronNetIntegration()],
+    transport: () => createTransport({ recordDroppedEvent: () => undefined }, (_) => resolvedSyncPromise({})),
+    stackParser: () => [],
+    tracePropagationTargets: [/.*/],
+    ...options,
+  });
+
+  getCurrentScope().setClient(client);
+  client.init();
+
+  const provider = new BasicTracerProvider({
+    sampler: new SentrySampler(client),
+    resource: getSentryResource('node'),
+    forceFlushTimeoutMillis: 500,
+    spanProcessors: [new SentrySpanProcessor()],
+  });
+
+  trace.setGlobalTracerProvider(provider);
+  propagation.setGlobalPropagator(new SentryPropagator());
+  context.setGlobalContextManager(new SentryContextManager());
+
+  return client;
+}
+
+function cleanupOtel(): void {
+  trace.disable();
+  context.disable();
+  propagation.disable();
+  resetGlobals();
+}
+
+describe('electron net trace header propagation', () => {
+  afterEach(() => {
+    cleanupOtel();
+  });
+
+  test('TWP mode: propagates valid trace ID from scope propagation context', () => {
+    setupSdk();
+
+    const scopeTraceId = getCurrentScope().getPropagationContext().traceId;
+    expect(scopeTraceId).not.toBe(NIL_TRACE_ID);
+
+    net.request('http://localhost:1234/test');
+
+    const sentryTrace = latestMockRequest._capturedHeaders['sentry-trace'];
+    expect(sentryTrace).toBeDefined();
+
+    const [traceId] = sentryTrace.split('-');
+    expect(traceId).toBe(scopeTraceId);
+  });
+
+  test('tracing enabled: propagates child span ID, not parent span ID', () => {
+    setupSdk({ tracesSampleRate: 1.0 });
+
+    startSpan({ name: 'parent-span' }, () => {
+      const parentSpanId = getActiveSpan()!.spanContext().spanId;
+      const parentTraceId = getActiveSpan()!.spanContext().traceId;
+
+      net.request('http://localhost:1234/test');
+
+      const sentryTrace = latestMockRequest._capturedHeaders['sentry-trace'];
+      expect(sentryTrace).toBeDefined();
+
+      const [traceId, spanId] = sentryTrace.split('-');
+      expect(traceId).toBe(parentTraceId);
+      expect(spanId).not.toBe(parentSpanId);
+    });
+  });
+});


### PR DESCRIPTION
The previous code `getTraceData({ span, propagateTraceparent })` could cause `0...0` Trace and Span IDs to be propagated when there's no parent span (either TwP i.e. `tracesSampleRate == null`, or `tracesSampleRate > 0` but simply no span around the HTTP call).
`span` is created with `onlyIfParent: true`, so when there's no parent, `span == NonRecordingSpan` with `INVALID_SPAN_CONTEXT`, and calling `getTraceData` returns `0...0` trace and span IDs that are propagated.

This PR mirrors the code in https://github.com/getsentry/sentry-javascript/blob/ccf5571c78c1116ba15fa7186234c86dcf57db5a/packages/core/src/integrations/http/client-subscriptions.ts#L119 to fix said behavior.
It stops passing `span` explicitly, so that `getTraceData` can either detect the active span injected by `withActiveSpan`, or fall back to the propagation context.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>