### PR TITLE
test: Build e2e native modules with clang on Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,11 @@ jobs:
         shard: [1, 2, 3, 4]
     env:
       ELECTRON_VERSION: ${{ matrix.electron }}
+      # GCC <= 12 (default on ubuntu-22.04) cannot parse the V8 headers from
+      # Electron >= 43, so build native test modules with clang. Ignored by
+      # node-gyp on Windows and macOS already defaults to clang.
+      CC: clang
+      CXX: clang++
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4


### PR DESCRIPTION
The `E2E Tests (ubuntu-22.04, 43.2.0, *)` jobs fail (see #1398) because `electron-rebuild` cannot compile `@sentry/node-native-stacktrace` against the Electron 43 headers with GCC.

Electron 43 ships V8 15.0, where `v8::String::Value` is now marked with a class-level `V8_DEPRECATED(...)` ([v8-primitive.h:655](https://github.com/v8/v8/blob/main/include/v8-primitive.h#L655)):

```cpp
class V8_DEPRECATED(
    "Prefer using String::ValueView if you can, or string->Write to a "
    "buffer if you cannot.") V8_EXPORT Value {
```

node-gyp compiles addons with `-DV8_DEPRECATION_WARNINGS=1`, so this expands to `class [[deprecated("…")]] __attribute__((visibility("default"))) Value` — a C++11 attribute mixed with a GNU attribute in a class head. GCC ≤ 12 cannot parse this construct (in either attribute order); GCC 13+ and clang accept it. The ubuntu-22.04 runners default to GCC 11, hence Linux-only failures.

This sets `CC`/`CXX` to clang (preinstalled on the runners) for the e2e job. Switching the runner to ubuntu-24.04 (GCC 13.3) would also fix the compile, but 24.04 breaks the native crash tests (#1332).

A follow-up fix in `@sentry/node-native-stacktrace` (e.g. stripping `V8_DEPRECATION_WARNINGS` in `binding.gyp`) is needed so end users building the ANR native module against Electron ≥ 43 with stock GCC ≤ 12 (Ubuntu 22.04 / Debian 12) aren't hit by the same failure.