### PR TITLE
test: Stabilize flaky window-good session test on Windows

### DIFF
--- a/test/e2e/test-apps/sessions/window-good/src/main.js
+++ b/test/e2e/test-apps/sessions/window-good/src/main.js
@@ -20,16 +20,22 @@ app.on('ready', () => {
   });
 
   mainWindow.loadFile(path.join(__dirname, 'index.html'));
+  // Windows CI runners don't always activate a programmatically shown window,
+  // so focus explicitly to ensure the session integration sees a focused window.
+  mainWindow.focus();
 
   setTimeout(() => {
     mainWindow.hide();
 
+    // Wait longer than backgroundTimeoutSeconds (1s) so the first session has
+    // reliably ended before we show the window again and start a second one.
     setTimeout(() => {
       mainWindow.show();
+      mainWindow.focus();
 
       setTimeout(() => {
         app.quit();
       }, 2000);
-    }, 2000);
+    }, 3000);
   }, 2000);
 });


### PR DESCRIPTION
## Problem

The `Good Session - Window` e2e test (`test/e2e/test-apps/sessions/window-good`) intermittently fails on Windows CI — most recently seen on the periodic SDK-update PR getsentry/sentry-electron#1416, and recurring across other PRs. The failure signature is always:

```
FAIL test-apps/sessions/window-good/test.ts > Good Session - Window
AssertionError: expected undefined to be defined
❯ Object.envelope test-apps/sessions/window-good/test.ts:51:33
    50|   secondSessionId = session?.sid;
    51|   expect(secondSessionId).toBeDefined();
```

i.e. the **second session never starts**.

## Root cause

The test app drives two sessions from one process using a `setTimeout` cascade (show → hide → show → quit), and session boundaries are inferred purely from `BrowserWindow` focus/visibility events. The `browserWindowSessionIntegration` only treats the app as active when a window is **both `isFocused()` and `isVisible()`**:

```ts
if (window.isFocused() && window.isVisible()) { return true; }
```

On Windows CI runners, `BrowserWindow.show()` does not reliably re-activate a programmatically shown window, so after the second `show()` the window is visible but not focused. `focusedWindow()` stays `false`, the integration never transitions back to `active`, the second session-start envelope is never emitted, and the assertion at line 51 fails. The tight timing (1s background timeout inside 2s gaps) plus `retry: 3` in `vitest.config.mts` is why it presents as an intermittent flake rather than a hard failure.

## Changes

- Call `mainWindow.focus()` after each `show()` so the integration deterministically sees a focused window (Windows won't auto-activate a programmatically shown window).
- Widen the hide→show gap from 2s to 3s so the first session — which ends after the 1s background timeout — has reliably completed before the second session begins, removing the tight timing race.

This only touches the e2e test app; no SDK behavior changes.

## Validation

The flake is Windows-specific and cannot be reproduced on Linux, so this relies on CI. Syntax-checked locally with `node --check`. Follow-up idea (not included here): make the integration itself more resilient to Windows focus quirks, so real-world programmatic `show()` without focus doesn't drop a session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGcnQ89SpPuNRpfyND7gVP)_