### PR TITLE
fix: preserve electron net request arguments

### DIFF
--- a/src/main/integrations/net-breadcrumbs.ts
+++ b/src/main/integrations/net-breadcrumbs.ts
@@ -94,7 +94,7 @@ function parseOptions(optionsIn: ClientRequestConstructorOptions | string): { me
 }
 
 type RequestOptions = string | ClientRequestConstructorOptions;
-type RequestMethod = (opt: RequestOptions) => ClientRequest;
+type RequestMethod = (opt: RequestOptions, ...args: unknown[]) => ClientRequest;
 type WrappedRequestMethodFactory = (original: RequestMethod) => RequestMethod;
 
 function createWrappedRequestFactory(
@@ -198,9 +198,13 @@ function createWrappedRequestFactory(
   };
 
   return function wrappedRequestMethodFactory(originalRequestMethod: RequestMethod): RequestMethod {
-    return function requestMethod(this: typeof electronNet, reqOptions: RequestOptions): ClientRequest {
+    return function requestMethod(
+      this: typeof electronNet,
+      reqOptions: RequestOptions,
+      ...args: unknown[]
+    ): ClientRequest {
       const { url, method } = parseOptions(reqOptions);
-      const request = originalRequestMethod.apply(this, [reqOptions]);
+      const request = originalRequestMethod.apply(this, [reqOptions, ...args]);
 
       if (url.match(/sentry_key/) || request.getHeader('x-sentry-auth')) {
         return request;

--- a/test/unit/net-trace-propagation.test.ts
+++ b/test/unit/net-trace-propagation.test.ts
@@ -13,10 +13,12 @@ function createMockClientRequest(): any {
 }
 
 let latestMockRequest: ReturnType<typeof createMockClientRequest>;
+let latestOriginalRequestArgs: unknown[];
 
 vi.mock('electron', () => ({
   net: {
-    request: () => {
+    request: (...args: unknown[]) => {
+      latestOriginalRequestArgs = args;
       latestMockRequest = createMockClientRequest();
       return latestMockRequest;
     },
@@ -122,5 +124,19 @@ describe('electron net trace header propagation', () => {
       expect(traceId).toBe(parentTraceId);
       expect(spanId).not.toBe(parentSpanId);
     });
+  });
+
+  test('preserves additional request arguments', () => {
+    setupSdk();
+
+    const responseCallback = vi.fn();
+
+    (net.request as unknown as (options: string, callback: typeof responseCallback) => void)(
+      'http://localhost:1234/test',
+      responseCallback,
+    );
+
+    expect(latestOriginalRequestArgs).toHaveLength(2);
+    expect(latestOriginalRequestArgs[1]).toBe(responseCallback);
   });
 });


### PR DESCRIPTION
## Summary

The Electron net integration wrapped `net.request` but only forwarded the first argument to the original request method. This made the wrapper non-transparent for callers which use Node-compatible request signatures such as `request(options, callback)`, causing the callback argument to be dropped.

Such as [vscode](https://github.com/microsoft/vscode/blob/1.126.0/src/vs/platform/request/node/requestService.ts#L226)

This updates the wrapper to preserve and forward any additional request arguments while still parsing the first argument for Sentry instrumentation.

## Testing

- `./node_modules/.bin/oxfmt --check src/main/integrations/net-breadcrumbs.ts test/unit/net-trace-propagation.test.ts`
- `OXLINT_TSGOLINT_DANGEROUSLY_SUPPRESS_PROGRAM_DIAGNOSTICS=true ./node_modules/.bin/oxlint src/main/integrations/net-breadcrumbs.ts test/unit/net-trace-propagation.test.ts`
- `./node_modules/.bin/vitest run --root=./test/unit net-trace-propagation.test.ts`
- `node scripts/update-version.js && ./node_modules/.bin/vitest run --root=./test/unit`